### PR TITLE
Autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ git submodule init
 git submodule update
 ```
 
+To use DOMPDF in your project, you must include the configuration file
+and class autoloader:
+
+```php
+// include DOMPDF's default configuration
+require_once '/path/to/dompdf/dompdf_config.inc.php';
+
+// include DOMPDF autoloader
+require_once '/path/to/dompdf/autoload.inc.php';
+```
+
 Install with composer
 ---
 To install with Composer, simply add the requirement to your `composer.json`
@@ -99,9 +110,6 @@ load the dompdf configuration file:
 // somewhere early in your project's loading, require the Composer autoloader
 // see: http://getcomposer.org/doc/00-intro.md
 require 'vendor/autoload.php';
-
-// disable DOMPDF's internal autoloader if you are using Composer
-define('DOMPDF_ENABLE_AUTOLOAD', false);
 
 // include DOMPDF's default configuration
 require_once '/path/to/vendor/dompdf/dompdf/dompdf_config.inc.php';

--- a/autoload.inc.php
+++ b/autoload.inc.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once(dirname(__FILE__) . "/include/autoload.inc.php");

--- a/dompdf.php
+++ b/dompdf.php
@@ -124,6 +124,7 @@ function getoptions() {
 }
 
 require_once("dompdf_config.inc.php");
+require_once("autoload.inc.php");
 global $_dompdf_show_warnings, $_dompdf_debug, $_DOMPDF_DEBUG_TYPES;
 
 $sapi = php_sapi_name();

--- a/dompdf_config.inc.php
+++ b/dompdf_config.inc.php
@@ -303,13 +303,6 @@ def("DOMPDF_FONT_HEIGHT_RATIO", 1.1);
 def("DOMPDF_ENABLE_CSS_FLOAT", false);
 
 /**
- * Enable the built in DOMPDF autoloader
- *
- * @var bool
- */
-def("DOMPDF_ENABLE_AUTOLOAD", true);
-
-/**
  * Prepend the DOMPDF autoload function to the spl_autoload stack
  *
  * @var bool
@@ -323,14 +316,6 @@ def("DOMPDF_ENABLE_HTML5PARSER", false);
 require_once(DOMPDF_LIB_DIR . "/html5lib/Parser.php");
 
 // ### End of user-configurable options ###
-
-/**
- * Load autoloader
- */
-if (DOMPDF_ENABLE_AUTOLOAD) {
-  require_once(DOMPDF_INC_DIR . "/autoload.inc.php");
-  require_once(DOMPDF_LIB_DIR . "/php-font-lib/classes/Font.php");
-}
 
 /**
  * Ensure that PHP is working with text internally using UTF8 character encoding.

--- a/include/autoload.inc.php
+++ b/include/autoload.inc.php
@@ -16,10 +16,15 @@
  * @param string $class
  */
 function DOMPDF_autoload($class) {
-  $filename = DOMPDF_INC_DIR . "/" . mb_strtolower($class) . ".cls.php";
-  
-  if ( is_file($filename) ) {
-    include_once $filename;
+  $filenames = array(
+    DOMPDF_INC_DIR . "/" . mb_strtolower($class) . ".cls.php",
+    DOMPDF_LIB_DIR . "/php-font-lib/" . $class . ".php",
+  );
+
+  foreach ($filenames as $file) {
+    if ( is_file($file) ) {
+      return include_once($file);
+    }
   }
 }
 


### PR DESCRIPTION
This is my proposed solution to #780. Basically we remove the autoloader entirely from dompdf_config.inc.php, and let the developer make their own decision whether or not to use it.

Unfortunately I didn't realise you were so close to releasing 0.6 final, it would have been nice to make this change before the release. As you said in 0.7 you are planning to make everything PSR0 perhaps you can drop the autoloader entirely at that point (or just ship a default PSR0 autoloader).