### PR TITLE
Failing import of php-font-lib with composer and autoload

### DIFF
--- a/dompdf_config.inc.php
+++ b/dompdf_config.inc.php
@@ -332,7 +332,6 @@ require_once(DOMPDF_LIB_DIR . "/html5lib/Parser.php");
  */
 if (DOMPDF_ENABLE_AUTOLOAD) {
   require_once(DOMPDF_INC_DIR . "/autoload.inc.php");
-  require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/font.cls.php");
 }
 
 /**


### PR DESCRIPTION
When composer is used to get dompdf, php-font-lib is dumped as dependency to phenx/php-font-lib in vendor folder; the git submodule in dompdf/lib is not initialized, so the require directive fails.
But the composer autoload mechanism does not need this import, cause all classes are already mapped (see the composer.json from php-font-lib), so, IMHO, we can safely remove it.
