### PR TITLE
Helpers::getContent() to get rid of allow_url_fopen off

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -336,9 +336,7 @@ class Stylesheet
                 $file = Helpers::build_url($this->_protocol, $this->_base_host, $this->_base_path, $filename);
             }
 
-            set_error_handler(array("\\Dompdf\\Helpers", "record_warnings"));
-            $css = file_get_contents($file, null, $this->_dompdf->get_http_context());
-            restore_error_handler();
+            $css = Helpers::getContent($file, $this->_dompdf->get_http_context());
 
             $good_mime_type = true;
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -732,18 +732,19 @@ class Helpers
 
     public static function getContent($path, $http_contest)
     {
+        $result = false;
         $is_remote_path = preg_match('/^https?:\/\//', $path);
 
-        if ($is_remote_path && function_exists("curl_exec")) {
+        if (!$is_remote_path || ini_get("allow_url_fopen")) {
+            set_error_handler(array("\\Dompdf\\Helpers", "record_warnings"));
+            $result = file_get_contents($path, null, $http_contest);
+            restore_error_handler();
+        }
+        elseif ($is_remote_path && function_exists("curl_exec")) {
             $curl = curl_init($path);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
             $result = curl_exec($curl);
             curl_close($curl);
-        }
-        else {
-            set_error_handler(array("\\Dompdf\\Helpers", "record_warnings"));
-            $result = file_get_contents($path, null, $http_contest);
-            restore_error_handler();
         }
 
         return $result;

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -726,4 +726,22 @@ class Helpers
         return $im;
     }
 
+    public static function getContent($path, $http_contest)
+    {
+        $is_remote_path = preg_match('/^https?:\/\//', $path);
+
+        if ($is_remote_path && function_exists("curl_exec")) {
+            $curl = curl_init($path);
+            curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+            $result = curl_exec($curl);
+            curl_close($curl);
+        }
+        else {
+            set_error_handler(array("\\Dompdf\\Helpers", "record_warnings"));
+            $result = file_get_contents($path, null, $http_contest);
+            restore_error_handler();
+        }
+
+        return $result;
+    }
 }

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -93,9 +93,7 @@ class Cache
                                 $image = $parsed_data_uri['data'];
                             }
                         } else {
-                            set_error_handler(array("\\Dompdf\\Helpers", "record_warnings"));
-                            $image = file_get_contents($full_url, null, $dompdf->getHttpContext());
-                            restore_error_handler();
+                            $image = Helpers::getContent($full_url, $dompdf->getHttpContext());
                         }
 
                         // Image not found or invalid


### PR DESCRIPTION
Currently Dompdf is not working with external images and css if allow_url_fopen is off. I created Helpers::getContent() method to wrap file_get_contents() and to use curl when allow_url_fopen is not enabled.
