### PR TITLE
Fix a couple of issues with table-cells

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -516,7 +516,10 @@ class Cellmap
 
             $start_row = $this->__row;
             foreach ($frame->get_children() as $child) {
-                $this->add_frame($child);
+                // Ignore all Text frames and :before/:after pseudo-selector elements.
+                if (!($child instanceof FrameDecorator\Text) && $child->get_node()->nodeName !== 'dompdf_generated') {
+                    $this->add_frame($child);
+                }
             }
 
             if ($display === "table-row") {


### PR DESCRIPTION
Fix a couple of issues with table-cells:
 * Table-row will now ignore :before/:after frames and not include them as cells.
 * Text frames between a </tr> closing tag and <td> opening tag will no longer be added as a table-cell. Fixes a potential issue with the getAttribute() method not existing in \DOMText.

Fixes tables in bootstrap, and also most likely fixes #1103.