### PR TITLE
Allow excluding pages for the page_script to be run on

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -911,7 +911,7 @@ class CPDF implements Canvas
             foreach ($this->_page_text as $pt) {
                 extract($pt);
 
-                if (in_array($page_number, $except_on)) {
+                if ($except_on && in_array($page_number, $except_on)) {
                     // don't run the script on the page that is to be excluded
                     break;
                 }

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -873,11 +873,13 @@ class CPDF implements Canvas
      *
      * @param string $code the script code
      * @param string $type the language type for script
+     * @param array $except_on the page numbers on which not to run the script
      */
-    function page_script($code, $type = "text/php")
+    function page_script($code, $type = "text/php", $except_on = array())
     {
         $_t = "script";
-        $this->_page_text[] = compact("_t", "code", "type");
+
+        $this->_page_text[] = compact("_t", "code", "type", "except_on");
     }
 
     function new_page()
@@ -908,6 +910,11 @@ class CPDF implements Canvas
 
             foreach ($this->_page_text as $pt) {
                 extract($pt);
+
+                if (in_array($page_number, $except_on)) {
+                    // don't run the script on the page that is to be excluded
+                    break;
+                }
 
                 switch ($_t) {
                     case "text":


### PR DESCRIPTION
I was looking for a way to run a `page_script` on all pages except the first one but there didn't seem to be any existing way to do it(or maybe I couldn't find it). So this pull request allows to specify the page numbers on which to exclude the `page_script` to be executed.

**Usage example:**
Show the page number on top of the page for every page except the first and third page.

    $pdf->page_script('$font = $fontMetrics->get_font("Arial, Helvetica, sans-serif", "normal");
                $size = 12;

                $page_text = "Page " . $PAGE_NUM . " of " . $PAGE_COUNT;
                $pdf->text(470, 15, $page_text, $font, $size);
        ', 'text/php', array(1, 3));

The page numbers to be excluded are passed in an array as third parameter to the `page_script` function.
