### PR TITLE
fix css selector issue

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -450,9 +450,8 @@ class Stylesheet
      * @throws Exception
      * @return array
      */
-    private function _css_selector_to_xpath($selector, $first_pass = false)
+    private function _css_selector_to_xpath(string $selector, bool $first_pass = false): array
     {
-
         // Collapse white space and strip whitespace around delimiters
         //$search = array("/\\s+/", "/\\s+([.>#+:])\\s+/");
         //$replace = array(" ", "\\1");
@@ -892,7 +891,7 @@ class Stylesheet
             $query = rtrim($query, "/");
         }
 
-        return ["query" => $query, "pseudo_elements" => $pseudo_elements];
+        return ['query' => $query, 'pseudo_elements' => $pseudo_elements];
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue when a numeric (invalid) CSS selector is passed, causing `Trying to access array offset on value of type int` error to be thrown on PHP 7.4. 
The fix is to simply cast `$selector` to `string` using a type hint.

This shouldn't really occur in ideal world because numeric CSS selectors are not valid, but if anyone passes an invalid input, they should be simply ignored instead of throwing an error.

PS: The error is thrown here: https://github.com/dompdf/dompdf/pull/2071/files#diff-c9ab10f725a388f7b86e26f58d4085d4R476

To consider: Using https://symfony.com/doc/current/components/css_selector.html instead.