### PR TITLE
do not allow failure on php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ matrix:
   allow_failures:
     - php: nightly
     - php: hhvm
-    - php: 7.3
+
   fast_finish: true


### PR DESCRIPTION
Do not allow any CI failure for PHP 7.3

Replaces https://github.com/dompdf/dompdf/pull/1948