### PR TITLE
Fixing issue #1423: support concurrent loading of the same font in FontMetrics::registerFont()

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -180,7 +180,7 @@ class FontMetrics
         }
 
         $localFile = $fontDir . DIRECTORY_SEPARATOR . md5($remoteFile);
-        $localTempFile = $this->options->get('tempDir') . "/" . md5($remoteFile);
+        $localTempFilePrefix = $this->options->get('tempDir') . "/" . md5($remoteFile);
         $cacheEntry = $localFile;
         $localFile .= ".".strtolower(pathinfo($remoteFile,PATHINFO_EXTENSION));
 
@@ -194,7 +194,12 @@ class FontMetrics
             if (false === $remoteFileContent) {
                 return false;
             }
-            file_put_contents($localTempFile, $remoteFileContent);
+            $i = 0;
+            do {
+                $localTempFile = $localTempFilePrefix.'-'.($i++);
+            } while (($tmpFile = @fopen($localTempFile, 'x')) === false);
+            fwrite($tmpFile, $remoteFileContent);
+            fclose($tmpFile);
 
             $font = Font::load($localTempFile);
 

--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -170,7 +170,6 @@ class FontMetrics
      */
     public function registerFont($style, $remoteFile, $context = null)
     {
-        $fontDir = $this->getOptions()->getFontDir();
         $fontname = mb_strtolower($style["family"]);
         $families = $this->getFontFamilies();
 
@@ -179,56 +178,61 @@ class FontMetrics
             $entry = $families[$fontname];
         }
 
-        $localFile = $fontDir . DIRECTORY_SEPARATOR . md5($remoteFile);
-        $localTempFilePrefix = $this->options->get('tempDir') . "/" . md5($remoteFile);
+        $styleString = $this->getType("{$style['weight']} {$style['style']}");
+        if (isset($entry[$styleString])) {
+            return true;
+        }
+
+        $fontDir = $this->getOptions()->getFontDir();
+        $remoteHash = md5($remoteFile);
+        $localFile = $fontDir . DIRECTORY_SEPARATOR . $remoteHash;
+        $localTempFilePrefix = $this->options->get('tempDir') . '/' . $remoteHash;
+
         $cacheEntry = $localFile;
         $localFile .= ".".strtolower(pathinfo($remoteFile,PATHINFO_EXTENSION));
 
-        $styleString = $this->getType("{$style['weight']} {$style['style']}");
+        $entry[$styleString] = $cacheEntry;
 
-        if ( !isset($entry[$styleString]) ) {
-            $entry[$styleString] = $cacheEntry;
-
-            // Download the remote file
-            list($remoteFileContent, $http_response_header) = @Helpers::getFileContent($remoteFile, $context);
-            if (false === $remoteFileContent) {
-                return false;
-            }
-            $i = 0;
-            do {
-                $localTempFile = $localTempFilePrefix.'-'.($i++);
-            } while (($tmpFile = @fopen($localTempFile, 'x')) === false);
-            fwrite($tmpFile, $remoteFileContent);
-            fclose($tmpFile);
-
-            $font = Font::load($localTempFile);
-
-            if (!$font) {
-                unlink($localTempFile);
-                return false;
-            }
-
-            $font->parse();
-            $font->saveAdobeFontMetrics("$cacheEntry.ufm");
-            $font->close();
-
-            unlink($localTempFile);
-
-            if ( !file_exists("$cacheEntry.ufm") ) {
-                return false;
-            }
-
-            // Save the changes
-            file_put_contents($localFile, $remoteFileContent);
-
-            if ( !file_exists($localFile) ) {
-                unlink("$cacheEntry.ufm");
-                return false;
-            }
-
-            $this->setFontFamily($fontname, $entry);
-            $this->saveFontFamilies();
+        // Download the remote file
+        list($remoteFileContent, $http_response_header) = @Helpers::getFileContent($remoteFile, $context);
+        if (false === $remoteFileContent) {
+            return false;
         }
+
+        $i = 0;
+        do {
+            $localTempFile = $localTempFilePrefix.'-'.($i++);
+        } while (($tmpFile = @fopen($localTempFile, 'x')) === false);
+        fwrite($tmpFile, $remoteFileContent);
+        fclose($tmpFile);
+
+        $font = Font::load($localTempFile);
+
+        if (!$font) {
+            unlink($localTempFile);
+            return false;
+        }
+
+        $font->parse();
+        $font->saveAdobeFontMetrics("$cacheEntry.ufm");
+        $font->close();
+
+        unlink($localTempFile);
+
+        if ( !file_exists("$cacheEntry.ufm") ) {
+            return false;
+        }
+
+        // Save the changes
+        file_put_contents($localFile, $remoteFileContent);
+
+        if ( !file_exists($localFile) ) {
+            unlink("$cacheEntry.ufm");
+            return false;
+        }
+
+        $this->setFontFamily($fontname, $entry);
+        $this->saveFontFamilies();
 
         return true;
     }


### PR DESCRIPTION
Small patch that prevents collisions when several processes place a font to the same temporary file and then one of them deletes it.
Also some minor code optimization made to the only affected function.