### PR TITLE
Support of PDFLib version 9 added

### DIFF
--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -55,6 +55,31 @@ class PDFLib implements Canvas
      */
     static private $MAJOR_VERSION = null;
 
+
+    /**
+     * Transforms the list of native fonts into PDFLib compatible names (casesensitive)
+     *
+     * @var array
+     */
+    static public $nativeFontsTpPDFLib = array(
+        "courier"               => "Courier",
+        "courier-bold"          => "Courier-Bold",
+        "courier-oblique"       => "Courier-Oblique",
+        "courier-boldoblique"   => "Courier-BoldOblique",
+        "helvetica"             => "Helvetica",
+        "helvetica-bold"        => "Helvetica-Bold",
+        "helvetica-oblique"     => "Helvetica-Oblique",
+        "helvetica-boldoblique" => "Helvetica-BoldOblique",
+        "times"                 => "Times-Roman",
+        "times-roman"           => "Times-Roman",
+        "times-bold"            => "Times-Bold",
+        "times-italic"          => "Times-Italic",
+        "times-bolditalic"      => "Times-BoldItalic",
+        "symbol"                => "Symbol",
+        "zapfdinbats"           => "Zapfdingbats",
+        "zapfdingbats"          => "Zapfdingbats",
+    );
+
     /**
      * @var \Dompdf\Dompdf
      */
@@ -202,6 +227,8 @@ class PDFLib implements Canvas
         $this->setPDFLibParameter("textformat", "utf8");
         if ($this->getPDFLibMajorVersion() >= 7) {
             $this->setPDFLibParameter("errorpolicy", "return");
+            //            $this->_pdf->set_option('logging={filename=' . \APP_PATH . '/logs/pdflib.log classes={api=1 warning=2}}');
+            //            $this->_pdf->set_option('errorpolicy=exception');
         } else {
             $this->setPDFLibParameter("fontwarning", "false");
         }
