### PR TITLE
Revert "Update php-font-lib requirement" - It breaks composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
         "classmap": ["include/"]
     },
     "require": {
-        "phenx/php-font-lib": "dev-master"
+        "phenx/php-font-lib": "0.2.*"
     }
 }


### PR DESCRIPTION
This reverts commit ffb51908cb6036a096b25c96a3f65dd30144f893.

If your lib requires dev-master, composer can't resolve it without setting the min stability of my project to dev, which I don't want to do on production. The default min-stability of composer is stable, so this causes trouble.

```
jdonat > JesseDonat-MBP ~CIL ±2.0.6⚡ » composer update                                                                  2↵ 16:42:49
Loading composer repositories with package information
Updating dependencies (including require-dev)                 
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - dompdf/dompdf dev-master requires phenx/php-font-lib dev-master -> no matching package found.
    - dompdf/dompdf dev-master requires phenx/php-font-lib dev-master -> no matching package found.
    - Installation request for dompdf/dompdf dev-master -> satisfiable by dompdf/dompdf[dev-master].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
