### PR TITLE
Correct border radius point placement.

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3278,7 +3278,7 @@ EOT;
         $this->addContent(sprintf("\n%.3F %.3F m ", $x1, $y1 - $rTL + $h));
 
         // line: bottom edge, left end
-        $this->addContent(sprintf("\n%.3F %.3F l ", $x1, $y1 - $rBL));
+        $this->addContent(sprintf("\n%.3F %.3F l ", $x1, $y1 + $rBL));
 
         // curve: bottom-left corner
         $this->ellipse($x1 + $rBL, $y1 + $rBL, $rBL, 0, 0, 8, 180, 270, false, false, false, true);


### PR DESCRIPTION
Corrects placement of additional clipping point added by commit f92c8b83. Fixes #1201.

[border-radius-fix.pdf](https://github.com/dompdf/dompdf/files/325597/border-radius-fix.pdf)
