### PR TITLE
Remove ext-gd as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,3 @@ matrix:
   allow_failures:
     - php: hhvm
   fast_finish: true
-  include:
-    -
-      php: "5.3"
-      dist: precise

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Follow us on [![Twitter](http://twitter-badges.s3.amazonaws.com/twitter-a.png)](
  
 ## Requirements
 
- * PHP version 5.3.0 or higher
+ * PHP version 5.4.0 or higher
  * DOM extension
  * GD extension
  * MBString extension

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "classmap" : ["lib/"]
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "ext-gd": "*",
         "ext-dom": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "ext-gd": "*",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "phenx/php-font-lib": "0.5.*",


### PR DESCRIPTION
On my docker image for development I have only installed ImageMagick to keep the image size small.

With `ext-gd` as requirement in `composer.json` I cannot simply run `composer install` because `gd` is missing on my image.

We can simply remove this requirement because a runtime error is thrown anyways.