### PR TITLE
Add DOMPDF_ENABLE_AUTOLOAD constant

### DIFF
--- a/dompdf_config.inc.php
+++ b/dompdf_config.inc.php
@@ -306,6 +306,13 @@ def("DOMPDF_FONT_HEIGHT_RATIO", 1.1);
 def("DOMPDF_ENABLE_CSS_FLOAT", false);
 
 /**
+ * Enable the built in DOMPDF autoloader
+ *
+ * @var bool
+ */
+def("DOMPDF_ENABLE_AUTOLOAD", true);
+
+/**
  * Prepend the DOMPDF autoload function the spl_autoload stack
  *
  * @var bool
@@ -320,24 +327,12 @@ require_once(DOMPDF_LIB_DIR . "/html5lib/Parser.php");
 
 // ### End of user-configurable options ###
 
-// is composer running?
-if (!class_exists("ComposerAutoloaderInit")) {
-  if (file_exists(DOMPDF_DIR . "/vendor/autoload.php")) {
-    // development mode - composer is installed locally
-    require_once(DOMPDF_DIR . "/vendor/autoload.php");
-  } else {
-    // composer is not installed - use our custom autoloader
-    require_once(DOMPDF_INC_DIR . "/autoload.inc.php");
-  }
-}
-
-// check for php-font-lib
-if (!class_exists('Font')) {
-  if (file_exists(DOMPDF_LIB_DIR . "/php-font-lib/classes/font.cls.php")) {
-    require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/font.cls.php");
-  } else {
-    exit("PHP-font-lib must either be installed via composer or copied to lib/php-font-lib\n");
-  }
+/**
+ * Load autoloader
+ */
+if (DOMPDF_ENABLE_AUTOLOAD) {
+  require_once(DOMPDF_INC_DIR . "/autoload.inc.php");
+  require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/font.cls.php");
 }
 
 /**

--- a/www/setup.php
+++ b/www/setup.php
@@ -10,7 +10,7 @@
 
 <h3 id="system">System Configuration</h3>
 
-<?php 
+<?php
 require_once("../dompdf_config.inc.php");
 
 $server_configs = array(
@@ -74,7 +74,7 @@ if (($gm = extension_loaded("gmagick")) || ($im = extension_loaded("imagick"))) 
     <th>Required</th>
     <th>Present</th>
   </tr>
-  
+
   <?php foreach($server_configs as $label => $server_config) { ?>
     <tr>
       <td class="title"><?php echo $label; ?></td>
@@ -95,12 +95,12 @@ if (($gm = extension_loaded("gmagick")) || ($im = extension_loaded("imagick"))) 
       </td>
     </tr>
   <?php } ?>
-  
+
 </table>
 
 <h3 id="dompdf-config">DOMPDF Configuration</h3>
 
-<?php 
+<?php
 $dompdf_constants = array();
 $defined_constants = get_defined_constants(true);
 
@@ -202,6 +202,9 @@ $constants = array(
   "DOMPDF_FONT_HEIGHT_RATIO" => array(
     "desc" => "The line height ratio to apply to get a render like web browsers",
   ),
+  "DOMPDF_ENABLE_AUTOLOAD" => array(
+    "desc" => "Enable the DOMPDF autoloader",
+  ),
 	"DOMPDF_AUTOLOAD_PREPEND" => array(
     "desc" => "Prepend the dompdf autoload function to the SPL autoload functions already registered instead of appending it",
   ),
@@ -224,40 +227,40 @@ $constants = array(
     <th>Description</th>
     <th>Status</th>
   </tr>
-  
+
   <?php foreach($defined_constants["user"] as $const => $value) { ?>
     <tr>
       <td class="title"><?php echo $const; ?></td>
       <td>
-      <?php 
+      <?php
         if (isset($constants[$const]["secret"])) {
           echo "******";
         }
         else {
-          var_export($value); 
+          var_export($value);
         }
       ?>
       </td>
       <td><?php if (isset($constants[$const]["desc"])) echo $constants[$const]["desc"]; ?></td>
-      <td <?php 
+      <td <?php
         $message = "";
         if (isset($constants[$const]["success"])) {
           switch($constants[$const]["success"]) {
-            case "read":  
+            case "read":
               $success = is_readable($value);
               $message = ($success ? "Readable" : "Not readable");
             break;
-            case "write": 
+            case "write":
               $success = is_writable($value);
               $message = ($success ? "Writable" : "Not writable");
             break;
-            case "remote": 
+            case "remote":
               $success = ini_get("allow_url_fopen");
               $message = ($success ? "allow_url_fopen enabled" : "allow_url_fopen disabled");
             break;
-            case "backend": 
+            case "backend":
               switch (strtolower($value)) {
-                case "cpdf": 
+                case "cpdf":
                   $success = true;
                 break;
                 case "pdflib":
@@ -270,7 +273,7 @@ $constants = array(
                 break;
               }
             break;
-            case "auth": 
+            case "auth":
               $success = !in_array($value, array("admin", "password"));
               $message = ($success ? "OK" : "Password should be changed");
             break;


### PR DESCRIPTION
Composer have changed the name of their autoloader class - now it is randomly generated each time. Therefore the original trick I added to detect `ComposerAutoloaderInit` and prevent loading of the DOMPDF autoloader no longer works. I've also been told that using `class_exists` can trigger bugs when using APC so it's probably not the best way to include php-font-lib.

Instead I've added a new constant to enable/disable the DOMPDF autoloader. That way, composer users can disable the DOMPDF autoloader and still include the `dompdf_config.inc.php` file to initialize all other defaults like so:

```
define('DOMPDF_ENABLE_AUTOLOAD', false);
require('dompdf_config.inc.php');
```

Obviously in future you want to completely get away from using defined constants, but this seems like the best immediate solution. Currently the only way to avoid this problem is to duplicate all the code in `dompdf_config.inc.php` and remove the autoloader bit.
