### PR TITLE
Resolved error Extension 'cpdf' is removed since PHP 5.1

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -194,7 +194,7 @@ class CPDF implements Canvas
         }
 
         $this->_dompdf = $dompdf;
-        $cpdf_class_var = \Cpdf;
+        $cpdf_class_var = "\Cpdf";
         $this->_pdf = new $cpdf_class_var(
             $size,
             true,

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -194,8 +194,8 @@ class CPDF implements Canvas
         }
 
         $this->_dompdf = $dompdf;
-
-        $this->_pdf = new \Cpdf(
+        $cpdf_class_var = \Cpdf;
+        $this->_pdf = new $cpdf_class_var(
             $size,
             true,
             $dompdf->getOptions()->getFontCache(),


### PR DESCRIPTION
After running phpcs following command for library getting error. 

**Command**: phpcs --standard=PHPCompatibility --extensions=php,module,inc,install,test,profile,theme,css --runtime-set testVersion 7.2 

**File**:sites\default\libraries\dompdf\src\Adapter\CPDF.php
----------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------
 198 | ERROR | Extension 'cpdf' is removed since PHP 5.1; Use pecl/pdflib instead
----------------------------------------------------------------------------------------------