### PR TITLE
Fix for "A non-numeric value encountered" in PHP 7.1

### DIFF
--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -591,7 +591,7 @@ class Block extends AbstractFrameReflower
                         continue;
                     }
                     $frameBox = $frame->get_frame()->get_border_box();
-                    $imageHeightDiff = $height * 0.8 - $frameBox['h'];
+                    $imageHeightDiff = $height * 0.8 - (float)$frameBox['h'];
 
                     $align = $frame->get_style()->vertical_align;
                     if (in_array($align, Style::$vertical_align_keywords) === true) {
@@ -626,7 +626,7 @@ class Block extends AbstractFrameReflower
                                 break;
                         }
                     } else {
-                        $y_offset = $baseline - (float)$style->length_in_pt($align, $style->font_size) - $frameBox['h'];
+                        $y_offset = $baseline - (float)$style->length_in_pt($align, $style->font_size) - (float)$frameBox['h'];
                     }
                 } else {
                     $parent = $frame->get_parent();


### PR DESCRIPTION
We're running PHP 7.1 with dompdf 0.8 and we've encountered this bug:
```
#0 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Block.php(594): A non-numeric value encountered
#1 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Block.php(906): Dompdf\FrameReflower\Block->vertical_align()
#2 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Block->reflow(Object(Dompdf\FrameDecorator\Block))
#3 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Block.php(850): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\Block))
#4 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Block->reflow(Object(Dompdf\FrameDecorator\TableCell))
#5 /xxx/vendor/dompdf/dompdf/src/FrameReflower/TableCell.php(95): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\TableCell))
#6 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\TableCell->reflow(NULL)
#7 /xxx/vendor/dompdf/dompdf/src/FrameReflower/TableRow.php(52): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow()
#8 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\TableRow->reflow(NULL)
#9 /xxx/vendor/dompdf/dompdf/src/FrameReflower/TableRowGroup.php(51): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow()
#10 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\TableRowGroup->reflow(NULL)
#11 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Table.php(488): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow()
#12 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Table->reflow(Object(Dompdf\FrameDecorator\Block))
#13 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Block.php(850): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\Block))
#14 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Block->reflow(Object(Dompdf\FrameDecorator\Block))
#15 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Block.php(850): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\Block))
#16 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Block->reflow(NULL)
#17 /xxx/vendor/dompdf/dompdf/src/FrameReflower/Page.php(141): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow()
#18 /xxx/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(893): Dompdf\FrameReflower\Page->reflow(NULL)
#19 /xxx/vendor/dompdf/dompdf/src/Dompdf.php(831): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow()
#20 /xxx/PdfCreator.php(34): Dompdf\Dompdf->render()
```

I've fixed both usages of the non-numeric value. It is "auto" in these cases and will be cast to zero.

Versions in use:
```
dompdf/dompdf      v0.8.0
phenx/php-font-lib  0.5
phenx/php-svg-lib  v0.2
PHP                 7.1.3
```

Related: https://github.com/dompdf/dompdf/issues/1272