### PR TITLE
Fixed some PHP7.1 string arithmetic issues, update to PHPUnit 4.8, fixed test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 install: travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phenx/php-svg-lib": "0.1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "5.7.*",
         "squizlabs/php_codesniffer": "2.*"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phenx/php-svg-lib": "0.1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*",
+        "phpunit/phpunit": "4.8.*",
         "squizlabs/php_codesniffer": "2.*"
     },
     "extra": {

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -992,11 +992,11 @@ class Style
 
         // Ensure relative sizes resolve to something
         if (($i = mb_strpos($fs, "em")) !== false) {
-            $fs = mb_substr($fs, 0, $i) * $this->_parent_font_size;
+            $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
         } else if (($i = mb_strpos($fs, "ex")) !== false) {
-            $fs = mb_substr($fs, 0, $i) * $this->_parent_font_size;
+            $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
         } else {
-            $fs = $this->length_in_pt($fs);
+            $fs = (float)$this->length_in_pt($fs);
         }
 
         //see __set and __get, on all assignments clear cache!

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -547,7 +547,7 @@ class Style
 
             if (($i = mb_strpos($l, "px")) !== false) {
                 $dpi = $this->_stylesheet->get_dompdf()->getOptions()->getDpi();
-                $ret += (mb_substr($l, 0, $i) * 72) / $dpi;
+                $ret += ((float)mb_substr($l, 0, $i) * 72) / $dpi;
                 continue;
             }
 
@@ -572,18 +572,18 @@ class Style
             }
 
             if (($i = mb_strpos($l, "cm")) !== false) {
-                $ret += mb_substr($l, 0, $i) * 72 / 2.54;
+                $ret += (float)mb_substr($l, 0, $i) * 72 / 2.54;
                 continue;
             }
 
             if (($i = mb_strpos($l, "mm")) !== false) {
-                $ret += mb_substr($l, 0, $i) * 72 / 25.4;
+                $ret += (float)mb_substr($l, 0, $i) * 72 / 25.4;
                 continue;
             }
 
             // FIXME: em:ex ratio?
             if (($i = mb_strpos($l, "ex")) !== false) {
-                $ret += mb_substr($l, 0, $i) * $this->__get("font_size") / 2;
+                $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size") / 2;
                 continue;
             }
 
@@ -1396,10 +1396,10 @@ class Style
             return $this->_computed_border_radius;
         }
 
-        $rTL = $this->__get("border_top_left_radius");
-        $rTR = $this->__get("border_top_right_radius");
-        $rBL = $this->__get("border_bottom_left_radius");
-        $rBR = $this->__get("border_bottom_right_radius");
+        $rTL = (float)$this->__get("border_top_left_radius");
+        $rTR = (float)$this->__get("border_top_right_radius");
+        $rBL = (float)$this->__get("border_bottom_left_radius");
+        $rBR = (float)$this->__get("border_bottom_right_radius");
 
         if ($rTL + $rTR + $rBL + $rBR == 0) {
             return $this->_computed_border_radius = array(
@@ -1411,10 +1411,10 @@ class Style
             );
         }
 
-        $t = $this->__get("border_top_width");
-        $r = $this->__get("border_right_width");
-        $b = $this->__get("border_bottom_width");
-        $l = $this->__get("border_left_width");
+        $t = (float)$this->__get("border_top_width");
+        $r = (float)$this->__get("border_right_width");
+        $b = (float)$this->__get("border_bottom_width");
+        $l = (float)$this->__get("border_left_width");
 
         $rTL = min($rTL, $h - $rBL - $t / 2 - $b / 2, $w - $rTR - $l / 2 - $r / 2);
         $rTR = min($rTR, $h - $rBR - $t / 2 - $b / 2, $w - $rTL - $l / 2 - $r / 2);

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -491,7 +491,7 @@ class Page extends AbstractFrameDecorator
             return false;
 
         // Determine the frame's maximum y value
-        $max_y = $frame->get_position("y") + $margin_height;
+        $max_y = (float)$frame->get_position("y") + (float)$margin_height;
 
         // If a split is to occur here, then the bottom margins & paddings of all
         // parents of $frame must fit on the page as well:

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -94,11 +94,11 @@ class TableCell extends Block
         }
 
         // Determine our height
-        $style_height = $style->length_in_pt($style->height, $h);
+        $style_height = (float)$style->length_in_pt($style->height, $h);
 
         $this->_frame->set_content_height($this->_calculate_content_height());
 
-        $height = max($style_height, $this->_frame->get_content_height());
+        $height = max($style_height, (float)$this->_frame->get_content_height());
 
         // Let the cellmap know our height
         $cell_height = $height / count($cells["rows"]);

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -66,5 +66,9 @@ class DompdfTest extends PHPUnit_Framework_TestCase
 
         $dom = $dompdf->getDom();
         $this->assertEquals('', $dom->textContent);
+
+        /* This closes the OB opened by render() */
+        $dompdf->output();
+
     }
 }


### PR DESCRIPTION
String arithmetic works slightly different in PHP7.1. I've added some explicit typecasting on places to make dompdf compatible with PHP 7.1

Example:
https://3v4l.org/9h376

 I've also changed PHPUnit version to recent 4.8
Fixed a detail in the `testRender()` test: no `$dompdf->output()` or` ->stream()` was called so the output buffer opened by `->render()` was not closed. 