### PR TITLE
Fixed appending pdf extension

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3508,7 +3508,7 @@ EOT;
         //FIXME: I don't know that this is sufficient for determining content length (i.e. what about transport compression?)
         header("Content-Length: " . mb_strlen($tmp, '8bit'));
         $filename = (isset($options['Content-Disposition']) ? $options['Content-Disposition'] : 'document.pdf');
-        $filename = str_replace(array("\n", "'"), "", basename($filename)) . '.pdf';
+        $filename = str_replace(array("\n", "'"), "", basename($filename, '.pdf')) . '.pdf';
 
         if (!isset($options["Attachment"])) {
             $options["Attachment"] = true;

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1090,7 +1090,7 @@ class PDFLib implements Canvas
         header("Cache-Control: private");
         header("Content-type: application/pdf");
 
-        $filename = str_replace(array("\n", "'"), "", basename($filename)) . '.pdf';
+        $filename = str_replace(array("\n", "'"), "", basename($filename, '.pdf')) . '.pdf';
         $attach = (isset($options["Attachment"]) && $options["Attachment"]) ? "attachment" : "inline";
 
         // detect the character encoding of the incoming file


### PR DESCRIPTION
If you pass a filename with a `.pdf` extension to these methods, you got a duplicate `.pdf.pdf` filename.
