### PR TITLE
Fix fatal error in Dompdf\FrameDecorator\Page::check_page_break

### DIFF
--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -588,7 +588,7 @@ class Page extends AbstractFrameDecorator
         // If we are in a table, backtrack to the nearest top-level table row
         if ($this->_in_table) {
             $iter = $frame;
-            while ($iter && $iter->get_style()->display !== "table-row")
+            while ($iter && $iter->get_style()->display !== "table-row" && $iter->get_style()->display !== 'table-row-group')
                 $iter = $iter->get_parent();
 
             $iter->split(null, true);


### PR DESCRIPTION
How to check bug (master branch):
```php
<?php
require __DIR__ . '/vendor/autoload.php';
use Dompdf\Dompdf;

error_reporting(E_ALL);
ini_set('display_errors', true);

$html = "<html><head></head><body><table style='margin-top: 678px'>
<tbody><th><td>Test</td></th><tr><td>Test2</td></tr></tbody></table></body></html>";
$dompdf = new Dompdf();
$dompdf->loadHtml($html);
// (Optional) Setup the paper size and orientation
$dompdf->setPaper('A4', 'landscape');

// Render the HTML as PDF
/* Fatal error: Call to a member function split() on a non-object in 
   /var/www/shared/dompdf/src/FrameDecorator/Page.php on line 594
*/
$dompdf->render();
```
My PHP version: **PHP 5.5.9-1ubuntu4.14 (cli)**