@@ -708,6 +735,12 @@ class PDFLib implements Canvas
      */
     protected function _load_font($font, $encoding = null, $options = "")
     {
+        // Fix for PDFLibs case-sensitive font names
+        $baseFont = basename($font);
+        if (isset(self::$nativeFontsTpPDFLib[$baseFont])) {
+            $font = self::$nativeFontsTpPDFLib[$baseFont];
+        }
+
         // Set up font paths
         $fontOutline = $this->getPDFLibParameter("FontOutline", 1);
         if ($fontOutline === "" || $fontOutline <= 0) {

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -49,7 +49,14 @@ class PDFLib implements Canvas
     static $IN_MEMORY = true;
 
     /**
-     * @var Dompdf
+     * Saves the major version of PDFLib for compatibility requests
+     *
+     * @var null|int
+     */
+    static private $MAJOR_VERSION = null;
+
+    /**
+     * @var \Dompdf\Dompdf
      */
     private $_dompdf;
 
@@ -161,7 +168,7 @@ class PDFLib implements Canvas
     /**
      * Class constructor
      *
-     * @param mixed $paper The size of paper to use either a string (see {@link Dompdf\Adapter\CPDF::$PAPER_SIZES}) or
+     * @param mixed  $paper       The size of paper to use either a string (see {@link Dompdf\Adapter\CPDF::$PAPER_SIZES}) or
      *                            an array(xmin,ymin,xmax,ymax)
      * @param string $orientation The orientation of the document (either 'landscape' or 'portrait')
      * @param Dompdf $dompdf
@@ -170,7 +177,7 @@ class PDFLib implements Canvas
     {
         if (is_array($paper)) {
             $size = $paper;
-        } else if (isset(self::$PAPER_SIZES[mb_strtolower($paper)])) {
+        } elseif (isset(self::$PAPER_SIZES[mb_strtolower($paper)])) {
             $size = self::$PAPER_SIZES[mb_strtolower($paper)];
         } else {
             $size = self::$PAPER_SIZES["letter"];
@@ -189,14 +196,23 @@ class PDFLib implements Canvas
 
         $license = $dompdf->getOptions()->getPdflibLicense();
         if (strlen($license) > 0) {
-            $this->_pdf->set_parameter("license", $license);
+            $this->setPDFLibParameter("license", $license);
         }
 
-        $this->_pdf->set_parameter("textformat", "utf8");
-        $this->_pdf->set_parameter("fontwarning", "false");
+        $this->setPDFLibParameter("textformat", "utf8");
+        if ($this->getPDFLibMajorVersion() >= 7) {
+            $this->setPDFLibParameter("errorpolicy", "return");
+        } else {
+            $this->setPDFLibParameter("fontwarning", "false");
+        }
 
-        // TODO: fetch PDFLib version information for the producer field
-        $this->_pdf->set_info("Producer Addendum", sprintf("%s + PDFLib", $dompdf->version));
+        $searchPath = $this->_dompdf->getOptions()->getFontDir();
+        if (empty($searchPath) === false) {
+            $this->_pdf->set_option('searchpath={' . $searchPath . '}');
+        }
+
+        // fetch PDFLib version information for the producer field
+        $this->_pdf->set_info("Producer Addendum", sprintf("%s + PDFLib %s", $dompdf->version, $this->getPDFLibMajorVersion()));
 
         // Silence pedantic warnings about missing TZ settings
         $tz = @date_default_timezone_get();
@@ -291,6 +307,7 @@ class PDFLib implements Canvas
         $ret = $this->_pdf->begin_template($this->_width, $this->_height);
         $this->_pdf->save();
         $this->_objs[$ret] = array("start_page" => $this->_page_number);
+
         return $ret;
     }
 
@@ -332,7 +349,7 @@ class PDFLib implements Canvas
      * - 'nextodd' add to all odd numbered pages from the next one
      * - 'nexteven' add to all even numbered pages from the next one
      *
-     * @param int $object the object handle returned by open_object()
+     * @param int    $object the object handle returned by open_object()
      * @param string $where
      */
     public function add_object($object, $where = 'all')
@@ -453,10 +470,10 @@ class PDFLib implements Canvas
     /**
      * Sets the line style
      *
-     * @param float $width
+     * @param float  $width
      * @param        $cap
      * @param string $join
-     * @param array $dash
+     * @param array  $dash
      *
      * @return void
      */
@@ -466,23 +483,43 @@ class PDFLib implements Canvas
             $dash[] = $dash[0];
         }
 
-        if (count($dash) > 1) {
-            $this->_pdf->setdashpattern("dasharray={" . implode(" ", $dash) . "}");
+        if ($this->getPDFLibMajorVersion() >= 9) {
+            if (count($dash) > 1) {
+                $this->_pdf->set_graphics_option("dasharray={" . implode(" ", $dash) . "}");
+            } else {
+                $this->_pdf->set_graphics_option("dasharray=none");
+            }
         } else {
-            $this->_pdf->setdash(0, 0);
+            if (count($dash) > 1) {
+                $this->_pdf->setdashpattern("dasharray={" . implode(" ", $dash) . "}");
+            } else {
+                $this->_pdf->setdash(0, 0);
+            }
         }
 
         switch ($join) {
             case "miter":
-                $this->_pdf->setlinejoin(0);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linejoin=0');
+                } else {
+                    $this->_pdf->setlinejoin(0);
+                }
                 break;
 
             case "round":
-                $this->_pdf->setlinejoin(1);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linejoin=1');
+                } else {
+                    $this->_pdf->setlinejoin(1);
+                }
                 break;
 
             case "bevel":
-                $this->_pdf->setlinejoin(2);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linejoin=2');
+                } else {
+                    $this->_pdf->setlinejoin(2);
+                }
                 break;
 
             default:
@@ -491,15 +528,27 @@ class PDFLib implements Canvas
 
         switch ($cap) {
             case "butt":
-                $this->_pdf->setlinecap(0);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linecap=0');
+                } else {
+                    $this->_pdf->setlinecap(0);
+                }
                 break;
 
             case "round":
-                $this->_pdf->setlinecap(1);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linecap=1');
+                } else {
+                    $this->_pdf->setlinecap(1);
+                }
                 break;
 
             case "square":
-                $this->_pdf->setlinecap(2);
+                if ($this->getPDFLibMajorVersion() >= 9) {
+                    $this->_pdf->set_graphics_option('linecap=2');
+                } else {
+                    $this->_pdf->setlinecap(2);
+                }
                 break;
 
             default:
