### PR TITLE
Fix floating elements position

### DIFF
--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -143,6 +143,17 @@ class Block extends AbstractFrameReflower
 
         }
 
+        // When previous sibling is floating, we have to ignore it when calculating the margin
+        if($lm > 0) {
+            $prev = $frame->get_prev_sibling();
+            if($prev) {
+                $prev_stype = $prev->get_style();
+                if ($prev_stype->float === "left") {
+                    $lm -= $prev_stype->width;
+                }
+            }
+        }
+
         return array(
             "width" => $width,
             "margin_left" => $lm,


### PR DESCRIPTION
When we have a floating previous sibling, we have to ignore it when calculating the margin, or we'll end up with a double margin.

For example, when using dompdf with the random generated contents of http://gensav.altervista.org/
Before my edit: https://dl.dropboxusercontent.com/u/18969675/dompdf_before.jpg
After my edit: https://dl.dropboxusercontent.com/u/18969675/dompdf_after.jpg