### PR TITLE
Fix FrameReflower\Block always appending "pt" causing style values like autopt and nonept

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -178,6 +178,11 @@ class Style
     private $__font_size_calculated; // Cache flag
 
     /**
+     * The computed bottom spacing
+     */
+    private $_computed_bottom_spacing = null;
+
+    /**
      * The computed border radius
      */
     private $_computed_border_radius = null;
@@ -779,6 +784,19 @@ class Style
         }
 
         return $this->_prop_cache[$prop] = $this->_props[$prop];
+    }
+
+    function computed_bottom_spacing() {
+        if ($this->_computed_bottom_spacing !== null) {
+            return $this->_computed_bottom_spacing;
+        }
+        return $this->_computed_bottom_spacing = $this->length_in_pt(
+            array(
+                $this->margin_bottom,
+                $this->padding_bottom,
+                $this->border_bottom_width
+            )
+        );
     }
 
     function get_font_family_raw()
@@ -1478,6 +1496,9 @@ class Style
         $prop = $style . '_' . $side . $type;
 
         if (!isset($this->_important_props[$prop]) || $important) {
+            if ($side === "bottom") {
+                $this->_computed_bottom_spacing = null; //reset computed cache, border style can disable/enable border calculations
+            }
             //see __set and __get, on all assignments clear cache!
             $this->_prop_cache[$prop] = null;
             if ($important) {
@@ -1530,6 +1551,9 @@ class Style
      */
     protected function _set_style_side_width_important($style, $side, $val)
     {
+        if ($side === "bottom") {
+            $this->_computed_bottom_spacing = null; //reset cache for any bottom width changes
+        }
         //see __set and __get, on all assignments clear cache!
         $this->_prop_cache[$style . '_' . $side] = null;
         $this->_props[$style . '_' . $side] = str_replace("none", "0px", $val);

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -497,14 +497,7 @@ class Page extends AbstractFrameDecorator
         // parents of $frame must fit on the page as well:
         $p = $frame->get_parent();
         while ($p) {
-            $style = $p->get_style();
-            $max_y += $style->length_in_pt(
-                array(
-                    $style->margin_bottom,
-                    $style->padding_bottom,
-                    $style->border_bottom_width
-                )
-            );
+            $max_y += $p->get_style()->computed_bottom_spacing();
             $p = $p->get_parent();
         }
 

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -688,11 +688,11 @@ class Block extends AbstractFrameReflower
         list($w, $left_margin, $right_margin, $left, $right) = $this->_calculate_restricted_width();
 
         // Store the calculated properties
-        $style->width = $w . "pt";
-        $style->margin_left = $left_margin . "pt";
-        $style->margin_right = $right_margin . "pt";
-        $style->left = $left . "pt";
-        $style->right = $right . "pt";
+        $style->width = $w;
+        $style->margin_left = $left_margin;
+        $style->margin_right = $right_margin;
+        $style->left = $left;
+        $style->right = $right;
 
         // Update the position
         $this->_frame->position();


### PR DESCRIPTION
When tracing through the Style->__set() calls I found that FrameReflower\Block.php forcibly appends "pt" to margin left/right, width and left/right causing weird style values such as nonept and autopt.
The html sample I was testing remained identical, when comparing bytewise, only the creation/modification block was different.