### PR TITLE
Register the autoloader only in the autoloader test

### DIFF
--- a/tests/Dompdf/Tests/AutoloaderTest.php
+++ b/tests/Dompdf/Tests/AutoloaderTest.php
@@ -8,6 +8,8 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
 {
     public function testAutoload()
     {
+        Autoloader::register();
+
         $declared = get_declared_classes();
         $declaredCount = count($declared);
         Autoloader::autoload('Foo');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,4 +18,3 @@ spl_autoload_register(function ($class) {
     }
 });
 
-Dompdf\Autoloader::register();


### PR DESCRIPTION
The Autoloader should be only registered in the AutoloaderTest. The other tests and tested classes can be loaded by the composer autoloader.