### PR TITLE
Fix and a test for removing spaces from the beginning of an inline tag

### DIFF
--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -314,7 +314,7 @@ class Text extends AbstractFrameReflower
             // FIXME: Include non-breaking spaces?
             $t = $frame->get_text();
             $parent = $frame->get_parent();
-            $is_inline_frame = get_class($parent) === 'Inline_Frame_Decorator';
+            $is_inline_frame = get_class($parent) === 'Dompdf\\FrameDecorator\\Inline';
 
             if ((!$is_inline_frame && !$frame->get_next_sibling()) /* ||
           ( $is_inline_frame && !$parent->get_next_sibling())*/

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -67,4 +67,31 @@ class DompdfTest extends PHPUnit_Framework_TestCase
         $dom = $dompdf->getDom();
         $this->assertEquals('', $dom->textContent);
     }
+
+    public function testSpaceAtStartOfSecondInlineTag()
+    {
+        $text_frame_contents = array();
+
+        $dompdf = new Dompdf();
+
+        // Use a callback to inspect the frame tree; otherwise FrameReflower\Page::reflow()
+        // will dispose of it before dompdf->render finishes
+        $dompdf->setCallbacks(array('test' => array(
+            'event' => 'end_page_render',
+            'f' => function($params) use (&$text_frame_contents) {
+                $frame = $params["frame"];
+                foreach ($frame->get_children() as $child) {
+                    foreach ($child->get_children() as $grandchild) {
+                        $text_frame_contents[] = $grandchild->get_text();
+                    }
+                }
+            }
+        )));
+
+        $dompdf->loadHtml('<span>one</span><span> - two</strong>');
+        $dompdf->render();
+
+        $this->assertEquals("one", $text_frame_contents[0]);
+        $this->assertEquals(" - two", $text_frame_contents[1]);
+    }
 }


### PR DESCRIPTION
It looks like a class name didn't get updated when the code was refactored, which results in some whitespace being removed that should not be.