### PR TITLE
Fixed php warning when using a stylesheet without any page rules

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -173,7 +173,7 @@ class Stylesheet
         $this->_styles = array();
         $this->_loaded_files = array();
         list($this->_protocol, $this->_base_host, $this->_base_path) = Helpers::explode_url($_SERVER["SCRIPT_FILENAME"]);
-        $this->_page_styles = array("base" => null);
+        $this->_page_styles = array("base" => new Style($this));
     }
 
     /**


### PR DESCRIPTION
When using a css sheet with no `@page` blocks the base style key is left as null. 
In the rendering it will try to call properties (ie. size on line 725 of src/Dompdf.php) on this key assuming its a Style object and not null.
So I just set the base key in the Stylesheet->_page_styles so be an empty Style object.