### PR TITLE
Encrypt some missing strings (issue 1502)

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -857,36 +857,8 @@ class Cpdf
                     // transform FPDF to TCPDF (http://tcpdf.sourceforge.net/)
 
                     $toUnicodeId = ++$this->numObj;
-                    $this->o_contents($toUnicodeId, 'new', 'raw');
+                    $this->o_toUnicode($toUnicodeId, 'new');
                     $this->objects[$id]['info']['toUnicode'] = $toUnicodeId;
-
-                    $stream = <<<EOT
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo
-<</Registry (Adobe)
-/Ordering (UCS)
-/Supplement 0
->> def
-/CMapName /Adobe-Identity-UCS def
-/CMapType 2 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-1 beginbfrange
-<0000> <FFFF> <0000>
-endbfrange
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-EOT;
-
-                    $res = "<</Length " . mb_strlen($stream, '8bit') . " >>\n";
-                    $res .= "stream\n" . $stream . "\nendstream";
-
-                    $this->objects[$toUnicodeId]['c'] = $res;
 
                     $cidFontId = ++$this->numObj;
                     $this->o_fontDescendentCID($cidFontId, 'new', $options);
@@ -974,6 +946,59 @@ EOT;
                     $res .= ">>\n";
                     $res .= "endobj";
                 }
