### PR TITLE
Fix the issue with Twitter Bootstrap Frameworks

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -213,7 +213,7 @@ class FontMetrics
 
         $local_file = $fontDir . DIRECTORY_SEPARATOR . md5($remoteFile);
         $cache_entry = $local_file;
-        $local_file .= ".ttf";
+        $local_file .= ".".pathinfo($remote_file,PATHINFO_EXTENSION);
 
         $style_string = $this->getType("{$style['weight']} {$style['style']}");
 


### PR DESCRIPTION
 When a page using TWB dompdf will be rendered to pdf, dompdf throws a FileNotFound exception(in my case I'am using Laravel 5.0) because not found a file <md5 generated filename>.ttf. The extension of the font is hardcoded. I know that dompdf only supports TrueType font format.
