### PR TITLE
Don't create temp font files before they are needed

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -186,7 +186,6 @@ class FontMetrics
         $fontDir = $this->getOptions()->getFontDir();
         $remoteHash = md5($remoteFile);
         $localFile = $fontDir . DIRECTORY_SEPARATOR . $remoteHash;
-        $localTempFile = tempnam($this->options->get("tempDir"), "dompdf-font-");
 
         $cacheEntry = $localFile;
         $localFile .= ".".strtolower(pathinfo(parse_url($remoteFile, PHP_URL_PATH),PATHINFO_EXTENSION));
@@ -198,6 +197,8 @@ class FontMetrics
         if (false === $remoteFileContent) {
             return false;
         }
+
+        $localTempFile = tempnam($this->options->get("tempDir"), "dompdf-font-");
         file_put_contents($localTempFile, $remoteFileContent);
 
         $font = Font::load($localTempFile);


### PR DESCRIPTION
In `\Dompdf\FontMetrics::registerFont()` a new `$localTempFile` is created before checking if`$remoteFileContent` is `false`.
This causes empty `dompdf-font-*` files to be left in the temp directory for cases where `$remoteFileContent` is in fact `false`.