### PR TITLE
Removed added ".pdf" file extension from the Cpdf stream function.

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3508,7 +3508,7 @@ EOT;
         //FIXME: I don't know that this is sufficient for determining content length (i.e. what about transport compression?)
         header("Content-Length: " . mb_strlen($tmp, '8bit'));
         $filename = (isset($options['Content-Disposition']) ? $options['Content-Disposition'] : 'document.pdf');
-        $filename = str_replace(array("\n", "'"), "", basename($filename)) . '.pdf';
+        $filename = str_replace(array("\n", "'"), "", basename($filename));
 
         if (!isset($options["Attachment"])) {
             $options["Attachment"] = true;


### PR DESCRIPTION
I removed this added .pdf extension, as calling `Dompdf::stream("test.pdf")` results in a generated file called "test.pdf.pdf".

The `Dompdf::stream()` function is supposed to be called with file extension, as suggested by the default for the filename parameter:
`Dompsd::stream($filename = 'document.pdf', $options = null)`
