### PR TITLE
More robust handling of characters in Content-Disposition filename

### DIFF
--- a/lib/class.pdf.php
+++ b/lib/class.pdf.php
@@ -3116,8 +3116,14 @@ EOT;
       $options["Attachment"] = true;
 
     $attachment = $options["Attachment"] ? "attachment" : "inline";
+    
+    // detect the character encoding of the incoming file
+    $encoding = mb_detect_encoding($fileName);
+    $fallbackfilename = mb_convert_encoding($fileName, "ISO-8859-1", $encoding); 
+    $encodedfallbackfilename = rawurlencode($fallbackfilename);
     $encodedfilename = rawurlencode($fileName);
-    header("Content-Disposition: $attachment; filename=". $encodedfilename ."; filename*=UTF-8''$encodedfilename");
+
+    header("Content-Disposition: $attachment; filename=". $encodedfallbackfilename ."; filename*=UTF-8''$encodedfilename");
 
     if (isset($options['Accept-Ranges']) && $options['Accept-Ranges'] == 1) {
       //FIXME: Is this the correct value ... spec says 1#range-unit


### PR DESCRIPTION
This is my first pull request so please bare with me.

I've been using the library an application and have ran into issues regarding filenames when streaming the pdf.

Specifically that when streaming file names with user generated content I sometimes found characters such a semicolons which would cause issues in IE8.

http://greenbytes.de/tech/tc2231/#attwithquotedsemicolon

To address this issue I first added rawurlencoding to the file names. This worked well to resolve the issue however we also have non-ascii characters in the file names from time to time so we need the header to support UTF-8.

Based on the RFC spec http://greenbytes.de/tech/webdav/rfc5987.html#rfc.section.4.2 I added the second section which allows legacy browsers to just receive the rawurlencoded ascii, while modern browsers can take the UTF8 setting.

This works well for me but may not work for everyone. 

**Pros:**
Robust handling of input, users of this library don't have to worry about the characters in their filenames. 

**Cons:**
The library is performing a transformation of user generated content which may be undesirable for some users. 

That said, this could be pulled out into another function, say streamUTF8(...) for lack of a better name. 

Thoughts?
