### PR TITLE
Fix table cells w/ rowspan over page break.

### DIFF
--- a/src/Dompdf/Cellmap.php
+++ b/src/Dompdf/Cellmap.php
@@ -725,7 +725,7 @@ class Cellmap
             return; // Presumably this row has alredy been removed
         }
 
-        $this->_row = $this->_num_rows--;
+        $this->__row = $this->_num_rows--;
 
         $rows = $this->_frames[$key]["rows"];
         $columns = $this->_frames[$key]["columns"];
@@ -736,11 +736,20 @@ class Cellmap
                 if (isset($this->_cells[$r][$c])) {
                     $id = $this->_cells[$r][$c]->get_id();
 
-                    $this->_frames[$id] = null;
-                    unset($this->_frames[$id]);
-
                     $this->_cells[$r][$c] = null;
                     unset($this->_cells[$r][$c]);
+                    
+                    // has multiple rows?
+                    if (isset($this->_frames[$id]) && count($this->_frames[$id]["rows"]) > 1) {
+                        // remove just the desired row, but leave the frame
+                        if (($row_key = array_search($r, $this->_frames[$id]["rows"])) !== false) {
+                            unset($this->_frames[$id]["rows"][$row_key]);
+                        }
+                        continue;
+                    }
+
+                    $this->_frames[$id] = null;
+                    unset($this->_frames[$id]);
                 }
             }
 


### PR DESCRIPTION
(This is a new version of #661, which was a pull request against master.)

I made an update to cellmap to prevent an exception when cells with rowspan span multiple pages. Rather than fully removing spaning frames (cells), it removes rows individually from the "rows" index. Only once the "rows" index is empty does it remove the frame (cell). This is not a perfect solution, as the layout on subsequent pages does not reflect the spanned cell, but it prevents an error and produces a reasonable rendering.