### PR TITLE
Check that file passed to load_html_file() exists

### DIFF
--- a/include/dompdf.cls.php
+++ b/include/dompdf.cls.php
@@ -479,8 +479,9 @@ class DOMPDF {
 
     if ($this->_protocol == "" || $this->_protocol === "file://") {
 
+      // Get the full path to $file, returns false if the file doesn't exist
       $realfile = realpath($file);
-      if ( !$file ) {
+      if ( !$realfile ) {
         throw new DOMPDF_Exception("File '$file' not found.");
       }
 


### PR DESCRIPTION
Previously `load_html_file()` was checking that `$file` was set. I think that the intended functionality was to check that the file actually exists.
