### PR TITLE
First step to fix bug #1027

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -637,6 +637,12 @@ abstract class AbstractFrameDecorator extends Frame
         }
 
         $node = $this->_frame->get_node();
+        
+        if ($node->hasAttribute("id"))
+        {
+            $node->setAttribute('data-dompdf-clone-temp-id', $node->getAttribute('id'));
+            $node->removeAttribute('id');
+        }
 
         $split = $this->copy($node->cloneNode());
         $split->reset();


### PR DESCRIPTION
I'm moving the `id`'s content to `data-dompdf-clone-temp-id`. To be honest, I don't understand why this code then works:
````php
        $dompdf = new Dompdf();
        $dompdfOptions = new Options();
        $dompdfOptions->set('defaultPaperSize', 'legal');
        $dompdf->setOptions($dompdfOptions);
        $html = '<style>#foo {color:green; }</style>';
        $html .= '<div id="foo">';
        for ($i=0; $i<1000; $i++)
        {
            $html .= 'Lorem ipsum ';
        }
        $html .= '</div>';
        $dompdf->loadHtml($html);
        $dompdf->render();
````
=> I get 3 pages in green. But shouldn't the `id` be gone? I'm not setting `data-dompdf-clone-temp-id` back to `id` anywhere!