### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - nightly
   - hhvm
 
 install: travis_retry composer install --no-interaction --prefer-source
@@ -18,4 +19,5 @@ script:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phenx/php-svg-lib": "0.3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8|^5.5|^6.5",
         "squizlabs/php_codesniffer": "2.*"
     },
     "extra": {

--- a/tests/Dompdf/Tests/AutoloaderTest.php
+++ b/tests/Dompdf/Tests/AutoloaderTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Dompdf\Tests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Dompdf\Autoloader;
 
-class AutoloaderTest extends PHPUnit_Framework_TestCase
+class AutoloaderTest extends TestCase
 {
     public function testAutoload()
     {

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -3,12 +3,12 @@ namespace Dompdf\Tests;
 
 use Dompdf\Frame\FrameTree;
 use Dompdf\Options;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Dompdf\Dompdf;
 use Dompdf\Css\Stylesheet;
 use DOMDocument;
 
-class DompdfTest extends PHPUnit_Framework_TestCase
+class DompdfTest extends TestCase
 {
     public function testConstructor()
     {

--- a/tests/Dompdf/Tests/HelpersTest.php
+++ b/tests/Dompdf/Tests/HelpersTest.php
@@ -2,9 +2,9 @@
 namespace Dompdf\Tests;
 
 use Dompdf\Helpers;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HelpersTest extends PHPUnit_Framework_TestCase
+class HelpersTest extends TestCase
 {
     public function testParseDataUriBase64Image()
     {

--- a/tests/Dompdf/Tests/OptionsTest.php
+++ b/tests/Dompdf/Tests/OptionsTest.php
@@ -2,9 +2,9 @@
 namespace Dompdf\Tests;
 
 use Dompdf\Options;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class OptionsTest extends PHPUnit_Framework_TestCase
+class OptionsTest extends TestCase
 {
     public function testConstructor()
     {


### PR DESCRIPTION
# Changed log

- Set the different PHPUnit version for the different PHP version tests.
- Use the class-based PHPUnit name space.
- Add the PHP ```nightly``` test and set that in the ```allow_failures``` when executing Travis build.