### PR TITLE
Made error message more clear

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -368,7 +368,7 @@ class Dompdf
 
             $ext = strtolower(pathinfo($realfile, PATHINFO_EXTENSION));
             if (!in_array($ext, $this->allowedLocalFileExtensions)) {
-                throw new Exception("Permission denied on $file.");
+                throw new Exception("Permission denied on $file. This file extension is forbidden");
             }
 
             if (!$realfile) {


### PR DESCRIPTION
The previous version did not specify why permission was denied