+
+                return $res;
+        }
+
+        return null;
+    }
+
+    protected function o_toUnicode($id, $action, $options = '')
+    {
+        switch ($action) {
+            case 'new':
+                $this->objects[$id] = array(
+                    't'    => 'toUnicode'
+                );
+                break;
+            case 'add':
+                break;
+            case 'out':
+                $ordering = '(UCS)';
+                $registry = '(Adobe)';
+
+                if ($this->encrypted) {
+                    $this->encryptInit($id);
+                    $ordering = $this->ARC4($ordering);
+                    $registry = $this->ARC4($registry);
+                }
+
+                $stream = <<<EOT
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<</Registry $registry
+/Ordering $ordering
+/Supplement 0
+>> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfrange
+<0000> <FFFF> <0000>
+endbfrange
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+EOT;
+
+                $res = "\n$id 0 obj\n";
+                $res .= "<</Length " . mb_strlen($stream, '8bit') . " >>\n";
+                $res .= "stream\n" . $stream . "\nendstream" . "\nendobj";;
 
                 return $res;
         }
@@ -1121,8 +1146,18 @@ EOT;
                 $cidSystemInfoId = ++$this->numObj;
                 $this->o_contents($cidSystemInfoId, 'new', 'raw');
                 $this->objects[$id]['info']['cidSystemInfo'] = $cidSystemInfoId;
-                $res = "<</Registry (Adobe)\n"; // A string identifying an issuer of character collections
-                $res .= "/Ordering (UCS)\n"; // A string that uniquely names a character collection issued by a specific registry
+
+                $ordering = '(UCS)';
+                $registry = '(Adobe)';
+
+                if ($this->encrypted) {
+                    $this->encryptInit($id);
+                    $ordering = $this->ARC4($ordering);
+                    $registry = $this->ARC4($registry);
+                }
+
+                $res = '<</Registry ' . $registry . "\n"; // A string identifying an issuer of character collections
+                $res .= '/Ordering ' . $ordering . "\n"; // A string that uniquely names a character collection issued by a specific registry
                 $res .= "/Supplement 0\n"; // The supplement number of the character collection.
                 $res .= ">>";
                 $this->objects[$cidSystemInfoId]['c'] = $res;
@@ -4464,6 +4499,7 @@ EOT;
         // close the object, as long as there was one open in the first place, which will be indicated by
         // an objectId on the stack.
         if ($this->nStack > 0) {
+            dd($this->stack[$this->nStack]);
             $this->currentContents = $this->stack[$this->nStack]['c'];
             $this->currentPage = $this->stack[$this->nStack]['p'];
             $this->nStack--;

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -953,7 +953,14 @@ class Cpdf
         return null;
     }
 
-    protected function o_toUnicode($id, $action, $options = '')
+    /**
+     * A toUnicode section, needed for unicode fonts
+     *
+     * @param $id
+     * @param $action
+     * @return null|string
+     */
+    protected function o_toUnicode($id, $action)
     {
         switch ($action) {
             case 'new':
@@ -1215,7 +1222,14 @@ EOT;
         return null;
     }
 
-    protected function o_cidSystemInfo($id, $action, $options = '')
+    /**
+     * CID system info section, needed for unicode fonts
+     *
+     * @param $id
+     * @param $action
+     * @return null|string
+     */
+    protected function o_cidSystemInfo($id, $action)
     {
         switch ($action) {
             case 'new':

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1144,23 +1144,8 @@ EOT;
 
                 // we need a CID system info section
                 $cidSystemInfoId = ++$this->numObj;
-                $this->o_contents($cidSystemInfoId, 'new', 'raw');
+                $this->o_cidSystemInfo($cidSystemInfoId, 'new');
                 $this->objects[$id]['info']['cidSystemInfo'] = $cidSystemInfoId;
-
-                $ordering = '(UCS)';
-                $registry = '(Adobe)';
-
-                if ($this->encrypted) {
-                    $this->encryptInit($id);
-                    $ordering = $this->ARC4($ordering);
-                    $registry = $this->ARC4($registry);
-                }
-
-                $res = '<</Registry ' . $registry . "\n"; // A string identifying an issuer of character collections
-                $res .= '/Ordering ' . $ordering . "\n"; // A string that uniquely names a character collection issued by a specific registry
-                $res .= "/Supplement 0\n"; // The supplement number of the character collection.
-                $res .= ">>";
-                $this->objects[$cidSystemInfoId]['c'] = $res;
 
                 // and a CID to GID map
                 $cidToGidMapId = ++$this->numObj;
@@ -1223,6 +1208,42 @@ EOT;
                 $res .= "/CIDToGIDMap " . $o['info']['cidToGidMap'] . " 0 R\n";
                 $res .= ">>\n";
                 $res .= "endobj";
+
+                return $res;
+        }
+
+        return null;
+    }
+
+    protected function o_cidSystemInfo($id, $action, $options = '')
+    {
+        switch ($action) {
+            case 'new':
+                $this->objects[$id] = array(
+                    't' => 'cidSystemInfo'
+                );
+                break;
+            case 'add':
+                break;
+            case 'out':
+                $ordering = '(UCS)';
+                $registry = '(Adobe)';
+
+                if ($this->encrypted) {
+                    $this->encryptInit($id);
+                    $ordering = $this->ARC4($ordering);
+                    $registry = $this->ARC4($registry);
+                }
+
+
+                $res = "\n$id 0 obj\n";
+
+                $res .= '<</Registry ' . $registry . "\n"; // A string identifying an issuer of character collections
+                $res .= '/Ordering ' . $ordering . "\n"; // A string that uniquely names a character collection issued by a specific registry
+                $res .= "/Supplement 0\n"; // The supplement number of the character collection.
+                $res .= ">>";
+
+                $res .= "\nendobj";;
 
                 return $res;
         }

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4534,7 +4534,6 @@ EOT;
         // close the object, as long as there was one open in the first place, which will be indicated by
         // an objectId on the stack.
         if ($this->nStack > 0) {
-            dd($this->stack[$this->nStack]);
             $this->currentContents = $this->stack[$this->nStack]['c'];
             $this->currentPage = $this->stack[$this->nStack]['p'];
             $this->nStack--;


### PR DESCRIPTION
Was a bit complicated for me to understand this object hierarchy and all those content blocks.
I think I got it and added two new "dumb" object-functions that more or less just use the output action and get no options passed.
Might be a good start for later parameterization as well.

I use this as a test html for all those unicode font issues
These are mixed samples from other issues.

```
<!DOCTYPE html>
<html>
<head>
  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
<style>
  @font-face {
    src: url("/fonts/DejaVuSans.ttf");
    font-family: "DejaVu Sans";
  }
  body {
    font-family: DejaVu Sans, sans-serif;
  }
</style>
<title>Testpdf 123 אב בג/רמ</title>
</head>
<body>
  <p>
28/07/2017<br />
׳כל<br />
Registered,agency, smith smith<br />
האב האב בג/רמ רובע לוחל תועיסנ חוטיבל יאופר םותיחל עגונב וניתצלמה ןלהל<br />
הווהמ ל״נה יכ עובקל ונירה םיאופרה םיכמסמבו שקבמה תרהצהב ןויע רחאל<br />
םיאבה םימעטהמ הגרחה -ל הניה וניתצלמה ךכיפלו<br />
- הלבגה<br />
General Text -<br />
Sport - -<br />
,הכרבב<br />
Avi 2
</p>
```