### PR TITLE
Fix: Uncaught Dompdf\Exception: No block-level parent found. Not good

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -490,6 +490,16 @@ class Dompdf
             $doc->loadHTML($str);
             $doc->encoding = $encoding;
 
+            // Remove #text children nodes in nodes that shouldn't have
+            $tag_names = array("html", "table", "tbody", "thead", "tfoot", "tr");
+            foreach ($tag_names as $tag_name) {
+                $nodes = $doc->getElementsByTagName($tag_name);
+
+                foreach ($nodes as $node) {
+                    self::removeTextNodes($node);
+                }
+            }
+
             // If some text is before the doctype, we are in quirksmode
             if (preg_match("/^(.+)<!doctype/i", ltrim($str), $matches)) {
                 $quirksmode = true;


### PR DESCRIPTION
Addresses issue: Fatal error: Uncaught Dompdf\Exception: No block-level parent found. Not good #1560 

The default DOM processor does not remove #text child nodes in nodes that should not have them.  While the HTML 5 processor does.

This seems to address random issues between versions of `libxml2` and encoding types.  It also explains why some people have seen success `inlining` the HTML sent for rendering.

I might suggest adding `head` elements to the list that are not allowed to have meaningful `#text` child elements ?

