### PR TITLE
Fix another PHP 7.1 non-numeric value error

### DIFF
--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -106,7 +106,7 @@ class Image extends AbstractFrameReflower
             $t = 0.0;
             for ($f = $this->_frame->get_parent(); $f; $f = $f->get_parent()) {
                 $f_style = $f->get_style();
-                $t = $f_style->length_in_pt($f_style->height);
+                $t = (float)$f_style->length_in_pt($f_style->height);
                 if ($t != 0) {
                     break;
                 }


### PR DESCRIPTION
It seems this one was already partially fixed, but it still threw the error for me.  
This change fixes it for me.

```
PHP message: A non-numeric value encountered in file: /home/some/path/libs/dompdf/src/FrameReflower/Image.php on line: 114
```