### PR TITLE
Enable autoloading HTML5_Tokenizer

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -465,7 +465,7 @@ class Dompdf
         // https://developer.mozilla.org/en/mozilla's_quirks_mode
         $quirksmode = false;
 
-        if ($this->options->isHtml5ParserEnabled() && class_exists("HTML5_Tokenizer", false)) {
+        if ($this->options->isHtml5ParserEnabled() && class_exists("HTML5_Tokenizer")) {
             $tokenizer = new HTML5_Tokenizer($str);
             $tokenizer->parse();
             $doc = $tokenizer->save();


### PR DESCRIPTION
The following allows for autoloading of the HTML5_Tokenizer.

When this package is installed via composer, the composer autoloader leverages a lazy loading technique.
This lazy loading means the class_exists statement never passes.

Setting the autoload flag to **true** (via removing the flag and leveraging default) allows this check to pass and HTML5 HTML templates to be parsed without error.

Without setting the above the following must be done to parse HTML5 tempaltes without exception:

```
<?php

$tokenizer = new HTML5_Tokenizer(array());
$dompdf = new Dompdf();
$dompdf->loadHtmlFile('someHtml5File.html') 
```
