### PR TITLE
Add basic composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "dompdf/dompdf",
+    "type": "library",
+    "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+    "homepage": "https://github.com/dompdf/dompdf",
+    "license": "LGPL",
+    "authors": [
+        {
+            "name": "Fabien Ménager",
+            "email": "fabien.menager@gmail.com"
+        },
+        {
+            "name": "Brian Sweeney",
+            "email": "eclecticgeek@gmail.com"
+        }
+    ]
+}


### PR DESCRIPTION
This is a basic composer.json. it's the easiest way to let people include DOMPDF using composer, without breaking backwards compatibility or making any drastic changes.

Before you can use the PSR0 autoloader we will need to abstract all the PHP constants into properties, so it's probably not worth doing that until the PHP 5.3 refactor (I'm happy to try this on another branch).

For now this composer.json will allow people to pull down the package, then they can manually include the `dompdf_config.inc.php` loader file as usual.
