### PR TITLE
Add decorator infrastructure for plugins

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -67,7 +67,7 @@ use Dompdf\Css\Stylesheet;
  *
  * @package dompdf
  */
-class Dompdf
+class Dompdf implements DompdfInterface
 {
     /**
      * Version string for dompdf
@@ -1482,6 +1482,14 @@ class Dompdf
     public function getFontMetrics()
     {
         return $this->fontMetrics;
+    }
+
+    /**
+     * @return FontMetrics
+     */
+    public function clone()
+    {
+        return new static($this->getOptions());
     }
 
     /**

--- a/src/DompdfDecorator.php
+++ b/src/DompdfDecorator.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @package dompdf
+ * @link    http://dompdf.github.com/
+ * @author  Benj Carson <benjcarson@digitaljunkies.ca>
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+namespace Dompdf;
+
+abstract class DompdfDecorator implements DompdfInterface
+{
+    /**
+     * @var DompdfInterface
+     */
+    protected $pdf;
+
+    public function __construct( DompdfInterface $pdf ) {
+        $this->pdf = $pdf;
+    }
+
+    public function getOptions() {
+        return $this->pdf->getOptions();
+    }
+
+    public function getDom() {
+        return $this->pdf->getDom();
+    }
+
+    public function render() {
+        $this->pdf->render();
+    }
+
+    public function output( $options = null ) {
+        return $this->pdf->output($options);
+    }
+
+    public function loadHtml( $html, $encoding = 'UTF-8' ) {
+        $this->pdf->loadHtml($html, $encoding);
+    }
+
+    public function clone() {
+        $this->pdf = $this->pdf->clone();
+        return $this;
+    }
+
+}

--- a/src/DompdfInterface.php
+++ b/src/DompdfInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package dompdf
+ * @link    http://dompdf.github.com/
+ * @author  Benj Carson <benjcarson@digitaljunkies.ca>
+ * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+namespace Dompdf;
+
+use DOMDocument;
+
+interface DompdfInterface
+{
+    /**
+     * @return Options
+     */
+    public function getOptions();
+
+    /**
+     * @return DOMDocument
+     */
+    public function getDom();
+
+    /**
+     * @return void
+     */
+    public function render();
+
+    /**
+     * @return string
+     */
+    public function output( $options = null );
+
+    /**
+     * @return void
+     */
+    public function loadHtml( $str, $encoding = 'UTF-8' );
+
+    /**
+     * @return DompdfInterface
+     */
+    public function clone();
+
+}


### PR DESCRIPTION
I want to make a few decorators for Dompdf tweaks I often use. To make a decorator, I need a simple interface that Dompdf already implements, so my decorators can implement the same interface. With decorators, you make make very useful Dompdf plugins that interact at any (public) moment in the Dompdf flow.

I've made 2 (no stealing!):

* Pageable - parses multiple `<body>` in input HTML to make multiple PDF and then merge them into one
* Processable - pre-processes input HTML to change simple expressive HTML intro page scripts etc

This PR doesn't actually include the plugins, but it allows for them by creating the infrastructure. All of this is doable without this PR, but not as pretty. I've only included the methods I need, not all public methods, because there are many. Maybe a few more would be more useful for other scenario's.

Demo decorators and current hacky infrastructure at [rudiedirkx/dompdf-demo](https://github.com/rudiedirkx/dompdf-demo/tree/master/src)

Very simple example to make all input documents UTF-8, because typing is such a hassle:

```
// Plugin
class Utf8Dompdf extends DompdfDecorator // implements DompdfInterface
{
  public function loadHtml($html)
  {
    $html = str_replace('<head>', <head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" />', $html);
    $this->pdf->loadHtml($html);
  }
}

// Implementation
$options = new Options();
$dompdf = new Utf8Dompdf(new Dompdf($options));
```

This simple example could of course be much easier by extending `Dompdf`. The benefit from decorators comes from combining them, and adding config and logic that doesn't belong in Dompdf itself..