### PR TITLE
Add US Half Letter to paper sizes

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -89,6 +89,7 @@ class CPDF implements Canvas
         "sra3" => array(0, 0, 907.09, 1275.59),
         "sra4" => array(0, 0, 637.80, 907.09),
         "letter" => array(0, 0, 612.00, 792.00),
+        "half-letter" => array(0, 0, 396.00, 612.00),
         "legal" => array(0, 0, 612.00, 1008.00),
         "ledger" => array(0, 0, 1224.00, 792.00),
         "tabloid" => array(0, 0, 792.00, 1224.00),


### PR DESCRIPTION
One of our customers asked us to add option for paper size 8.5"x5.5" - which is US Half Letter (according to http://www.papersizes.org/us-paper-sizes.htm). Can we add this size to DomPdf? Is it enough to add it here in the CPDF Adapter?