### PR TITLE
Fix the issue with Twitter Bootstrap Frameworks

### DIFF
--- a/include/font_metrics.cls.php
+++ b/include/font_metrics.cls.php
@@ -329,7 +329,7 @@ class Font_Metrics {
     
     $local_file = DOMPDF_FONT_DIR . md5($remote_file);
     $cache_entry = $local_file;
-    $local_file .= ".ttf";
+    $local_file .=".".pathinfo($remote_file,PATHINFO_EXTENSION); //Minor fix (replace .ttf by the extension of remote file)
     
     $style_string = Font_Metrics::get_type("{$style['weight']} {$style['style']}");
     


### PR DESCRIPTION
//Minor fix (replace .ttf by the extension of remote font file)
Now is posible render pages with Twitter Bootstrap Framework integrated. 
But glyph-icons not are showed yet 
Tested with Twitter Bootstrap 3.3.1