### PR TITLE
Fix 'Install with git' commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ the following commands:
 
 ```sh
 git clone https://github.com/dompdf/dompdf.git
-git submodule init
-git submodule update
+cd dompdf
+git submodule update --init
 ```
 
 Install with composer


### PR DESCRIPTION
Submodules cannot be updated if you are not inside the cloned directory.
