### PR TITLE
Fixed calculation of minimum width of text if 'word-wrap' is 'break-word'

### DIFF
--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -467,9 +467,18 @@ class Text extends AbstractFrameReflower
             $style->border_right_width,
             $style->margin_right), $line_width);
         $min += $delta;
+        $min_word = $min;
         $max += $delta;
 
-        return $this->_min_max_cache = array($min, $max, "min" => $min, "max" => $max);
+        if ($style->word_wrap === 'break-word') {
+            // If it is allowed to break words, the min width is the widest character.
+            // But for performance reasons, we only check the first character.
+            $char = mb_substr($str, 0, 1);
+            $min_char = $this->getFontMetrics()->getTextWidth($char, $font, $size, $word_spacing, $char_spacing);
+            $min = $delta + $min_char;
+        }
+
+        return $this->_min_max_cache = array($min, $max, $min_word, "min" => $min, "max" => $max, 'min_word' => $min_word);
     }
 
     /**


### PR DESCRIPTION
dompdf already supports the CSS option `word-wrap` with `break-word`. It correctly breaks words if they are too long to fit in their parent's block. But the calculation of the minimum width of the text has not respected this setting. The problem is that their parent elements are rendered wider as they have to - even if a width is specified.

HTML code to test this behaviour:

```html
<table>
    <tr>
        <td style="width: 283pt; border:1pt solid black;">
            <ul style="border:1pt solid green;">
                <li style="word-wrap:break-word;">
                    nfioweifjiewpfijiepwfjiewpfjiepwjfipwejfipwejfipwejfiwejfiewjfiwejfewfjiowefjipowefjiowefjiowefjiowefjioewfjiwefjiowefjiwoefjiowefjiowefjiowefjiowefjiowefjiowefjiowefjioewfwifiowejfowiejf
                </li>
            </ul>
        </td>
        <td>Hello World</td>
    </tr>
</table>
```

Before the patch the above HTML produced this output:
![dompdf_before](https://user-images.githubusercontent.com/1118790/45808212-9342ae00-bcc5-11e8-8895-3c62f041fd23.png)

After:
![dompdf_after](https://user-images.githubusercontent.com/1118790/45808226-9c337f80-bcc5-11e8-9e5d-4fc1eb568dce.png)
