### PR TITLE
`get_spanned_cells` can return NULL

### DIFF
--- a/src/Renderer/TableCell.php
+++ b/src/Renderer/TableCell.php
@@ -53,6 +53,11 @@ class TableCell extends Block
 
         $cellmap = $table->get_cellmap();
         $cells = $cellmap->get_spanned_cells($frame);
+
+        if (is_null($cells)) {
+            return;
+        }
+
         $num_rows = $cellmap->get_num_rows();
         $num_cols = $cellmap->get_num_cols();
 


### PR DESCRIPTION
Thought it best just to have the method return...