### PR TITLE
Do not allow failures on PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ matrix:
   allow_failures:
     - php: nightly
     - php: hhvm
-    - php: 7.3
   fast_finish: true


### PR DESCRIPTION
We should not be allowing failures on PHP 7.3 by now since it has been out for quite a bit of time. 

Thanks.