### PR TITLE
Added a missing break in the @page stylesheet parsing

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1359,7 +1359,7 @@ class Stylesheet
                             /** @noinspection PhpMissingBreakStatementInspection */
                             case ":first":
                                 $key = $page_selector;
-
+                                break;
                             default:
                                 break 2;
                         }


### PR DESCRIPTION
Since updating to version 0.8.3 my HTML wasn't rendering properly. I traced it back to pull-request #1825 Only the default should break 2, the other cases should only break once. 