@@ -583,7 +632,7 @@ class PDFLib implements Canvas
      */
     public function _set_fill_opacity($opacity, $mode = "Normal")
     {
-        if ($mode === "Normal") {
+        if ($mode === "Normal" && is_null($opacity) === false) {
             $this->_set_gstate("opacityfill=$opacity");
         }
     }
@@ -596,7 +645,7 @@ class PDFLib implements Canvas
      */
     public function _set_stroke_opacity($opacity, $mode = "Normal")
     {
-        if ($mode === "Normal") {
+        if ($mode === "Normal" && is_null($opacity) === false) {
             $this->_set_gstate("opacitystroke=$opacity");
         }
     }
@@ -609,7 +658,7 @@ class PDFLib implements Canvas
      */
     public function set_opacity($opacity, $mode = "Normal")
     {
-        if ($mode === "Normal") {
+        if ($mode === "Normal" && is_null($opacity) === false) {
             $this->_set_gstate("opacityfill=$opacity opacitystroke=$opacity");
             $this->_current_opacity = $opacity;
         }
@@ -627,6 +676,7 @@ class PDFLib implements Canvas
             $gstate = $this->_pdf->create_gstate($gstate_options);
             $this->_gstates[$gstate] = $gstate_options;
         }
+
         return $this->_pdf->set_gstate($gstate);
     }
 
@@ -644,7 +694,7 @@ class PDFLib implements Canvas
          * fitwindow Fit the complete page to the window.
          * fixed
          */
-        //$this->_pdf->set_parameter("openaction", $view);
+        //$this->setPDFLibParameter("openaction", $view);
     }
 
     /**
@@ -659,7 +709,8 @@ class PDFLib implements Canvas
     protected function _load_font($font, $encoding = null, $options = "")
     {
         // Set up font paths
-        if ($this->_pdf->get_parameter("FontOutline", 1) === "") {
+        $fontOutline = $this->getPDFLibParameter("FontOutline", 1);
+        if ($fontOutline === "" || $fontOutline <= 0) {
             $families = $this->_dompdf->getFontMetrics()->getFontFamilies();
             foreach ($families as $files) {
                 foreach ($files as $file) {
@@ -670,16 +721,16 @@ class PDFLib implements Canvas
                     if (file_exists("$file.ttf")) {
                         $outline = "$file.ttf";
 
-                    } else if (file_exists("$file.TTF")) {
+                    } elseif (file_exists("$file.TTF")) {
                         $outline = "$file.TTF";
 
-                    } else if (file_exists("$file.pfb")) {
+                    } elseif (file_exists("$file.pfb")) {
                         $outline = "$file.pfb";
                         if (file_exists("$file.afm")) {
                             $afm = "$file.afm";
                         }
 
-                    } else if (file_exists("$file.PFB")) {
+                    } elseif (file_exists("$file.PFB")) {
                         $outline = "$file.PFB";
                         if (file_exists("$file.AFM")) {
                             $afm = "$file.AFM";
@@ -688,10 +739,18 @@ class PDFLib implements Canvas
                         continue;
                     }
 
-                    $this->_pdf->set_parameter("FontOutline", "\{$face\}=\{$outline\}");
+                    if ($this->getPDFLibMajorVersion() >= 9) {
+                        $this->setPDFLibParameter("FontOutline", '{' . "$face=$outline" . '}');
+                    } else {
+                        $this->setPDFLibParameter("FontOutline", "\{$face\}=\{$outline\}");
+                    }
 
                     if (!is_null($afm)) {
-                        $this->_pdf->set_parameter("FontAFM", "\{$face\}=\{$afm\}");
+                        if ($this->getPDFLibMajorVersion() >= 9) {
+                            $this->setPDFLibParameter("FontAFM", '{' . "$face=$afm" . '}');
+                        } else {
+                            $this->setPDFLibParameter("FontAFM", "\{$face\}=\{$afm\}");
+                        }
                     }
                 }
             }
@@ -723,6 +782,7 @@ class PDFLib implements Canvas
             return $this->_fonts[$key];
         } else {
             $this->_fonts[$key] = $this->_pdf->load_font($font, $encoding, $options);
+
             return $this->_fonts[$key];
         }
     }
@@ -759,7 +819,7 @@ class PDFLib implements Canvas
         $this->_pdf->lineto($x2, $y2);
         $this->_pdf->stroke();
 
-        $this->_set_line_transparency("Normal", $this->_current_opacity);
+        $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -783,7 +843,7 @@ class PDFLib implements Canvas
         $this->_pdf->arc($x1, $y1, $r1, $astart, $aend);
         $this->_pdf->stroke();
 
-        $this->_set_line_transparency("Normal", $this->_current_opacity);
+        $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -793,7 +853,7 @@ class PDFLib implements Canvas
      * @param float $h
      * @param array $color
      * @param float $width
-     * @param null $style
+     * @param null  $style
      */
     public function rectangle($x1, $y1, $w, $h, $color, $width, $style = null)
     {
@@ -805,7 +865,7 @@ class PDFLib implements Canvas
         $this->_pdf->rect($x1, $y1, $w, $h);
         $this->_pdf->stroke();
 
-        $this->_set_line_transparency("Normal", $this->_current_opacity);
+        $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -824,7 +884,7 @@ class PDFLib implements Canvas
         $this->_pdf->rect(floatval($x1), floatval($y1), floatval($w), floatval($h));
         $this->_pdf->fill();
 
-        $this->_set_fill_transparency("Normal", $this->_current_opacity);
+        $this->_set_fill_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -855,7 +915,6 @@ class PDFLib implements Canvas
      */
     public function clipping_roundrectangle($x1, $y1, $w, $h, $rTL, $rTR, $rBR, $rBL)
     {
-        // @todo
         $this->clipping_rectangle($x1, $y1, $w, $h);
     }
 
@@ -946,9 +1005,9 @@ class PDFLib implements Canvas
     /**
      * @param array $points
      * @param array $color
-     * @param null $width
-     * @param null $style
-     * @param bool $fill
+     * @param null  $width
+     * @param null  $style
+     * @param bool  $fill
      */
     public function polygon($points, $color, $width = null, $style = null, $fill = false)
     {
@@ -975,8 +1034,8 @@ class PDFLib implements Canvas
             $this->_pdf->closepath_stroke();
         }
 
-        $this->_set_fill_transparency("Normal", $this->_current_opacity);
-        $this->_set_line_transparency("Normal", $this->_current_opacity);
+        $this->_set_fill_opacity($this->_current_opacity, "Normal");
+        $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -984,9 +1043,9 @@ class PDFLib implements Canvas
      * @param float $y
      * @param float $r
      * @param array $color
-     * @param null $width
-     * @param null $style
-     * @param bool $fill
+     * @param null  $width
+     * @param null  $style
+     * @param bool  $fill
      */
     public function circle($x, $y, $r, $color, $width = null, $style = null, $fill = false)
     {
@@ -1007,16 +1066,16 @@ class PDFLib implements Canvas
             $this->_pdf->stroke();
         }
 
-        $this->_set_fill_transparency("Normal", $this->_current_opacity);
-        $this->_set_line_transparency("Normal", $this->_current_opacity);
+        $this->_set_fill_opacity($this->_current_opacity, "Normal");
+        $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
     /**
      * @param string $img_url
-     * @param float $x
-     * @param float $y
-     * @param int $w
-     * @param int $h
+     * @param float  $x
+     * @param float  $y
+     * @param int    $w
+     * @param int    $h
      * @param string $resolution
      */
     public function image($img_url, $x, $y, $w, $h, $resolution = "normal")
@@ -1037,15 +1096,15 @@ class PDFLib implements Canvas
     }
 
     /**
-     * @param float $x
-     * @param float $y
+     * @param float  $x
+     * @param float  $y
      * @param string $text
      * @param string $font
-     * @param float $size
-     * @param array $color
-     * @param int $word_spacing
-     * @param int $char_spacing
-     * @param int $angle
+     * @param float  $size
+     * @param array  $color
+     * @param int    $word_spacing
+     * @param int    $char_spacing
+     * @param int    $angle
      */
     public function text($x, $y, $text, $font, $size, $color = array(0, 0, 0), $word_spacing = 0, $char_spacing = 0, $angle = 0)
     {
@@ -1062,7 +1121,7 @@ class PDFLib implements Canvas
 
         $this->_pdf->fit_textline($text, $x, $y, "rotate=$angle wordspacing=$word_spacing charspacing=$char_spacing ");
 
-        $this->_set_fill_transparency("Normal", $this->_current_opacity);
+        $this->_set_fill_opacity($this->_current_opacity, "Normal");
     }
 
     /**
@@ -1088,11 +1147,11 @@ class PDFLib implements Canvas
     /**
      * Add a link to the pdf
      *
-     * @param string $url The url to link to
-     * @param float $x The x position of the link
-     * @param float $y The y position of the link
-     * @param float $width The width of the link
-     * @param float $height The height of the link
+     * @param string $url    The url to link to
+     * @param float  $x      The x position of the link
+     * @param float  $y      The y position of the link
+     * @param float  $width  The width of the link
+     * @param float  $height The height of the link
      */
     public function add_link($url, $x, $y, $width, $height)
     {
@@ -1121,9 +1180,9 @@ class PDFLib implements Canvas
     /**
      * @param string $text
      * @param string $font
-     * @param float $size
-     * @param int $word_spacing
-     * @param int $letter_spacing
+     * @param float  $size
+     * @param int    $word_spacing
+     * @param int    $letter_spacing
      * @return mixed
      */
     public function get_text_width($text, $font, $size, $word_spacing = 0, $letter_spacing = 0)
@@ -1144,7 +1203,7 @@ class PDFLib implements Canvas
 
     /**
      * @param string $font
-     * @param float $size
+     * @param float  $size
      * @return float
      */
     public function get_font_height($font, $size)
@@ -1158,17 +1217,19 @@ class PDFLib implements Canvas
 
         // $desc is usually < 0,
         $ratio = $this->_dompdf->getOptions()->getFontHeightRatio();
+
         return $size * ($asc - $desc) * $ratio;
     }
 
     /**
      * @param string $font
-     * @param float $size
+     * @param float  $size
      * @return float
      */
     public function get_font_baseline($font, $size)
     {
         $ratio = $this->_dompdf->getOptions()->getFontHeightRatio();
+
         return $this->get_font_height($font, $size) / $ratio * 1.1;
     }
 
@@ -1180,15 +1241,15 @@ class PDFLib implements Canvas
      *
      * See {@link Style::munge_color()} for the format of the color array.
      *
-     * @param float $x
-     * @param float $y
-     * @param string $text the text to write
-     * @param string $font the font file to use
-     * @param float $size the font size, in points
-     * @param array $color
-     * @param float $word_space word spacing adjustment
-     * @param float $char_space char spacing adjustment
-     * @param float $angle angle to write the text at, measured CW starting from the x-axis
+     * @param float  $x
+     * @param float  $y
+     * @param string $text       the text to write
+     * @param string $font       the font file to use
+     * @param float  $size       the font size, in points
+     * @param array  $color
+     * @param float  $word_space word spacing adjustment
+     * @param float  $char_space char spacing adjustment
+     * @param float  $angle      angle to write the text at, measured CW starting from the x-axis
      */
     public function page_text($x, $y, $text, $font, $size, $color = array(0, 0, 0), $word_space = 0.0, $char_space = 0.0, $angle = 0.0)
     {
@@ -1272,7 +1333,7 @@ class PDFLib implements Canvas
      * Streams the PDF to the client.
      *
      * @param string $filename The filename to present to the client.
-     * @param array $options Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
+     * @param array  $options  Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
      * @throws Exception
      */
     public function stream($filename = "document.pdf", $options = array())
@@ -1281,15 +1342,19 @@ class PDFLib implements Canvas
             die("Unable to stream pdf: headers already sent");
         }
 
-        if (!isset($options["compress"])) $options["compress"] = true;
-        if (!isset($options["Attachment"])) $options["Attachment"] = true;
+        if (!isset($options["compress"])) {
+            $options["compress"] = true;
+        }
+        if (!isset($options["Attachment"])) {
+            $options["Attachment"] = true;
+        }
 
         $this->_add_page_text();
 
         if ($options["compress"]) {
-            $this->_pdf->set_value("compress", 6);
+            $this->setPDFLibValue("compress", 6);
         } else {
-            $this->_pdf->set_value("compress", 0);
+            $this->setPDFLibValue("compress", 0);
         }
 
         $this->_close();
@@ -1348,14 +1413,16 @@ class PDFLib implements Canvas
      */
     public function output($options = array())
     {
-        if (!isset($options["compress"])) $options["compress"] = true;
+        if (!isset($options["compress"])) {
+            $options["compress"] = true;
+        }
 
         $this->_add_page_text();
 
         if ($options["compress"]) {
-            $this->_pdf->set_value("compress", 6);
+            $this->setPDFLibValue("compress", 6);
         } else {
-            $this->_pdf->set_value("compress", 0);
+            $this->setPDFLibValue("compress", 0);
         }
 
         $this->_close();
@@ -1377,6 +1444,78 @@ class PDFLib implements Canvas
         }
 
         return $data;
+    }
+
+    /**
+     * @param string $keyword
+     * @param string $optlist
+     * @return mixed
+     */
+    protected function getPDFLibParameter($keyword, $optlist = "")
+    {
+        if ($this->getPDFLibMajorVersion() >= 9) {
+            return $this->_pdf->get_option($keyword, "");
+        }
+
+        return $this->_pdf->get_parameter($keyword, $optlist);
+    }
+
+    /**
+     * @param string $keyword
+     * @param string $value
+     * @return mixed
+     */
+    protected function setPDFLibParameter($keyword, $value)
+    {
+        if ($this->getPDFLibMajorVersion() >= 9) {
+            return $this->_pdf->set_option($keyword . "=" . $value);
+        }
+
+        return $this->_pdf->set_parameter($keyword, $value);
+    }
+
+    /**
+     * @param string $keyword
+     * @param string $optlist
+     * @return mixed
+     */
+    protected function getPDFLibValue($keyword, $optlist = "")
+    {
+        if ($this->getPDFLibMajorVersion() >= 9) {
+            return $this->getPDFLibParameter($keyword, $optlist);
+        }
+
+        return $this->_pdf->get_value($keyword);
+    }
+
+    /**
+     * @param string $keyword
+     * @param string $value
+     * @return mixed
+     */
+    protected function setPDFLibValue($keyword, $value)
+    {
+        if ($this->getPDFLibMajorVersion() >= 9) {
+            return $this->setPDFLibParameter($keyword, $value);
+        }
+
+        return $this->_pdf->set_value($keyword, $value);
+    }
+
+    /**
+     * @return int
+     */
+    private function getPDFLibMajorVersion()
+    {
+        if (is_null(self::$MAJOR_VERSION)) {
+            if (method_exists($this->_pdf, "get_option")) {
+                self::$MAJOR_VERSION = abs(intval($this->_pdf->get_option("major", "")));
+            } else {
+                self::$MAJOR_VERSION = abs(intval($this->_pdf->get_value("major", "")));
+            }
+        }
+
+        return self::$MAJOR_VERSION;
     }
 }
 


