### PR TITLE
Excluding files from git archive exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,10 @@
 *.txt   text
 *.svg   text
 
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.travis          export-ignore
+phpunit.xml.dist export-ignore
+Tests/           export-ignore
+
 VERSION export-subst


### PR DESCRIPTION
These files aren't needed in production, so we should remove them from the git archive export.