### PR TITLE
Updating pdflib_adapter.csl.php stream() to match class.pdf.php 

### DIFF
--- a/include/pdflib_adapter.cls.php
+++ b/include/pdflib_adapter.cls.php
@@ -1017,7 +1017,14 @@ class PDFLib_Adapter implements Canvas {
 
     header("Cache-Control: private");
     header("Content-type: application/pdf");
-    header("Content-Disposition: $attach; filename=\"$filename\"");
+
+    // detect the character encoding of the incoming file
+    $encoding = mb_detect_encoding($fileName);
+    $fallbackfilename = mb_convert_encoding($fileName, "ISO-8859-1", $encoding);
+    $encodedfallbackfilename = rawurlencode($fallbackfilename);
+    $encodedfilename = rawurlencode($fileName);
+
+    header("Content-Disposition: $attach; filename=". $encodedfallbackfilename ."; filename*=UTF-8''$encodedfilename");
 
     //header("Content-length: " . $size);
 


### PR DESCRIPTION
Updating the stream() function to match class.pdf.php to handle UTF-8 characters in filename.

We had already gone over these changes in https://github.com/dompdf/dompdf/pull/594 so the review aspect should be good to go. 