### PR TITLE
Drop PHP older than PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -15,7 +11,7 @@ install: travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit
-#  - vendor/bin/phpcs --standard=phpcs.xml src
+  - vendor/bin/phpcs --standard=phpcs.xml src
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -19,21 +19,23 @@
         }
     ],
     "autoload": {
-        "psr-4" : {
-            "Dompdf\\" : "src/"
+        "psr-4": {
+            "Dompdf\\": "src/"
         },
-        "classmap" : ["lib/"]
+        "classmap": [
+            "lib/"
+        ]
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
-        "phenx/php-font-lib": "0.5.*",
+        "phenx/php-font-lib": "^0.5.1",
         "phenx/php-svg-lib": "^0.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.5|^6.5",
-        "squizlabs/php_codesniffer": "2.*"
+        "phpunit/phpunit": "^7.5",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "suggest": {
         "ext-gd": "Needed to process images",

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -309,12 +309,12 @@ class Cpdf
     /**
      * @var string The target internal encoding
      */
-    static protected $targetEncoding = 'Windows-1252';
+    protected static $targetEncoding = 'Windows-1252';
 
     /**
      * @var array The list of the core fonts
      */
-    static protected $coreFonts = array(
+    protected static $coreFonts = array(
         'courier',
         'courier-bold',
         'courier-oblique',

--- a/lib/html5lib/Parser.php
+++ b/lib/html5lib/Parser.php
@@ -16,7 +16,7 @@ class HTML5_Parser
      * @param $builder | Custom builder implementation
      * @return DOMDocument|DOMNodeList Parsed HTML as DOMDocument
      */
-    static public function parse($text, $builder = null) {
+    public static function parse($text, $builder = null) {
         $tokenizer = new HTML5_Tokenizer($text, $builder);
         $tokenizer->parse();
         return $tokenizer->save();
@@ -29,7 +29,7 @@ class HTML5_Parser
      * @param $builder | Custom builder implementation
      * @return DOMDocument|DOMNodeList Parsed HTML as DOMDocument
      */
-    static public function parseFragment($text, $context = null, $builder = null) {
+    public static function parseFragment($text, $context = null, $builder = null) {
         $tokenizer = new HTML5_Tokenizer($text, $builder);
         $tokenizer->parseFragment($context);
         return $tokenizer->save();

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -39,7 +39,7 @@ class PDFLib implements Canvas
      *
      * @var array;
      */
-    static public $PAPER_SIZES = array(); // Set to Dompdf\Adapter\CPDF::$PAPER_SIZES below.
+    public static $PAPER_SIZES = array(); // Set to Dompdf\Adapter\CPDF::$PAPER_SIZES below.
 
     /**
      * Whether to create PDFs in memory or on disk
@@ -53,7 +53,7 @@ class PDFLib implements Canvas
      *
      * @var null|int
      */
-    static private $MAJOR_VERSION = null;
+    private static $MAJOR_VERSION = null;
 
 
     /**
@@ -61,7 +61,7 @@ class PDFLib implements Canvas
      *
      * @var array
      */
-    static public $nativeFontsTpPDFLib = array(
+    public static $nativeFontsTpPDFLib = array(
         "courier"               => "Courier",
         "courier-bold"          => "Courier-Bold",
         "courier-oblique"       => "Courier-Oblique",

--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -452,7 +452,6 @@ class Cellmap
         $row["height"] = $height;
         $next_row =& $this->get_row($i + 1);
         $next_row["y"] = $row["y"] + $height;
-
     }
 
     /**

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -22,7 +22,7 @@ class AttributeTranslator
     // Munged data originally from
     // http://www.w3.org/TR/REC-html40/index/attributes.html
     // http://www.cs.tut.fi/~jkorpela/html2css.html
-    static private $__ATTRIBUTE_LOOKUP = array(
+    private static $__ATTRIBUTE_LOOKUP = array(
         //'caption' => array ( 'align' => '', ),
         'img' => array(
             'align' => array(
@@ -183,8 +183,8 @@ class AttributeTranslator
         ),
     );
 
-    static protected $_last_basefont_size = 3;
-    static protected $_font_size_lookup = array(
+    protected static $_last_basefont_size = 3;
+    protected static $_font_size_lookup = array(
         // For basefont support
         -3 => "4pt",
         -2 => "5pt",
@@ -249,7 +249,6 @@ class AttributeTranslator
             $style = ltrim($style);
             $node->setAttribute(self::$_style_attr, $style);
         }
-
     }
 
     /**
@@ -259,7 +258,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _resolve_target(\DOMNode $node, $target, $value)
+    protected static function _resolve_target(\DOMNode $node, $target, $value)
     {
         if ($target[0] === "!") {
             // Function call
@@ -288,7 +287,7 @@ class AttributeTranslator
      *
      * @return \DOMNodeList|\DOMElement[]
      */
-    static protected function get_cell_list(\DOMNode $node)
+    protected static function get_cell_list(\DOMNode $node)
     {
         $xpath = new \DOMXpath($node->ownerDocument);
 
@@ -317,7 +316,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _get_valid_color($value)
+    protected static function _get_valid_color($value)
     {
         if (preg_match('/^#?([0-9A-F]{6})$/i', $value, $matches)) {
             $value = "#$matches[1]";
@@ -332,7 +331,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_color(\DOMElement $node, $value)
+    protected static function _set_color(\DOMElement $node, $value)
     {
         $value = self::_get_valid_color($value);
 
@@ -345,7 +344,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_background_color(\DOMElement $node, $value)
+    protected static function _set_background_color(\DOMElement $node, $value)
     {
         $value = self::_get_valid_color($value);
 
@@ -358,7 +357,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_table_cellpadding(\DOMElement $node, $value)
+    protected static function _set_table_cellpadding(\DOMElement $node, $value)
     {
         $cell_list = self::get_cell_list($node);
 
@@ -375,7 +374,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_table_border(\DOMElement $node, $value)
+    protected static function _set_table_border(\DOMElement $node, $value)
     {
         $cell_list = self::get_cell_list($node);
 
@@ -398,7 +397,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_table_cellspacing(\DOMElement $node, $value)
+    protected static function _set_table_cellspacing(\DOMElement $node, $value)
     {
         $style = rtrim($node->getAttribute(self::$_style_attr), ";");
 
@@ -417,7 +416,7 @@ class AttributeTranslator
      *
      * @return null|string
      */
-    static protected function _set_table_rules(\DOMElement $node, $value)
+    protected static function _set_table_rules(\DOMElement $node, $value)
     {
         $new_style = "; border-collapse: collapse;";
 
@@ -467,7 +466,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_hr_size(\DOMElement $node, $value)
+    protected static function _set_hr_size(\DOMElement $node, $value)
     {
         $style = rtrim($node->getAttribute(self::$_style_attr), ";");
         $style .= "; border-width: " . max(0, $value - 2) . "; ";
@@ -481,7 +480,7 @@ class AttributeTranslator
      *
      * @return null|string
      */
-    static protected function _set_hr_align(\DOMElement $node, $value)
+    protected static function _set_hr_align(\DOMElement $node, $value)
     {
         $style = rtrim($node->getAttribute(self::$_style_attr), ";");
         $width = $node->getAttribute("width");
@@ -518,7 +517,7 @@ class AttributeTranslator
      *
      * @return null|string
      */
-    static protected function _set_input_width(\DOMElement $node, $value)
+    protected static function _set_input_width(\DOMElement $node, $value)
     {
         if (empty($value)) { return null; }
 
@@ -535,7 +534,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_table_row_align(\DOMElement $node, $value)
+    protected static function _set_table_row_align(\DOMElement $node, $value)
     {
         $cell_list = self::get_cell_list($node);
 
@@ -552,7 +551,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_table_row_valign(\DOMElement $node, $value)
+    protected static function _set_table_row_valign(\DOMElement $node, $value)
     {
         $cell_list = self::get_cell_list($node);
 
@@ -569,7 +568,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_table_row_bgcolor(\DOMElement $node, $value)
+    protected static function _set_table_row_bgcolor(\DOMElement $node, $value)
     {
         $cell_list = self::get_cell_list($node);
         $value = self::_get_valid_color($value);
@@ -587,7 +586,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_body_link(\DOMElement $node, $value)
+    protected static function _set_body_link(\DOMElement $node, $value)
     {
         $a_list = $node->getElementsByTagName("a");
         $value = self::_get_valid_color($value);
@@ -605,7 +604,7 @@ class AttributeTranslator
      *
      * @return null
      */
-    static protected function _set_basefont_size(\DOMElement $node, $value)
+    protected static function _set_basefont_size(\DOMElement $node, $value)
     {
         // FIXME: ? we don't actually set the font size of anything here, just
         // the base size for later modification by <font> tags.
@@ -620,7 +619,7 @@ class AttributeTranslator
      *
      * @return string
      */
-    static protected function _set_font_size(\DOMElement $node, $value)
+    protected static function _set_font_size(\DOMElement $node, $value)
     {
         $style = $node->getAttribute(self::$_style_attr);
 

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -110,9 +110,9 @@ class Style
      *
      * @var array
      */
-    static protected $_props_shorthand = array("background", "border", 
-        "border_bottom", "border_color", "border_left", "border_radius", 
-        "border_right", "border_style", "border_top", "border_width", 
+    protected static $_props_shorthand = array("background", "border",
+        "border_bottom", "border_color", "border_left", "border_radius",
+        "border_right", "border_style", "border_top", "border_width",
         "flex", "font", "list_style", "margin", "padding");
 
     /**
@@ -122,7 +122,7 @@ class Style
      *
      * @var array
      */
-    static protected $_defaults = null;
+    protected static $_defaults = null;
 
     /**
      * List of inherited properties
@@ -131,14 +131,14 @@ class Style
      *
      * @var array
      */
-    static protected $_inherited = null;
+    protected static $_inherited = null;
 
     /**
      * Caches method_exists result
      *
      * @var array<bool>
      */
-    static protected $_methods_cache = array();
+    protected static $_methods_cache = array();
 
     /**
      * The stylesheet this style belongs to
@@ -172,11 +172,11 @@ class Style
      */
     protected $_props_computed = array();
 
-    static protected $_dependency_map = array(
+    protected static $_dependency_map = array(
         "font_size" => array(
             "border_top_width",
             "border_right_width",
-            "border_bottom_width", 
+            "border_bottom_width",
             "border_left_width",
             "line_height",
             "margin_top",
@@ -890,7 +890,7 @@ class Style
         if (!isset(self::$_defaults[$prop])) {
             throw new Exception("'$prop' is not a recognized CSS property.");
         }
-        
+
         if (isset($this->_prop_cache[$prop])) {
             return $this->_prop_cache[$prop];
         }
@@ -898,7 +898,7 @@ class Style
         $method = "get_$prop";
 
         $retval = null;
-        // Preview the value based on the default if the property's computed value has not 
+        // Preview the value based on the default if the property's computed value has not
         // yet been set or the current value is "inherit" (the computed value will be based
         // on the parent's value if inheritance has been applied).
         // Reset the specified property afterwards so that we don't block inheritance later.
@@ -934,7 +934,7 @@ class Style
             $this->_props[$prop] = $specified_value;
             $this->_props_computed[$prop] = $computed_value;
         }
-        
+
         return $retval;
     }
 
@@ -1474,7 +1474,7 @@ class Style
     {
         $color = $this->__get("border_" . $side . "_color");
 
-        return $this->__get("border_" . $side . "_width") . " " . 
+        return $this->__get("border_" . $side . "_width") . " " .
             $this->__get("border_" . $side . "_style") . " " . $color["hex"];
     }
 
@@ -1682,7 +1682,7 @@ class Style
     {
         $val = trim($this->_props_computed["counter_increment"]);
         $value = null;
-        
+
         if (in_array($val, array("none", "inherit"))) {
             $value = $val;
         } else {
@@ -2134,7 +2134,7 @@ class Style
             //FIXME: prefer just calling length_in_pt, when we provide a ref size to length_in_pt should em and ex use that instead of the current font size?
             $fs = (float)$this->length_in_pt($fs, $this->_parent_font_size);
         }
-        
+
         $this->_props_computed["font_size"] = $fs;
     }
 
@@ -2230,7 +2230,7 @@ class Style
                 $val = $match[2];
             }
         }
-        
+
         if (strlen($val) != 0) {
             $this->_set_style("font_family", $val, $important);
         }
@@ -2238,7 +2238,7 @@ class Style
 
     /**
      * Sets line height property
-     * 
+     *
      * @link http://www.w3.org/TR/CSS21/visudet.html#propdef-line-height
      * @param $val
      */
@@ -2786,7 +2786,7 @@ class Style
         $this->_props["size"] = $val;
         $this->_props_computed["size"] = null;
         $this->_prop_cache["size"] = null;
-        
+
         $length_re = "/(\d+\s*(?:pt|px|pc|em|ex|in|cm|mm|%))/";
 
         $val = mb_strtolower($val);

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -455,7 +455,6 @@ class Page extends AbstractFrameDecorator
                 }
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
As discussed and agreed in https://github.com/dompdf/dompdf/pull/1991#issuecomment-540320166, in anticipation for a 1.0.0 release.

Also fix phpcs errors and re-enable it on Travis