### PR TITLE
Auto-width calculation, and other related bootstrap improvements

### DIFF
--- a/lib/res/html.css
+++ b/lib/res/html.css
@@ -373,8 +373,11 @@ input[type=reset],
 input[type=file],
 button {
   background: #CCC;
-  width: 8em;
   text-align: center;
+}
+
+input[type=file] {
+  width: 8em;
 }
 
 input[type=text]:before,

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -777,6 +777,32 @@ class Style
         return $this->_prop_cache[$prop] = $this->_props[$prop];
     }
 
+    /**
+     * Similar to __get() without storing the result. Useful for accessing
+     * properties while loading stylesheets.
+     *
+     * @return string
+     */
+    function get_prop($prop)
+    {
+        if (!isset(self::$_defaults[$prop])) {
+            throw new Exception("'$prop' is not a valid CSS2 property.");
+        }
+
+        $method = "get_$prop";
+
+        // Fall back on defaults if property is not set
+        if (!isset($this->_props[$prop])) {
+            return self::$_defaults[$prop];
+        }
+
+        if (method_exists($this, $method)) {
+            return $this->$method();
+        }
+
+        return $this->_props[$prop];
+    }
+
     function get_font_family_raw()
     {
         return trim($this->_props["font_family"], " \t\n\r\x0B\"'");

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -612,6 +612,7 @@ class Stylesheet
                         case "first-letter": // TODO
 
                             // N/A
+                        case "focus":
                         case "active":
                         case "hover":
                         case "visited":
@@ -860,7 +861,7 @@ class Stylesheet
                         continue;
                     }
 
-                    if (($src = $this->_image($style->content)) !== "none") {
+                    if (($src = $this->_image($style->get_prop('content'))) !== "none") {
                         $new_node = $node->ownerDocument->createElement("img_generated");
                         $new_node->setAttribute("src", $src);
                     } else {
@@ -895,7 +896,7 @@ class Stylesheet
                 $id = $node->getAttribute("frame_id");
 
                 // Assign the current style to the scratch array
-                $spec = $this->_specificity($selector);
+                $spec = $this->_specificity($selector, $style->get_origin());
                 $styles[$id][$spec][] = $style;
             }
         }

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -773,6 +773,18 @@ class Frame
     /**
      * @return bool
      */
+    public function is_inline_block()
+    {
+        if (isset($this->_is_cache["inline_block"])) {
+            return $this->_is_cache["inline_block"];
+        }
+
+        return $this->_is_cache["inline_block"] = ($this->get_style()->display === 'inline-block');
+    }
+
+    /**
+     * @return bool
+     */
     public function is_in_flow()
     {
         if (isset($this->_is_cache["in_flow"])) {

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -805,4 +805,14 @@ abstract class AbstractFrameDecorator extends Frame
     {
         return $this->_reflower->get_min_max_width();
     }
+
+    /**
+     * Determine current frame width based on contents
+     *
+     * @return float
+     */
+    final function calculate_auto_width()
+    {
+        return $this->_reflower->calculate_auto_width();
+    }
 }

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -68,7 +68,8 @@ abstract class AbstractFrameReflower
         $cb = $frame->get_containing_block();
         $style = $frame->get_style();
 
-        if (!$frame->is_in_flow()) {
+        // Margins of float/absolutely positioned/inline-block elements do not collapse.
+        if (!$frame->is_in_flow() || $frame->is_inline_block()) {
             return;
         }
 
@@ -436,7 +437,7 @@ abstract class AbstractFrameReflower
             $frame->increment_counters($increment);
         }
 
-        if ($style->content && !$frame->get_first_child() && $frame->get_node()->nodeName === "dompdf_generated") {
+        if ($style->content && /*!$frame->get_first_child() && */$frame->get_node()->nodeName === "dompdf_generated") {
             $content = $this->_parse_content();
             // add generated content to the font subset
             // FIXME: This is currently too late because the font subset has already been generated.
@@ -456,5 +457,15 @@ abstract class AbstractFrameReflower
             Factory::decorate_frame($new_frame, $frame->get_dompdf(), $frame->get_root());
             $frame->append_child($new_frame);
         }
+    }
+
+    /**
+     * Determine current frame width based on contents
+     *
+     * @return float
+     */
+    public function calculate_auto_width()
+    {
+        return $this->_frame->get_margin_width();
     }
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -753,11 +753,12 @@ class Block extends AbstractFrameReflower
         $style->top = $top;
         $style->bottom = $bottom;
 
+        $orig_style = $this->_frame->get_original_style();
+
         $needs_reposition = ($style->position === "absolute" && ($style->right !== "auto" || $style->bottom !== "auto"));
 
         // Absolute positioning measurement
         if ($needs_reposition) {
-            $orig_style = $this->_frame->get_original_style();
             if ($orig_style->width === "auto" && ($orig_style->left === "auto" || $orig_style->right === "auto")) {
                 $width = 0;
                 foreach ($this->_frame->get_line_boxes() as $line) {
@@ -768,6 +769,25 @@ class Block extends AbstractFrameReflower
 
             $style->left = $orig_style->left;
             $style->right = $orig_style->right;
+        }
+
+        // Calculate inline-block / float auto-widths
+        if (($style->display === "inline-block" || $style->float !== 'none') && $orig_style->width === 'auto') {
+            $width = 0;
+
+            foreach ($this->_frame->get_line_boxes() as $line) {
+                $line->recalculate_width();
+
+                $width = max($line->w, $width);
+            }
+
+            if ($width === 0) {
+                foreach ($this->_frame->get_children() as $child) {
+                    $width += $child->calculate_auto_width();
+                }
+            }
+
+            $style->width = $width;
         }
 
         $this->_text_align();
@@ -789,5 +809,33 @@ class Block extends AbstractFrameReflower
                 $block->add_line();
             }
         }
+    }
+
+    /**
+     * Determine current frame width based on contents
+     *
+     * @return float
+     */
+    public function calculate_auto_width()
+    {
+        $width = 0;
+
+        foreach ($this->_frame->get_line_boxes() as $line) {
+            $line_width = 0;
+
+            foreach ($line->get_frames() as $frame) {
+                if ($frame->get_original_style()->width == 'auto') {
+                    $line_width += $frame->calculate_auto_width();
+                } else {
+                    $line_width += $frame->get_margin_width();
+                }
+            }
+
+            $width = max($line_width, $width);
+        }
+
+        $this->_frame->get_style()->width = $width;
+
+        return $this->_frame->get_margin_width();
     }
 }

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -73,4 +73,26 @@ class Inline extends AbstractFrameReflower
             $child->reflow($block);
         }
     }
