### PR TITLE
Avoid applying vertical-align to text within cells

### DIFF
--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -12,6 +12,7 @@ use Dompdf\FontMetrics;
 use Dompdf\Frame;
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Text as TextFrameDecorator;
+use Dompdf\FrameDecorator\TableCell as TableCellFrameDecorator;
 use Dompdf\Exception;
 
 /**
@@ -529,7 +530,14 @@ class Block extends AbstractFrameReflower
                     continue;
                 }
 
-                $align = $frame->get_parent()->get_style()->vertical_align;
+                $parent = $frame->get_parent();
+
+                if ($parent instanceof TableCellFrameDecorator) {
+                    // Table cells are not inline elements.
+                    $align = "baseline";
+                } else {
+                    $align = $parent->get_style()->vertical_align;
+                }
 
                 if (!isset($canvas)) {
                     $canvas = $frame->get_root()->get_dompdf()->get_canvas();


### PR DESCRIPTION
It seems that currently vertical-align is applied twice to table cells: once, correctly, to align the cell's contents within the table row (in FrameDecorator\TableCell::set_cell_height), and secondly, incorrectly, to align text directly within table cells (in FrameReflower\Block::vertical_align). This change inhibits the second alignment by defaulting it to 'baseline', the same as text elsewhere, so that only inline elements within the table cell are aligned.

You can see the difference with HTML like this:

```
<style> td { vertical-align: top; } </style>
<table><tr><td> different <span>heights</span> </td></tr></table>
```

Looking at the code, I think there are still some deficiencies with the vertical-align implementation (e.g. images are not affected; nested inline elements are not correctly treated). I may look into these issues also at some stage, but this change covers a common case that is worth fixing immediately, in my opinion, and is the high priority change for us.

Thanks again for a great library.
