### PR TITLE
Prevent page break between a block and its first child, if there is no gap

### DIFF
--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -235,6 +235,10 @@ class Page extends AbstractFrameDecorator
      *    break occurs here, the used values of the relevant
      *    'margin-top' and 'margin-bottom' properties are set to '0'.
      *    2. Between line boxes inside a block box.
+     *    3. Between the content edge of a block container box and the
+     *    outer edges of its child content (margin edges of block-level
+     *    children or line box edges for inline-level children) if there
+     *    is a (non-zero) gap between them.
      *
      * These breaks are subject to the following rules:
      *
@@ -330,10 +334,14 @@ class Page extends AbstractFrameDecorator
                 return false;
             }
 
-            // If the frame is the first block-level frame, use the value from
-            // $frame's parent instead.
+            // If the frame is the first block-level frame, only allow a page
+            // break if there is a (non-zero) gap between the frame and its
+            // parent
             if (!$prev && $parent) {
-                return $this->_page_break_allowed($parent);
+                Helpers::dompdf_debug("page-break", "First block level frame, checking gap");
+
+                return $frame->get_style()->length_in_pt($frame->get_style()->margin_top) != 0
+                    || $parent->get_style()->length_in_pt($parent->get_style()->padding_top) != 0;
             }
 
             Helpers::dompdf_debug("page-break", "block: break allowed");


### PR DESCRIPTION
Bring the page-break code a bit closer to the spec by implementing case 3 from https://www.w3.org/TR/2011/REC-CSS2-20110607/page.html#allowed-page-breaks for block-level elements. A gap should only exist if there is a positive top margin on the child, or a positive top padding on the parent (am I missing any other possibilities?).

Possibly a gap could also exist at the bottom (positive bottom margin reps. padding) and as far as I read the spec, a break should also be possible in that case. This would require more changes.

I am not sure if this is the best way to read the margins/paddings, but it seems to work.

See the attached test cases (page size 400×300pt) for a comparison between a scenario where a break should occur between parent and child (box-edge-split-2) and where a break should occur only before the parent (box-edge-split-1).
[box-edge-split.zip](https://github.com/dompdf/dompdf/files/1552244/box-edge-split.zip)