### PR TITLE
Update dompdf_config.inc.php

### DIFF
--- a/dompdf_config.inc.php
+++ b/dompdf_config.inc.php
@@ -16,17 +16,23 @@ PHP_VERSION >= 5.0 or die("DOMPDF requires PHP 5.0+");
 /**
  * The root of your DOMPDF installation
  */
-define("DOMPDF_DIR", str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname(__FILE__))));
+if (!defined('DOMPDF_DIR')) {
+  define("DOMPDF_DIR", str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname(__FILE__))));
+}
 
 /**
  * The location of the DOMPDF include directory
  */
-define("DOMPDF_INC_DIR", DOMPDF_DIR . "/include");
+if (!defined('DOMPDF_INC_DIR')) {
+  define("DOMPDF_INC_DIR", DOMPDF_DIR . "/include");
+}
 
 /**
  * The location of the DOMPDF lib directory
  */
-define("DOMPDF_LIB_DIR", DOMPDF_DIR . "/lib");
+if (!defined('DOMPDF_LIB_DIR')) {
+  define("DOMPDF_LIB_DIR", DOMPDF_DIR . "/lib");
+}
 
 /**
  * Some installations don't have $_SERVER['DOCUMENT_ROOT']


### PR DESCRIPTION
Should check if constats already exists.

Use case : I'm using zf2 dompdf module and phpoffice/phpexcel, I want to print some excel files and use dompdf wich is loaded with dompdf module. It will load dompdf a second time so I need to check if this constants are already in use.
