### PR TITLE
Enforce extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     },
     "require": {
         "php": ">=5.3.0",
+        "ext-gd": "*",
+        "ext-dom": "*",
+        "ext-mbstring": "*",
         "phenx/php-font-lib": "0.4.*",
         "phenx/php-svg-lib": "0.1.*"
     },


### PR DESCRIPTION
Require them in composer, so it will produce an error when you are missing something, instead of failing when the functions are actually called.