### PR TITLE
Account for \n at start of xref in startxref

### DIFF
--- a/lib/class.pdf.php
+++ b/lib/class.pdf.php
@@ -1896,6 +1896,9 @@ EOT;
       $content.= "/ID[<$this->fileIdentifier><$this->fileIdentifier>]\n";
     }
 
+    // account for \n added at start of xref table
+    $pos++;
+
     $content.= ">>\nstartxref\n$pos\n%%EOF\n";
 
     return $content;


### PR DESCRIPTION
Although (most) PDF readers seem to cope with an incorrect startxref value
it is off by one and can cause problems with other PDF libraries if they
trust the startxref value (i.e. they don't account for this issue).

The value is almost calculated correctly, but the \n added when adding the
xref table is not accounted for.
