### PR TITLE
Fixed issues with list bullets on page break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 
 install: travis_retry composer install --no-interaction --prefer-source

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://github.com/dompdf/dompdf/wiki/Requirements
 PDF documents internally support the following fonts: Helvetica, Times-Roman,
 Courier, Zapf-Dingbats, & Symbol. These fonts only support Windows ANSI
 encoding. In order for a PDF to display characters that are not available in
-Windows ANSI you must supply an external font. Dompdf will embed any referenced
+Windows ANSI, you must supply an external font. Dompdf will embed any referenced
 font in the PDF so long as it has been pre-loaded or is accessible to dompdf and
 reference in CSS @font-face rules. See the
 [font overview](https://github.com/dompdf/dompdf/wiki/About-Fonts-and-Character-Encoding)

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -562,6 +562,25 @@ class CPDF implements Canvas
     }
 
     /**
+     * Draw line at the specified coordinates on every page.
+     *
+     * See {@link Style::munge_color()} for the format of the colour array.
+     *
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param array $color
+     * @param float $width
+     * @param array $style optional
+     */
+    public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = array())
+    {
+        $_t = 'line';
+        $this->_page_text[] = compact('_t', 'x1', 'y1', 'x2', 'y2', 'color', 'width', 'style');
+    }
+
+    /**
      * @param float $x
      * @param float $y
      * @param float $r1
@@ -1091,6 +1110,10 @@ class CPDF implements Canvas
                             $eval = new PhpEvaluator($this);
                         }
                         $eval->evaluate($code, array('PAGE_NUM' => $page_number, 'PAGE_COUNT' => $this->_page_count));
+                        break;
+
+                    case 'line':
+                        $this->line( $x1, $y1, $x2, $y2, $color, $width, $style );
                         break;
                 }
             }

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -978,6 +978,11 @@ class GD implements Canvas
         // N/A
     }
 
+    public function page_line()
+    {
+        // N/A
+    }
+
     /**
      * Streams the image to the client.
      *

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -874,6 +874,25 @@ class PDFLib implements Canvas
     }
 
     /**
+     * Draw line at the specified coordinates on every page.
+     *
+     * See {@link Style::munge_color()} for the format of the colour array.
+     *
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param array $color
+     * @param float $width
+     * @param array $style optional
+     */
+    public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = array())
+    {
+        $_t = 'line';
+        $this->_page_text[] = compact('_t', 'x1', 'y1', 'x2', 'y2', 'color', 'width', 'style');
+    }
+
+    /**
      * @param float $x1
      * @param float $y1
      * @param float $r1
@@ -1371,6 +1390,11 @@ class PDFLib implements Canvas
                         }
                         $eval->evaluate($code, array('PAGE_NUM' => $p, 'PAGE_COUNT' => $this->_page_count));
                         break;
+
+                    case 'line':
+                        $this->line( $x1, $y1, $x2, $y2, $color, $width, $style );
+                        break;
+
                 }
             }
 

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -368,7 +368,7 @@ class Dompdf
 
             $ext = strtolower(pathinfo($realfile, PATHINFO_EXTENSION));
             if (!in_array($ext, $this->allowedLocalFileExtensions)) {
-                throw new Exception("Permission denied on $file.");
+                throw new Exception("Permission denied on $file. This file extension is forbidden");
             }
 
             if (!$realfile) {
@@ -945,7 +945,7 @@ class Dompdf
      *
      * @param array $options options (see above)
      *
-     * @return string
+     * @return string|null
      */
     public function output($options = array())
     {

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -756,10 +756,7 @@ abstract class AbstractFrameDecorator extends Frame
 
         // If the frame is completely empty after the splitting, it must be removed from the tree.
         // This is necessary to avoid drawing list bullets although the list item has been emptied during splitting.
-        if (((null === $this->get_first_child() && null === $this->get_last_child())
-            || ($this->get_first_child() === $this->get_last_child() && 'bullet' === $this->get_first_child()->get_node()->nodeName))
-            && '' === trim($this->get_node()->textContent)
-        ) {
+        if ($this->is_empty()) {
             $this->get_parent()->remove_child($this);
 
             // Mark the copy as non-splitted, because we want the bullet to be drawn if the origin was removed.
@@ -929,5 +926,30 @@ abstract class AbstractFrameDecorator extends Frame
     final function calculate_auto_width()
     {
         return $this->_reflower->calculate_auto_width();
+    }
+
+    /**
+     * Check if the frame is empty.
+     *
+     * A frame that only consists of list bullets or empty text nodes is regarded as empty.
+     */
+    public function is_empty()
+    {
+        if (null === $this->get_first_child() && null === $this->get_last_child()) {
+            return true;
+        }
+
+        $child = $this->get_first_child();
+
+        do {
+            $nodeName = $child->get_node()->nodeName;
+            $empty = 'bullet' === $nodeName || ('#text' === $nodeName && '' === trim($this->get_node()->textContent));
+
+            if (!$empty) {
+                return false;
+            }
+        } while ($child = $child->get_next_sibling());
+
+        return true;
     }
 }

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -697,6 +697,13 @@ abstract class AbstractFrameDecorator extends Frame
         $split->_splitted = true;
         $split->_already_pushed = true;
 
+        // Workaround for list item bullets, because the counter of the bullet gets lost,
+        // because node is not cloned deeply.
+        if ('list-item' === $split->get_style()->display && $node instanceof DOMElement) {
+            $counter = $node->childNodes->item(0)->getAttribute('dompdf-counter');
+            $split->get_node()->childNodes->item(0)->setAttribute('dompdf-counter', $counter);
+        }
+
         // The body's properties must be kept
         if ($node->nodeName !== "body") {
             // Style reset on the first and second parts
@@ -745,6 +752,18 @@ abstract class AbstractFrameDecorator extends Frame
         if ($style->counter_reset && ($reset = $style->counter_reset) !== "none") {
             $vars = preg_split('/\s+/', trim($reset), 2);
             $split->_counters['__' . $vars[0]] = $this->lookup_counter_frame($vars[0])->_counters[$vars[0]];
+        }
+
+        // If the frame is completely empty after the splitting, it must be removed from the tree.
+        // This is necessary to avoid drawing list bullets although the list item has been emptied during splitting.
+        if (((null === $this->get_first_child() && null === $this->get_last_child())
+            || ($this->get_first_child() === $this->get_last_child() && 'bullet' === $this->get_first_child()->get_node()->nodeName))
+            && '' === trim($this->get_node()->textContent)
+        ) {
+            $this->get_parent()->remove_child($this);
+
+            // Mark the copy as non-splitted, because we want the bullet to be drawn if the origin was removed.
+            $split->_splitted = false;
         }
     }
 

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -498,7 +498,7 @@ class Page extends AbstractFrameDecorator
         // parents of $frame must fit on the page as well:
         $p = $frame->get_parent();
         while ($p) {
-            $max_y += $p->get_style()->computed_bottom_spacing();
+            $max_y += (float) $p->get_style()->computed_bottom_spacing();
             $p = $p->get_parent();
         }
 


### PR DESCRIPTION
There are several issues mentioning problems with the rendering of bullets when the page is breaked within a list (see #403, #872 and #1045).

When dompdf detects that the content of a list item overflows the page, it clones the item to the next page and moves all following content to it. If the first child of the item leads to the overflow, the bullet is still drawn at the end of the first page and no bullet is drawn for the cloned item on the next page.

In fact there are three issues that I address in this PR:
* The origin list item gets removed if it has no content anymore after it was splitted.
* The cloned element is marked as non-splitted if the origin item was removed, so that the bullet of the cloned item on the next page gets rendered.
* Copy the value of the attribute `dompdf-counter` of the origin bullet element. Because the attribute of the new bullet element that is created for the cloned list item was not filled correctly, so that the bullet was not rendered if an ordered list (`<ol>`) is used.

The fix is a bit hacky, but I couldn't find a cleaner way of fixing the issue. The problem is that the bullet is handled by a custom DOM element which makes some checks more complicated.

Maybe this could be changed sometime.

I hope this PR could be merged, soon. If so please create a new release, so that it gets installed when composer is used.