### PR TITLE
Try class_exists before manually loading Font class

### DIFF
--- a/dompdf_config.inc.php
+++ b/dompdf_config.inc.php
@@ -331,7 +331,9 @@ require_once(DOMPDF_LIB_DIR . "/html5lib/Parser.php");
  */
 if (DOMPDF_ENABLE_AUTOLOAD) {
   require_once(DOMPDF_INC_DIR . "/autoload.inc.php");
-  require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/Font.php");
+  if( !class_exists('Font') ) {
+    require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/Font.php");
+  }
 }
 
 /**


### PR DESCRIPTION
Calling `class_exists` serves two purposes. 

- If the class is already loaded, it skips it 
- More importantly it triggers the autoloader to look before including it manually which fixes a problem using the default config with composer as the `DOMPDF_LIB_DIR . "/php-font-lib/classes/Font.php` path is incorrect when loading with composer.