+
+    /**
+     * Determine current frame width based on contents
+     *
+     * @return float
+     */
+    public function calculate_auto_width()
+    {
+        $width = 0;
+
+        foreach ($this->_frame->get_children() as $child) {
+            if ($child->get_original_style()->width == 'auto') {
+                $width += $child->calculate_auto_width();
+            } else {
+                $width += $child->get_margin_width();
+            }
+        }
+
+        $this->_frame->get_style()->width = $width;
+
+        return $this->_frame->get_margin_width();
+    }
 }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -484,4 +484,14 @@ class Text extends AbstractFrameReflower
     {
         return $this->fontMetrics;
     }
+
+    /**
+     * Determine current frame width based on contents
+     *
+     * @return float
+     */
+    public function calculate_auto_width()
+    {
+        return $this->_frame->recalculate_width();
+    }
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -72,7 +72,7 @@ class Helpers
             //drive: followed by a relative path would be a drive specific default folder.
             //not known in php app code, treat as abs path
             //($url[1] !== ':' || ($url[2]!=='\\' && $url[2]!=='/'))
-            if ($url[0] !== '/' && (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' || ($url[0] !== '\\' && $url[1] !== ':'))) {
+            if ($url[0] !== '/' && (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' || (mb_strlen($url) > 1 && $url[0] !== '\\' && $url[1] !== ':'))) {
                 // For rel path and local acess we ignore the host, and run the path through realpath()
                 $ret .= realpath($base_path) . '/';
             }

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -234,6 +234,22 @@ class LineBox
         $this->_frames[] = $frame;
     }
 
+    /**
+     * Recalculate LineBox width based on the contained frames total width.
+     *
+     * @return float
+     */
+    public function recalculate_width()
+    {
+        $width = 0;
+
+        foreach ($this->get_frames() as $frame) {
+            $width += $frame->calculate_auto_width();
+        }
+
+        return $this->w = $width;
+    }
+
     function __toString()
     {
         $props = array("wc", "y", "w", "h", "left", "right", "br");


### PR DESCRIPTION
Bootstrap Improvements:
- Auto-width calculation for floated and inline-block elements.
- Fix style specificity based on the origin of the stylesheet.
- Add :focus psudo-class to stylesheet parser.
- Modify default UA stylesheet to reflect auto-width changes.
- Fix 'content' css property being set to 'normal' for all :before/:after selectors before determining their specificity.
- Add extra check to prevent Helpers::build_url() from throwing a warning for URIs of 1 character (eg: '#').

Visually improves the usability of bootstrap (and most likely any other inline-block/float heavy CSS) substantially. Included PDF examples of the documentation both pre and post changes (see below).

Auto-width appears to work OK based on my testing so far, any feedback on the implementation is welcome.

Included quite a few changes in this PR, if you would prefer these (or some of) individually I can split them up.

[badges-pre-changes.pdf](https://github.com/dompdf/dompdf/files/195505/badges-pre-changes.pdf)
[buttons-pre-changes.pdf](https://github.com/dompdf/dompdf/files/195503/buttons-pre-changes.pdf)
[buttons-post-changes.pdf](https://github.com/dompdf/dompdf/files/195504/buttons-post-changes.pdf)
[badges-post-changes.pdf](https://github.com/dompdf/dompdf/files/195502/badges-post-changes.pdf)
