### PR TITLE
Fixed reading file content for e.g. SVGs

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -529,7 +529,7 @@ class Helpers
         $type = isset($types[$type]) ? $types[$type] : null;
 
         if ($width == null || $height == null) {
-            list($data, $headers) = Helpers::getFileContent($filename, null, $context, 0, 26);
+            list($data, $headers) = Helpers::getFileContent($filename, $context);
 
             if (substr($data, 0, 2) === "BM") {
                 $meta = unpack('vtype/Vfilesize/Vreserved/Voffset/Vheadersize/Vwidth/Vheight', $data);


### PR DESCRIPTION
I have a problem using SVGs in image tags. The verification of files (BM or SVG) uses the getFileContent method in the Helpers class. 
1.) It passes five parameters but the method has only four parameters. The second is wrong and has to be removed. 
2.) If the SVG has more than 26 chars before the svg tag, it couldn't be detected, so the max-length shouldn't be passed to check the whole content. The last two parameters should be removed.