### PR TITLE
Fix border-radius not correctly applying …

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3286,6 +3286,9 @@ EOT;
         // start: top edge, left end
         $this->addContent(sprintf("\n%.3F %.3F m ", $x1, $y1 - $rTL + $h));
 
+        // line: bottom edge, left end
+        $this->addContent(sprintf("\n%.3F %.3F l ", $x1, $y1 - $rBL));
+
         // curve: bottom-left corner
         $this->ellipse($x1 + $rBL, $y1 + $rBL, $rBL, 0, 0, 8, 180, 270, false, false, false, true);
 


### PR DESCRIPTION
Fix border-radius not correctly applying when bottom points have a value of 0.

If no corners were rendered the first two points would be the top left and bottom right. This fix adds an additional bottom left point in-between.

Fixes #1130, and possibly other related border-radius issues.