### PR TITLE
define default value for Imagick::negateImage

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4871,7 +4871,10 @@ EOT;
             if ($imagick->getImageAlphaChannel() !== 0) {
                 $alpha_channel = $imagickClonable ? clone $imagick : $imagick->clone();
                 $alpha_channel->separateImageChannel(\Imagick::CHANNEL_ALPHA);
-                $alpha_channel->negateImage(true);
+                // Since ImageMagick7 negate invert transparency as default
+                if (\Imagick::getVersion()['versionNumber'] < 1800) {
+                    $alpha_channel->negateImage(true);
+                }
                 $alpha_channel->writeImage($tempfile_alpha);
 
                 // Cast to 8bit+palette


### PR DESCRIPTION
Extension php-imagick with ImageMagick version 7 and above default value is changed for method negateImage
I fix it in concrete value