### PR TITLE
Actually trigger the begin_frame event

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -58,6 +58,8 @@ class Renderer extends AbstractRenderer
     {
         global $_dompdf_debug;
 
+        $this->_check_callbacks("begin_frame", $frame);
+
         if ($_dompdf_debug) {
             echo $frame;
             flush();


### PR DESCRIPTION
See issue [1530](https://github.com/dompdf/dompdf/issues/1530).

I am not sure this is the right place to add the event, but it definitely allows me to modify the frame before it gets rendered (e.g. by replacing some text).