### PR TITLE
Remove development only files/folders when pulling through composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,9 @@
 *.txt   text
 *.svg   text
 
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore


### PR DESCRIPTION
This will remove tests and git only files - as they do not need to be pulled onto production machines, or when pulled from composer.

More Info on this: http://bit.ly/2176xGM
