### PR TITLE
Add support for ID linking

### DIFF
--- a/src/Renderer/Block.php
+++ b/src/Renderer/Block.php
@@ -80,6 +80,10 @@ class Block extends AbstractRenderer
                 $frame->_debug_layout(array($line->x, $line->y, $line->w, $line->h), "orange");
             }
         }
+
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
     }
 
     protected function _render_border(AbstractFrameDecorator $frame, $border_box = null, $corner_style = "bevel")

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -121,5 +121,9 @@ class Image extends Block
                 $this->_debug_layout($frame->get_padding_box(), "blue", array(0.5, 0.5));
             }
         }
+
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
     }
 }

--- a/src/Renderer/Inline.php
+++ b/src/Renderer/Inline.php
@@ -175,12 +175,16 @@ class Inline extends AbstractRenderer
             $this->$method($x + $w, $y, $h, $bp["right"]["color"], $widths, "right");
         }
 
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
+
         // Only two levels of links frames
         $link_node = null;
         if ($frame->get_node()->nodeName === "a") {
             $link_node = $frame->get_node();
 
-            if (($name = $link_node->getAttribute("name")) || ($name = $link_node->getAttribute("id"))) {
+            if (($name = $link_node->getAttribute("name"))) {
                 $this->_canvas->add_named_dest($name);
             }
         }

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -244,5 +244,9 @@ class ListBullet extends AbstractRenderer
                     break;
             }
         }
+
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
     }
 }

--- a/src/Renderer/TableCell.php
+++ b/src/Renderer/TableCell.php
@@ -156,5 +156,8 @@ class TableCell extends Block
             }
         }
 
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
     }
 }

--- a/src/Renderer/TableRowGroup.php
+++ b/src/Renderer/TableRowGroup.php
@@ -40,5 +40,9 @@ class TableRowGroup extends Block
                 $frame->_debug_layout(array($line->x, $line->y, $line->w, $line->h), "orange");
             }
         }
+
+        if ($id = $frame->get_node()->getAttribute("id")) {
+            $this->_canvas->add_named_dest($id);
+        }
     }
 }


### PR DESCRIPTION
Addresses one of the issues related to anchor linking, mentioned in #1147. This patch is hardly testet though.

Empty (a) tags are still ignored. This must be fixed, but is slightly more complicated...

For more information see:

  http://w3c.github.io/html/browsers.html#navigating-to-a-fragment-identifier
