### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phenx/php-svg-lib": "0.3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "squizlabs/php_codesniffer": "2.*"
     },
     "extra": {

--- a/tests/Dompdf/Tests/AutoloaderTest.php
+++ b/tests/Dompdf/Tests/AutoloaderTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Dompdf\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Dompdf\Autoloader;
 
-class AutoloaderTest extends PHPUnit_Framework_TestCase
+class AutoloaderTest extends TestCase
 {
     public function testAutoload()
     {

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -3,12 +3,12 @@ namespace Dompdf\Tests;
 
 use Dompdf\Frame\FrameTree;
 use Dompdf\Options;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Dompdf\Dompdf;
 use Dompdf\Css\Stylesheet;
 use DOMDocument;
 
-class DompdfTest extends PHPUnit_Framework_TestCase
+class DompdfTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/Dompdf/Tests/HelpersTest.php
+++ b/tests/Dompdf/Tests/HelpersTest.php
@@ -2,9 +2,9 @@
 namespace Dompdf\Tests;
 
 use Dompdf\Helpers;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HelpersTest extends PHPUnit_Framework_TestCase
+class HelpersTest extends TestCase
 {
     public function testParseDataUriBase64Image()
     {

--- a/tests/Dompdf/Tests/OptionsTest.php
+++ b/tests/Dompdf/Tests/OptionsTest.php
@@ -2,9 +2,9 @@
 namespace Dompdf\Tests;
 
 use Dompdf\Options;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class OptionsTest extends PHPUnit_Framework_TestCase
+class OptionsTest extends TestCase
 {
     public function testConstructor()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.