### PR TITLE
Fix Default Width Use

### DIFF
--- a/src/Renderer/Text.php
+++ b/src/Renderer/Text.php
@@ -72,7 +72,7 @@ class Text extends AbstractRenderer
         $size = $frame_font_size = $style->font_size;
         $word_spacing = $frame->get_text_spacing() + (float)$style->length_in_pt($style->word_spacing);
         $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
-        $width = $style->width;
+        $width = $style->width !== 'auto' ? $style->width : 0;
 
         /*$text = str_replace(
           array("{PAGE_NUM}"),

--- a/tests/Dompdf/Tests/DompdfTest.php
+++ b/tests/Dompdf/Tests/DompdfTest.php
@@ -68,6 +68,24 @@ class DompdfTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $dom->textContent);
     }
 
+    public function testRenderWithDefaultWidth()
+    {
+        $dompdf = new Dompdf();
+        $dompdf->loadHtml('<html>
+<body>
+  <ul></ul>
+  <div style="line-height:inherit">
+    <div style="line-height:inherit">
+      <div>
+        <div style="text-decoration:none solid rgb(0,0,0);">1</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>');
+        $dompdf->render();
+    }
+
     public function testSpaceAtStartOfSecondInlineTag()
     {
         $text_frame_contents = array();


### PR DESCRIPTION
Adds a fix for use of the width property when it has it's default value of `auto`. This currently emits a PHP warning in PHP 7.2 (and possibly other versions).

Some notes..
- I've tried to copy the same check I've seen in other parts of the codebase
- I couldn't see a better place to put a test, let me know if I missed something (are CONTRIBUTING docs out of date?)
- The HTML is the most minimal test case I could reducedfrom some real-world data.