### PR TITLE
Update the website for dejavu-fonts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ reference in CSS @font-face rules. See the
 [font overview](https://github.com/dompdf/dompdf/wiki/About-Fonts-and-Character-Encoding)
 for more information on how to use fonts.
 
-The [DejaVu TrueType fonts](http://dejavu-fonts.org) have been pre-installed
+The [DejaVu TrueType fonts](https://dejavu-fonts.github.io/) have been pre-installed
 to give dompdf decent Unicode character coverage by default. To use the DejaVu
 fonts reference the font in your stylesheet, e.g. `body { font-family: DejaVu
 Sans; }` (for DejaVu Sans). The following DejaVu 2.34 fonts are available:


### PR DESCRIPTION
The previous domain now has nothing to do with dejaview-fonts. Have updated with the current domain, https://dejavu-fonts.github.io/.