### PR TITLE
Allow for passing of options during Dompdf construction

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -255,10 +255,12 @@ class Dompdf
 
     /**
      * Class constructor
+     *
+     * @param array $options
      */
-    public function __construct()
+    public function __construct($options = null)
     {
-        $this->setOptions(new Options);
+        $this->setOptions(new Options($options));
         
         $versionFile = realpath(__DIR__ . '/../VERSION');
         if (file_exists($versionFile) && ($version = file_get_contents($versionFile)) !== false && $version !== '$Format:<%h>$') {


### PR DESCRIPTION
Pass an array of options via the constructor.  Whilst handy long-term, it is also a work-around for issue #1062 