### PR TITLE
Fixes an issue with selectFont() not respecting tempDir settings.

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -2577,7 +2577,7 @@ EOT;
                         $font_obj->reduce();
 
                         // Write new font
-                        $tmp_name = "$fbfile.tmp." . uniqid();
+                        $tmp_name = $this->tmp . "/" . basename($fbfile) . ".tmp." . uniqid();
                         $font_obj->open($tmp_name, BinaryStream::modeWrite);
                         $font_obj->encode(array("OS/2"));
                         $font_obj->close();


### PR DESCRIPTION
When running dompdf, cpdf needs to create temporary files, and it creates them in the same folder as the default dompdf fonts, with .tmp.uniqid() added to the end of the file's name. 

The problem is, the default dompdf font folder is not always writable. Dompdf allows setting a separate font cache / temporary folder to deal with that, and it passes those to cpdf, but cpdf was ignoring it in this instance, which caused problems in situations where the font folder wasn't writable.

I made the files go to `$this->tmp` because they are temporary files that are created and deleted a few lines of code later.