### PR TITLE
save locale correctly

### DIFF
--- a/include/dompdf.cls.php
+++ b/include/dompdf.cls.php
@@ -314,7 +314,8 @@ class DOMPDF {
       return;
     }
 
-    $this->_system_locale = setlocale(LC_NUMERIC, "C");
+    $this->_system_locale = setlocale(LC_NUMERIC, "0");
+    setlocale(LC_NUMERIC, "C");
   }
 
   /**


### PR DESCRIPTION
DOMPDF::save_locale is not correctly implemented as setlocale() only returns the current locale with a locale parameter of "0".

This only appears if you change the locale before loading/using dompdf so I have no idea how to include a test in "www/test/" but here is a simple php file to test it:

``` php
<?php

setlocale(LC_ALL, 'de_DE.UTF-8');

echo "Before: " . setlocale(LC_ALL, 0) . "\n";

require_once('dompdf_config.inc.php');

echo "After include: " . setlocale(LC_ALL, 0) . "\n";

$dompdf = new DOMPDF();

echo "After constructor: " . setlocale(LC_ALL, 0) . "\n";

?>
```

This should print "de_DE.UTF-8" three times but without my patch, it does not.

Hope you like it, cheers!

dompdf version: just forked
php version: 5.3.17
