### PR TITLE
Fix rendering of remote images on PHP 7.1+

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4801,12 +4801,12 @@ EOT;
         imagesavealpha($img, false);
 
         // create temp alpha file
-        $tempfile_alpha = tempnam($this->tmp, "cpdf_img_");
+        $tempfile_alpha = @tempnam($this->tmp, "cpdf_img_");
         @unlink($tempfile_alpha);
         $tempfile_alpha = "$tempfile_alpha.png";
 
         // create temp plain file
-        $tempfile_plain = tempnam($this->tmp, "cpdf_img_");
+        $tempfile_plain = @tempnam($this->tmp, "cpdf_img_");
         @unlink($tempfile_plain);
         $tempfile_plain = "$tempfile_plain.png";
 

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -627,7 +627,7 @@ class CPDF implements Canvas
             imageinterlace($im, false);
 
             $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
-            $tmp_name = tempnam($tmp_dir, "{$type}dompdf_img_");
+            $tmp_name = @tempnam($tmp_dir, "{$type}dompdf_img_");
             @unlink($tmp_name);
             $filename = "$tmp_name.png";
             $this->_image_cache[] = $filename;

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -208,7 +208,7 @@ class PDFLib implements Canvas
             $this->_pdf->begin_document("", "");
         } else {
             $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
-            $tmp_name = tempnam($tmp_dir, "libdompdf_pdf_");
+            $tmp_name = @tempnam($tmp_dir, "libdompdf_pdf_");
             @unlink($tmp_name);
             $this->_file = "$tmp_name.pdf";
             $this->_pdf->begin_document($this->_file, "");

--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -186,7 +186,7 @@ class FontMetrics
         $fontDir = $this->getOptions()->getFontDir();
         $remoteHash = md5($remoteFile);
         $localFile = $fontDir . DIRECTORY_SEPARATOR . $remoteHash;
-        $localTempFile = tempnam($this->options->get("tempDir"), "dompdf-font-");
+        $localTempFile = @tempnam($this->options->get("tempDir"), "dompdf-font-");
 
         $cacheEntry = $localFile;
         $localFile .= ".".strtolower(pathinfo(parse_url($remoteFile, PHP_URL_PATH),PATHINFO_EXTENSION));

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -88,7 +88,7 @@ class Cache
                     } // From remote
                     else {
                         $tmp_dir = $dompdf->getOptions()->getTempDir();
-                        $resolved_url = tempnam($tmp_dir, "ca_dompdf_img_");
+                        $resolved_url = @tempnam($tmp_dir, "ca_dompdf_img_");
                         $image = "";
 
                         if ($data_uri) {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -401,7 +401,7 @@ abstract class AbstractRenderer
             $this->_canvas->get_cpdf()->addImagePng($filedummy, $x, $this->_canvas->get_height() - $y - $height, $width, $height, $bg);
         } else {
             $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
-            $tmp_name = tempnam($tmp_dir, "bg_dompdf_img_");
+            $tmp_name = @tempnam($tmp_dir, "bg_dompdf_img_");
             @unlink($tmp_name);
             $tmp_file = "$tmp_name.png";
 


### PR DESCRIPTION
Fixes #1781 

Following [a change with the `tempnam()` function in PHP 7.1](https://bugs.php.net/bug.php?id=69489), rendering a PDF with remote images (when they are enabled) is broken. This PR prevents PHP from throwing the notice that breaks it.