### PR TITLE
Remove repetitive config included in setup.php

### DIFF
--- a/www/setup.php
+++ b/www/setup.php
@@ -11,7 +11,6 @@
 <h3 id="system">System Configuration</h3>
 
 <?php
-require_once("../dompdf_config.inc.php");
 
 $server_configs = array(
   "PHP Version" => array(


### PR DESCRIPTION
Setup.php included head.inc which include dompdf_config.inc.php
It's not necessary to include again in setup.php
If you rename or move dompdf_config.inc.php file, you must do so in several files for nothing.
