### PR TITLE
Fix PHP 7.1 non-numeric value error

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -544,7 +544,7 @@ class Style
             }
 
             if ($l === "normal") {
-                $ret += $ref_size;
+                $ret += (float)$ref_size;
                 continue;
             }
 
@@ -576,7 +576,7 @@ class Style
             }
 
             if (($i = mb_strpos($l, "%")) !== false) {
-                $ret += (float)mb_substr($l, 0, $i) / 100 * $ref_size;
+                $ret += (float)mb_substr($l, 0, $i) / 100 * (float)$ref_size;
                 continue;
             }
 


### PR DESCRIPTION
In encountered ref_size being something like "1234.56pt", when using CSS transforms on an image.
I can provide a sample if you want.