### PR TITLE
Cache the get_parent() results, 8% speedup

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -83,6 +83,13 @@ abstract class AbstractFrameDecorator extends Frame
     private $_positionned_parent;
 
     /**
+     * Cache for the get_parent wehile loop results
+     *
+     * @var Frame
+     */
+    private $_cached_parent;
+
+    /**
      * Class constructor
      *
      * @param Frame $frame   The decoration target
@@ -172,6 +179,8 @@ abstract class AbstractFrameDecorator extends Frame
         $this->_frame->reset();
 
         $this->_counters = array();
+
+        $this->_cached_parent = null; //clear get_parent() cache
 
         // Reset all children
         foreach ($this->get_children() as $child) {
@@ -403,20 +412,19 @@ abstract class AbstractFrameDecorator extends Frame
      */
     function get_parent()
     {
+        if ($this->_cached_parent) {
+            return $this->_cached_parent;
+        }
         $p = $this->_frame->get_parent();
         if ($p && $deco = $p->get_decorator()) {
             while ($tmp = $deco->get_decorator()) {
                 $deco = $tmp;
             }
 
-            return $deco;
+            return $this->_cached_parent = $deco;
         } else {
-            if ($p) {
-                return $p;
-            }
+            return $this->_cached_parent = $p;
         }
-
-        return null;
     }
 
     /**


### PR DESCRIPTION
Cache get_parent() in the AbstractFrameDecorator and reset cache in reset(), which is called when splitting elements to another page and thus changing the parent.

Reduces Frame->get_decorator() calls from 8800 to 2000 and Frame->get_parent() calls from 4000 to 270 in my sample, giving ~8% additional speedup.
