### PR TITLE
Set default filename

### DIFF
--- a/src/Dompdf/Dompdf.php
+++ b/src/Dompdf/Dompdf.php
@@ -876,7 +876,7 @@ class Dompdf
      * @param string $filename the name of the streamed file
      * @param array $options header options (see above)
      */
-    public function stream($filename, $options = null)
+    public function stream($filename = 'document.pdf', $options = null)
     {
         $this->saveLocale();
 


### PR DESCRIPTION
So stream() can be called without argument. (As it's used in the example)