### PR TITLE
Dompdf compatibility on HHVM (no Imagick::IMAGICK_EXTVER constant)

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4790,7 +4790,12 @@ EOT;
             // the first version containing it was 3.0.1RC1
             static $imagickClonable = null;
             if ($imagickClonable === null) {
-                $imagickClonable = version_compare(Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
+                if (defined('Imagick::IMAGICK_EXTVER')) {
+                    $imagickVersion = Imagick::IMAGICK_EXTVER;
+                } else {
+                    $imagickVersion = phpversion('imagick');
+                }
+                $imagickClonable = version_compare($imagickVersion, '3.0.1rc1') > 0;
             }
 
             $imagick = new \Imagick($file);


### PR DESCRIPTION
When running Dompdf on HHVM, it errors at the point of trying to use Imagick::IMAGICK_EXTVER in order to work out whether or not Imagick is cloneable. I realise in a previous version (see #1296) the change was made to go from phpversion('imagick') which provides the version of library and not the extension, but in the case where this constant is not available, can we fallback to the previous method anyway?