### PR TITLE
Implement support for widows when determining the location of page breaks

### DIFF
--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -792,24 +792,30 @@ class Block extends AbstractFrameReflower
 
         // Set the containing blocks and reflow each child
         foreach ($this->_frame->get_children() as $child) {
-
-            // Bail out if the page is full
-            if ($page->is_full()) {
-                break;
-            }
-
             $child->set_containing_block($cb_x, $cb_y, $w, $cb_h);
 
             $this->process_clear($child);
 
             $child->reflow($this->_frame);
 
-            // Don't add the child to the line if a page break has occurred
-            if ($page->check_page_break($child)) {
-                break;
-            }
-
             $this->process_float($child, $cb_x, $w);
+        }
+
+        // Go back through and handle any page breaks
+        foreach ($this->_frame->get_children() as $child) {
+            // Skip children that are empty text nodes
+            if (!$child->is_text_node() ||
+                $child->get_node()->nodeValue != ""
+            ) {
+                if ($page->check_page_break($child)) {
+                    break;
+                }
+
+                // Bail out if the page is full
+                if ($page->is_full()) {
+                    break;
+                }
+            }
         }
 
         // Determine our height

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -98,4 +98,125 @@ class DompdfTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("one", $text_frame_contents[0]);
         $this->assertEquals(" - two", $text_frame_contents[1]);
     }
+
+    private function _pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page)
+    {
+        $dompdf = new Dompdf();
+
+        $callback_count = 0;
+        $number_of_lines_on_second_page = 0;
+
+        // Use a callback to inspect the frame tree; otherwise FrameReflower\Page::reflow()
+        // will dispose of it before dompdf->render finishes
+        $dompdf->setCallbacks(array('test' => array(
+            'event' => 'end_page_render',
+            'f' => function($params) use (&$number_of_lines_on_second_page, &$callback_count) {
+                if ($callback_count == 1) {
+                    $frame = $params["frame"];
+                    foreach ($frame->get_children() as $child) {
+                        foreach ($child->get_children() as $grandchild) {
+                            if ($grandchild->get_node()->nodeName == "#text")
+                                $number_of_lines_on_second_page++;
+                        }
+                    }
+                }
+                $callback_count++;
+            }
+        )));
+
+        $html = "<p>";
+        $filler = array();
+        $MAX_FILLER = 47; // Is there a better way to know how many lines fit on a page?
+        for ($i = 1; $i <= $MAX_FILLER - $lines_that_could_fit_on_first_page; $i++) {
+            $filler[] = "Filler $i";
+        }
+        $html .= join("<br>", $filler);
+        $html .= "</p>";
+
+        $html .= "<p style=\"widows: $widows; orphans: $orphans;\">";
+        $lines = array();
+        for ($i = 1; $i <= $lines_in_paragraph; $i++) {
+            $lines[] = "Line $i";
+        }
+        $html .= join("<br>", $lines);
+        $html .= "</p>";
+
+        $dompdf->loadHtml($html);
+        $dompdf->render();
+
+        return $number_of_lines_on_second_page;
+    }
+
+    public function testPageBreak1orphan1widow()
+    {
+        $orphans = 1;        // Minimum lines on first page
+        $widows = 1;        // Minimum lines on second page
+        $lines_in_paragraph = 4; // Expected: 2 on first, 2 on second
+        $lines_that_could_fit_on_first_page = 2;
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+
+        $this->assertEquals(2, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak1orphan2widows()
+    {
+        $orphans = 1;
+        $widows = 2;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 2 on first, 2 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+
+        $this->assertEquals(2, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak1orphan3widows()
+    {
+        $orphans = 1;
+        $widows = 3;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 1 on first, 3 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+        $this->assertEquals(3, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak1orphan4widows()
+    {
+        $orphans = 1;
+        $widows = 4;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 0 on first, 4 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+        $this->assertEquals(4, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak2orphans1widow()
+    {
+        $orphans = 2;
+        $widows = 1;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 2 on first, 2 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+        $this->assertEquals(2, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak3orphans1widow()
+    {
+        $orphans = 3;
+        $widows = 1;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 0 on first, 4 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+        $this->assertEquals(4, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
+    public function testPageBreak4orphans1widow()
+    {
+        $orphans = 4;
+        $widows = 1;        // Minimum lines on second page
+        $lines_in_paragraph = 4;
+        $lines_that_could_fit_on_first_page = 2; // Expected: 0 on first, 4 on second
+        $number_of_lines_on_second_page = $this->_pageBreak($orphans, $widows, $lines_in_paragraph, $lines_that_could_fit_on_first_page);
+        $this->assertEquals(4, $number_of_lines_on_second_page, "Unexpected number of lines on the second page");
+    }
+
 }


### PR DESCRIPTION
I took a shot at implementing the code for CSS widows.  This was previously a "FIX ME" comment in the code.

While testing my new code, I noticed and corrected some issues in how whitespace in the HTML affected the page breaks.  I'm not sure whether or not these problems were introduced by my widows changes.