### PR DESCRIPTION
- Support of PDFLib version 9 added. resolve #1181
- Added searchpath for fonts
- Completed TODO for PDFLib version info

Test I run:

```php
$dompdfOptions = new Options();
$dompdfOptions->setPdfBackend('PDFLib');
$dompdfOptions->setIsPhpEnabled(false);
$dompdfOptions->setIsJavascriptEnabled(false);
$dompdfOptions->setIsRemoteEnabled(false);
$dompdfOptions->setChroot(__DIR__);
$dompdfOptions->setIsFontSubsettingEnabled(true);
$dompdfOptions->setFontDir(__DIR__ . '/fonts/');
$dompdfOptions->setDefaultPaperOrientation('Landscape');

$dompdf = new Dompdf($dompdfOptions);
$canvas = $dompdf->getCanvas();

// dashed line
$canvas->line(1.0, 2.0, 40.0, 50.0, [0, 0, 1], 4.0, [6, 4]);
// normal line
$canvas->line(40.0, 50.0, 40.0, 1.0, [1, 0, 1], 2.0);
// Some thing
$canvas->polygon([60.0, 70.0, 140.0, 150.0, 90, 100, 110, 80], [0, 0, 1], 4.0, [6, 4]);
// Another thing but filled
$canvas->polygon([140.0, 50.0, 180.0, 100.0, 160, 190, 160, 140], [0, 0.5, 1], 4.0, [6, 4], true);
// dash / fill
$canvas->circle(200.0, 200.0, 40.0, [0.2, 0.5, 1], 4.0, [6, 4], true);
// dash / no fill
$canvas->circle(200.0, 200.0, 40.0, [0, 0, 0], 2.0, [6, 4]);
// no dash / no fill
$canvas->circle(200.0, 200.0, 42.0, [0, .7, 0], 2.0);
// no dash / fill
$canvas->circle(200.0, 200.0, 10.0, [1, 1, 1], 2.0, [], true);
// external font for searchpath
$canvas->text(20, 100, 'Test', 'Raleway-Regular', 18);
// internal font
$canvas->text(100, 200, 'Test', 'Helvetica', 12);
// link in center of circle
$canvas->add_link('https://github.com/dompdf/dompdf', 180, 180, 40, 40);

$dompdf->loadHtml('Text');
$dompdf->render();
$dompdf->stream(['compress' => true]);
```