### PR TITLE
added namespace for class Cpdf in lib folder

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -15,6 +15,9 @@
  * @license Public Domain http://creativecommons.org/licenses/publicdomain/
  * @package Cpdf
  */
+
+namespace Dompdf;
+
 use FontLib\Font;
 use FontLib\BinaryStream;
 

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4859,7 +4859,7 @@ EOT;
             // the first version containing it was 3.0.1RC1
             static $imagickClonable = null;
             if ($imagickClonable === null) {
-                $imagickClonable = version_compare(Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
+                $imagickClonable = version_compare(\Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
             }
 
             $imagick = new \Imagick($file);

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -195,7 +195,7 @@ class CPDF implements Canvas
 
         $this->_dompdf = $dompdf;
 
-        $this->_pdf = new \Cpdf(
+        $this->_pdf = new \Dompdf\Cpdf(
             $size,
             true,
             $dompdf->getOptions()->getFontCache(),

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -25,7 +25,7 @@ class Autoloader
      */
     public static function autoload($class)
     {
-        if ($class === 'Cpdf') {
+        if ($class === 'Dompdf\Cpdf') {
             require_once __DIR__ . "/../lib/Cpdf.php";
             return;
         }


### PR DESCRIPTION
s. issue #1668: https://github.com/dompdf/dompdf/issues/1668

Added a namespace to lib/Cpdf.php to avoid namespace conflicts, e.g. with rospdf/php-pdf 

Not sure, if it's "allowed" to add "\Dompdf" namespace to Cpdf - is it an old/modified version of rospdf/php-pdf?


