### PR TITLE
Fix filename with spaces for streamed output

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -17,7 +17,7 @@
  */
 use FontLib\Font;
 use FontLib\BinaryStream;
-
+use Dompdf\Helpers;
 
 class Cpdf
 {
@@ -3841,17 +3841,7 @@ EOT;
 
         $attachment = $options["Attachment"] ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming filename
-        $encoding = mb_detect_encoding($filename);
-        $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
-        $encodedfilename = rawurlencode($filename);
-
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
-        if ($fallbackfilename !== $filename) {
-            $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
-        }
-        header($contentDisposition);
+        header(Helpers::buildContentDispositionHeader($attachment, $filename));
 
         if (isset($options['Accept-Ranges']) && $options['Accept-Ranges'] == 1) {
             //FIXME: Is this the correct value ... spec says 1#range-unit

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3841,14 +3841,14 @@ EOT;
 
         $attachment = $options["Attachment"] ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming file
+        // detect the character encoding of the incoming filename
         $encoding = mb_detect_encoding($filename);
         $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $encodedfallbackfilename = rawurlencode($fallbackfilename);
+        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
         $encodedfilename = rawurlencode($filename);
 
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"" . $encodedfallbackfilename . "\"";
-        if ($encodedfallbackfilename !== $encodedfilename) {
+        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
+        if ($fallbackfilename !== $filename) {
             $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
         }
         header($contentDisposition);

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -1026,17 +1026,7 @@ class GD implements Canvas
         }
         $attachment = (isset($options["Attachment"]) && $options["Attachment"]) ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming filename
-        $encoding = mb_detect_encoding($filename);
-        $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
-        $encodedfilename = rawurlencode($filename);
-
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
-        if ($fallbackfilename !== $filename) {
-            $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
-        }
-        header($contentDisposition);
+        header(Helpers::buildContentDispositionHeader($attachment, $filename));
 
         switch ($type) {
 

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -1026,14 +1026,14 @@ class GD implements Canvas
         }
         $attachment = (isset($options["Attachment"]) && $options["Attachment"]) ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming file
+        // detect the character encoding of the incoming filename
         $encoding = mb_detect_encoding($filename);
         $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $encodedfallbackfilename = rawurlencode($fallbackfilename);
+        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
         $encodedfilename = rawurlencode($filename);
 
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"" . $encodedfallbackfilename . "\"";
-        if ($encodedfallbackfilename !== $encodedfilename) {
+        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
+        if ($fallbackfilename !== $filename) {
             $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
         }
         header($contentDisposition);

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1302,17 +1302,7 @@ class PDFLib implements Canvas
         $filename = str_replace(array("\n", "'"), "", basename($filename, ".pdf")) . ".pdf";
         $attachment = (isset($options["Attachment"]) && $options["Attachment"]) ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming filename
-        $encoding = mb_detect_encoding($filename);
-        $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
-        $encodedfilename = rawurlencode($filename);
-
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
-        if ($fallbackfilename !== $filename) {
-            $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
-        }
-        header($contentDisposition);
+        header(Helpers::buildContentDispositionHeader($attachment, $filename));
 
         //header("Content-length: " . $size);
 

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1302,14 +1302,14 @@ class PDFLib implements Canvas
         $filename = str_replace(array("\n", "'"), "", basename($filename, ".pdf")) . ".pdf";
         $attachment = (isset($options["Attachment"]) && $options["Attachment"]) ? "attachment" : "inline";
 
-        // detect the character encoding of the incoming file
+        // detect the character encoding of the incoming filename
         $encoding = mb_detect_encoding($filename);
         $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
-        $encodedfallbackfilename = rawurlencode($fallbackfilename);
+        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
         $encodedfilename = rawurlencode($filename);
 
-        $contentDisposition = "Content-Disposition: $attachment; filename=\"" . $encodedfallbackfilename . "\"";
-        if ($encodedfallbackfilename !== $encodedfilename) {
+        $contentDisposition = "Content-Disposition: $attachment; filename=\"$fallbackfilename\"";
+        if ($fallbackfilename !== $filename) {
             $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
         }
         header($contentDisposition);

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -405,18 +405,18 @@ interface Canvas
     function new_page();
 
     /**
-     * Streams the PDF directly to the browser
+     * Streams the PDF directly to the browser.
      *
-     * @param string $filename the name of the PDF file
-     * @param array $options associative array, 'Attachment' => 0 or 1, 'compress' => 1 or 0
+     * @param string $filename The filename to present to the browser.
+     * @param array $options Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
      */
-    function stream($filename, $options = null);
+    function stream($filename, $options = array());
 
     /**
-     * Returns the PDF as a string
+     * Returns the PDF as a string.
      *
-     * @param array $options associative array: 'compress' => 1 or 0
+     * @param array $options Associative array: 'compress' => 1 or 0 (default 1).
      * @return string
      */
-    function output($options = null);
+    function output($options = array());
 }

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -898,15 +898,10 @@ class Dompdf
     }
 
     /**
-     * Streams the PDF to the client
+     * Streams the PDF to the client.
      *
      * The file will open a download dialog by default. The options
      * parameter controls the output. Accepted options (array keys) are:
-     *
-     * 'Accept-Ranges' => 1 or 0 (=default): Send an 'Accept-Ranges:'
-     *   HTTP header, see https://tools.ietf.org/html/rfc2616#section-14.5
-     *   This header seems to have caused some problems, despite the fact
-     *   that it is supposed to solve them, so I am leaving it off by default.
      *
      * 'compress' = > 1 (=default) or 0:
      *   Apply content stream compression
@@ -918,7 +913,7 @@ class Dompdf
      * @param string $filename the name of the streamed file
      * @param array $options header options (see above)
      */
-    public function stream($filename = 'document.pdf', $options = null)
+    public function stream($filename = "document.pdf", $options = array())
     {
         $this->saveLocale();
 
@@ -931,21 +926,18 @@ class Dompdf
     }
 
     /**
-     * Returns the PDF as a string
+     * Returns the PDF as a string.
      *
-     * The file will open a download dialog by default.  The options
-     * parameter controls the output.  Accepted options are:
-     *
+     * The options parameter controls the output. Accepted options are:
      *
      * 'compress' = > 1 or 0 - apply content stream compression, this is
      *    on (1) by default
-     *
      *
      * @param array $options options (see above)
      *
      * @return string
      */
-    public function output($options = null)
+    public function output($options = array())
     {
         $this->saveLocale();
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -113,7 +113,6 @@ class Helpers
      */
     public static function buildContentDispositionHeader($dispositionType, $filename)
     {
-        // detect the character encoding of the incoming filename
         $encoding = mb_detect_encoding($filename);
         $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
         $fallbackfilename = str_replace("\"", "", $fallbackfilename);

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -100,6 +100,34 @@ class Helpers
     }
 
     /**
+     * Builds a HTTP Content-Disposition header string using `$dispositionType`
+     * and `$filename`.
+     *
+     * If the filename contains any characters not in the ISO-8859-1 character
+     * set, a fallback filename will be included for clients not supporting the
+     * `filename*` parameter.
+     *
+     * @param string $dispositionType
+     * @param string $filename
+     * @return string
+     */
+    public static function buildContentDispositionHeader($dispositionType, $filename)
+    {
+        // detect the character encoding of the incoming filename
+        $encoding = mb_detect_encoding($filename);
+        $fallbackfilename = mb_convert_encoding($filename, "ISO-8859-1", $encoding);
+        $fallbackfilename = str_replace("\"", "", $fallbackfilename);
+        $encodedfilename = rawurlencode($filename);
+
+        $contentDisposition = "Content-Disposition: $dispositionType; filename=\"$fallbackfilename\"";
+        if ($fallbackfilename !== $filename) {
+            $contentDisposition .= "; filename*=UTF-8''$encodedfilename";
+        }
+
+        return $contentDisposition;
+    }
+
+    /**
      * Converts decimal numbers to roman numerals
      *
      * @param int $num


### PR DESCRIPTION
Follow https://tools.ietf.org/html/rfc6266#appendix-D by not encoding the `filename` parameter. As a consequence, any double quotes need to be stripped, as the RFC also advices against including the backslash character.

Also, use the `iconv` method to get a transliterated fallback filename instead of ?s for characters not in ISO-8859-1.

Addresses #1532.