### PR TITLE
Use the base href on anchors that have relative URLs

### DIFF
--- a/src/Dompdf/Helpers.php
+++ b/src/Dompdf/Helpers.php
@@ -60,7 +60,7 @@ class Helpers
         }
 
         // Is the url already fully qualified or a Data URI?
-        if (mb_strpos($url, "://") !== false || mb_strpos($url, "data:") === 0) {
+        if (mb_strpos($url, "://") !== false || mb_strpos($url, "data:" || mb_strpos($url, "mailto:") === 0) {
             return $url;
         }
 

--- a/src/Dompdf/Renderer/Block.php
+++ b/src/Dompdf/Renderer/Block.php
@@ -40,6 +40,7 @@ class Block extends AbstractRenderer
 
         // Handle anchors & links
         if ($node->nodeName === "a" && $href = $node->getAttribute("href")) {
+            $href = Helpers::build_url($this->_dompdf->getProtocol(), $this->_dompdf->getBaseHost(), $this->_dompdf->getBasePath(), $href);
             $this->_canvas->add_link($href, $x, $y, $w, $h);
         }
 

--- a/src/Dompdf/Renderer/Inline.php
+++ b/src/Dompdf/Renderer/Inline.php
@@ -97,6 +97,7 @@ class Inline extends AbstractRenderer
                 }
 
                 if ($link_node && $href = $link_node->getAttribute("href")) {
+                    $href = Helpers::build_url($this->_dompdf->getProtocol(), $this->_dompdf->getBaseHost(), $this->_dompdf->getBasePath(), $href);
                     $this->_canvas->add_link($href, $x, $y, $w, $h);
                 }
 
@@ -187,8 +188,10 @@ class Inline extends AbstractRenderer
 
         // Handle anchors & links
         if ($link_node) {
-            if ($href = $link_node->getAttribute("href"))
+            if ($href = $link_node->getAttribute("href")) {
+                $href = Helpers::build_url($this->_dompdf->getProtocol(), $this->_dompdf->getBaseHost(), $this->_dompdf->getBasePath(), $href);
                 $this->_canvas->add_link($href, $x, $y, $w, $h);
+            }
         }
     }
 }


### PR DESCRIPTION
If set, use the base href on anchors that have relative URLs.  Also fixed a build_url() bug regarding mailto: URLs that this exposed.