### PR TITLE
fix: comparing instead of assign

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -312,7 +312,7 @@ class Helpers
 
         $arr = parse_url($url);
         if ( isset($arr["scheme"]) ) {
-            $arr["scheme"] == mb_strtolower($arr["scheme"]);
+            $arr["scheme"] = mb_strtolower($arr["scheme"]);
         }
 
         // Exclude windows drive letters...


### PR DESCRIPTION
Probably there is typo ( '==' instead of '=') in the code.

This possible defect found by [static code analyzer AppСhecker](http://www.npo-echelon.ru/en/solutions/appchecker.php)