### PR TITLE
Invalid type check on $style argument, style can be passed in as an e…

### DIFF
--- a/src/Dompdf/Adapter/GD.php
+++ b/src/Dompdf/Adapter/GD.php
@@ -300,7 +300,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!empty($style)) {
+        if (is_array($style) && count($style) > 0) {
             $gd_style = array();
 
             if (count($style) == 1) {
@@ -374,7 +374,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!empty($style)) {
+        if (is_array($style) && count($style) > 0) {
             $gd_style = array();
 
             foreach ($style as $length) {
@@ -514,7 +514,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!empty($style) && !$fill) {
+        if (is_array($style) && count($style) > 0 && !$fill) {
             $gd_style = array();
 
             foreach ($style as $length) {
@@ -562,7 +562,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!empty($style) && !$fill) {
+        if (is_array($style) && count($style) > 0 && !$fill) {
             $gd_style = array();
 
             foreach ($style as $length) {

--- a/src/Dompdf/Adapter/GD.php
+++ b/src/Dompdf/Adapter/GD.php
@@ -300,7 +300,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!is_null($style)) {
+        if (!empty($style)) {
             $gd_style = array();
 
             if (count($style) == 1) {
@@ -374,7 +374,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!is_null($style)) {
+        if (!empty($style)) {
             $gd_style = array();
 
             foreach ($style as $length) {
@@ -514,7 +514,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!is_null($style) && !$fill) {
+        if (!empty($style) && !$fill) {
             $gd_style = array();
 
             foreach ($style as $length) {
@@ -562,7 +562,7 @@ class GD implements Canvas
         $c = $this->_allocate_color($color);
 
         // Convert the style array if required
-        if (!is_null($style) && !$fill) {
+        if (!empty($style) && !$fill) {
             $gd_style = array();
 
             foreach ($style as $length) {


### PR DESCRIPTION
Invalid type check on $style argument, style can be passed in as an empty array.

This fixed an issue where passing empty arrays into the 2nd argument of imagesetstyle() can cause subsequent functions such as imagerectangle() to crash PHP (Windows / PHP 5.5.12 / x86 MSVC11).

Haven't attempted to replicate this on any other setup.