### PR TITLE
DOMPDF::_process_html does an incorrect store & restore of locals

### DIFF
--- a/include/dompdf.cls.php
+++ b/include/dompdf.cls.php
@@ -675,8 +675,6 @@ class DOMPDF {
    * the {@link Frame_Tree}
    */
   protected function _process_html() {
-    $this->save_locale();
-
     $this->_tree->build_tree();
 
     $this->_css->load_css_file(Stylesheet::DEFAULT_STYLESHEET, Stylesheet::ORIG_UA);
@@ -759,8 +757,6 @@ class DOMPDF {
           break;
       }
     }
-
-    $this->restore_locale();
   }
 
   /**


### PR DESCRIPTION
My test suite just finished and told me about this problem, so I am sorry that I did not put this commit in the previous merge request! Since ALL my tests pass now (this time I played it safe), I am certain that my locale problems are gone with this additional commit :-)

The problem is a double store & restore of locales via DOMPDF::render() which executes DOMPDF::_process_html(). _process_html() does an additional store & restore of the locales. Since DOMPDF::save_locale() & DOMPDF::restore_locale() are not stack-based this will save the temporary locale via _process_html() and therefore overwrite the system locale.

I thought about implementing a stack-based save_locale() & restore_locale() but _process_html() is only used in render() and I do not see any other double uses.

Here is a test for this problem:

``` php
<?php

setlocale(LC_ALL, 'de_DE.UTF-8');

echo "Before: " . setlocale(LC_ALL, 0) . "\n";

require_once('dompdf_config.inc.php');

$dompdf = new DOMPDF();

echo "After init: " . setlocale(LC_ALL, 0) . "\n";

$dompdf->load_html('<html><head><title>Hey</title></head><body>ho</body></html>');

$dompdf->set_paper('A4', 'portrait');

$dompdf->render();

$dompdf->output(array( 'compress' => 0 ));

echo "After output: " . setlocale(LC_ALL, 0) . "\n";

?>
```

This should print "de_DE.UTF-8" three times.

Cheers!

PS: I would like to see a phpunit test suite for dompdf. Are there any plans on adding one?
