### PR TITLE
Initialize font subset temp file prior to access

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -2838,7 +2838,8 @@ EOT;
 
                         // Write new font
                         $tmp_name = $this->tmp . "/" . basename($fbfile) . ".tmp." . uniqid();
-                        $font_obj->open($tmp_name, BinaryStream::modeWrite);
+                        touch($tmp_name);
+                        $font_obj->open($tmp_name, BinaryStream::modeReadWrite);
                         $font_obj->encode(array("OS/2"));
                         $font_obj->close();
 


### PR DESCRIPTION
Starting from PHP 7.4, `fread()` [raises a notice](https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.fread-fwrite) when trying to read from a write-only file resource instead of silently failing:
```
PHP Notice:  fread(): read of 8192 bytes failed with errno=9 Bad file descriptor in /var/www/html/vendor/phenx/php-font-lib/src/FontLib/BinaryStream.php on line 145
```

Creating a new font file using `DirectoryEntry::encode()` tries to read from file which does not exist and is open in write-only mode. This change should fix the issue.