### PR TITLE
add missing global namespace declaration to Imagick::IMAGICK_EXTVER

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4857,7 +4857,7 @@ EOT;
             // the first version containing it was 3.0.1RC1
             static $imagickClonable = null;
             if ($imagickClonable === null) {
-                $imagickClonable = version_compare(Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
+                $imagickClonable = version_compare(\Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
             }
 
             $imagick = new \Imagick($file);


### PR DESCRIPTION
Fixes https://github.com/dompdf/dompdf/issues/2000 by explicitly calling Imagick from the global namespace.