### PR TITLE
Autoload classmap lib dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,13 @@ $ curl -sS http://getcomposer.org/installer | php
 $ php composer.phar update
 ```
 
-Most Composer applications typically only require the Composer autoloader in order
-to load all class files. Dompdf, however, still needs a bit of a kick-start by
-including its own autoloder.
+Make sure that the autoload file from Composer is loaded.
 
 ```php
 // somewhere early in your project's loading, require the Composer autoloader
 // see: http://getcomposer.org/doc/00-intro.md
 require 'vendor/autoload.php';
 
-// include dompdf's autoloader
-require 'vendor/dompdf/dompdf/src/autoload.inc.php';
 ```
 
 ### Download and install

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-0" : {
             "Dompdf" : "src/"
-        }
+        },
+        "classmap" : ["lib/"]
     },
     "require": {
         "php": ">=5.3.0",


### PR DESCRIPTION
With classmap, alle php files are scanned in that directory, so the autoloader doesn't have to be manually called.