### PR TITLE
Multi styled text runs together due to spaces being trimmed.

### DIFF
--- a/include/text_frame_reflower.cls.php
+++ b/include/text_frame_reflower.cls.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * @package dompdf
  * @link    http://dompdf.github.com/
@@ -289,8 +289,8 @@ class Text_Frame_Reflower extends Frame_Reflower {
       $parent = $frame->get_parent();
       $is_inline_frame = get_class($parent) === 'Inline_Frame_Decorator';
       
-      if ((!$is_inline_frame && !$frame->get_next_sibling()) || 
-          ( $is_inline_frame && !$parent->get_next_sibling())) {
+      if ((!$is_inline_frame && !$frame->get_next_sibling())/* ||
+          ( $is_inline_frame && !$parent->get_next_sibling())*/) { // fails <b>BOLD <u>UNDERLINED</u></b> becomes <b>BOLD<u>UNDERLINED</u></b>
         $t = rtrim($t);
       }
       


### PR DESCRIPTION
This is in relation to an issue I posted last year: 
https://github.com/dompdf/dompdf/issues/475

At first it seemed like a font metric but is due to text_frame_reflower right trimming strings in cases where a tag is in a tag.  Example:

```
<p><b>THIS IS BOLD, <u>UNDERLINED AND <i>ITALIC</i></u></b></p>
```

becomes

```
<p><b>THIS IS BOLD,<u>UNDERLINED AND<i>ITALIC</i></u></b></p>
```

This same problem seems to have been commented out in the past regarding left trimmed strings which is visible just a few lines down from the one I commented out.
