### PR TITLE
Update block_frame_reflower.cls.php

### DIFF
--- a/include/block_frame_reflower.cls.php
+++ b/include/block_frame_reflower.cls.php
@@ -780,6 +780,8 @@ class Block_Frame_Reflower extends Frame_Reflower {
       
       $style->left = $orig_style->left;
       $style->right = $orig_style->right;
+      $style->top = $orig_style->top; // added by GB to set proper height of block element
+      $style->bottom = $orig_style->bottom; // added by GB to set proper height of block element
     }
 
     $this->_text_align();


### PR DESCRIPTION
Fixes problem when not showing block elements (like DIVs) when they are styled with 
position: absolute;
and
height: in pixels
