### PR TITLE
Set MediaBox paramter for each page

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1444,6 +1444,15 @@ EOT;
 
             case 'out':
                 $res = "\n$id 0 obj\n<< /Type /Page";
+                if ($this->currentPageSize['width'] > 0 && $this->currentPageSize['height'] > 0) {
+                    $res .= "\n/MediaBox [" . sprintf(
+                            '%.3F %.3F %.3F %.3F',
+                            0,
+                            0,
+                            $this->currentPageSize['width'],
+                            $this->currentPageSize['height']
+                        ) . "]";
+                }
                 $res .= "\n/Parent " . $o['info']['parent'] . " 0 R";
 
                 if (isset($o['info']['annot'])) {


### PR DESCRIPTION
Sets the `MediaBox` for each page to the same value as for the whole document. This fixes printing 100 x 150 mm PDFs (similar to DIN A6) with Google Cloud Print.