### PR TITLE
Fixes an issue with Dompdf\Image\Cache::resolve_url().

### DIFF
--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -95,6 +95,9 @@ class Cache
                             }
                         } else {
                             $image = Helpers::getFileContent($full_url, $dompdf->getHttpContext());
+
+                            # Helpers::getFileContent returns an array, and the contents are the first item in it.
+                            $image = $image[0];
                         }
 
                         // Image not found or invalid


### PR DESCRIPTION
Helpers::getFileContent() returns an array, but during the refactoring this bit of code wasn't updated to handle it.