### PR TITLE
Add bottom spacing computing cache and use it in the Page->check_page_break()

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -178,6 +178,11 @@ class Style
     private $__font_size_calculated; // Cache flag
 
     /**
+     * The computed bottom spacing
+     */
+    private $_computed_bottom_spacing = null;
+
+    /**
      * The computed border radius
      */
     private $_computed_border_radius = null;
@@ -779,6 +784,19 @@ class Style
         }
 
         return $this->_prop_cache[$prop] = $this->_props[$prop];
+    }
+
+    function computed_bottom_spacing() {
+        if ($this->_computed_bottom_spacing !== null) {
+            return $this->_computed_bottom_spacing;
+        }
+        return $this->_computed_bottom_spacing = $this->length_in_pt(
+            array(
+                $this->margin_bottom,
+                $this->padding_bottom,
+                $this->border_bottom_width
+            )
+        );
     }
 
     function get_font_family_raw()
@@ -1478,6 +1496,9 @@ class Style
         $prop = $style . '_' . $side . $type;
 
         if (!isset($this->_important_props[$prop]) || $important) {
+            if ($side === "bottom") {
+                $this->_computed_bottom_spacing = null; //reset computed cache, border style can disable/enable border calculations
+            }
             //see __set and __get, on all assignments clear cache!
             $this->_prop_cache[$prop] = null;
             if ($important) {
@@ -1530,6 +1551,9 @@ class Style
      */
     protected function _set_style_side_width_important($style, $side, $val)
     {
+        if ($side === "bottom") {
+            $this->_computed_bottom_spacing = null; //reset cache for any bottom width changes
+        }
         //see __set and __get, on all assignments clear cache!
         $this->_prop_cache[$style . '_' . $side] = null;
         $this->_props[$style . '_' . $side] = str_replace("none", "0px", $val);

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -497,14 +497,7 @@ class Page extends AbstractFrameDecorator
         // parents of $frame must fit on the page as well:
         $p = $frame->get_parent();
         while ($p) {
-            $style = $p->get_style();
-            $max_y += $style->length_in_pt(
-                array(
-                    $style->margin_bottom,
-                    $style->padding_bottom,
-                    $style->border_bottom_width
-                )
-            );
+            $max_y += $p->get_style()->computed_bottom_spacing();
             $p = $p->get_parent();
         }
 


### PR DESCRIPTION
For my sample, it reduces Style->__get() calls from 17400 to 13500 and Style->length_in_pt() calls from 3300 to 2300, giving additional ~3.5% speedup.
Such pre-computing can be used because check_page_break used the length_in_pt without the second parameter. Places that modify any padding/margin or border properties needed special "bottom" check to clear the computed value.