### PR TITLE
Fix CPDF adapter

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -254,7 +254,7 @@ class CPDF implements Canvas
     /**
      * Returns the Cpdf instance
      *
-     * @return \Cpdf
+     * @return \Dompdf\Cpdf
      */
     public function get_cpdf()
     {

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -275,7 +275,7 @@ class Dompdf
 
         if (version_compare(PHP_VERSION, '7.0.0') >= 0)
         {
-            ini_set('pcre.jit', 0);
+            @ini_set('pcre.jit', 0);
         }
 
         if (isset($options) && $options instanceof Options) {


### PR DESCRIPTION
Fixes minor bug introduced in https://github.com/dompdf/dompdf/pull/1851.

PHPStan complains:
```
Library/Dompdf/DompdfHelpers.php:22
 ↳ Access to property $objects on an unknown class Cpdf.
```