### PR TITLE
Fix: page breaking on rows with rowspan.

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -415,7 +415,7 @@ class Frame
     }
 
     /**
-     * @return FrameList|Frame[]
+     * @return FrameList|Frame[] !! TODO fixup doc. It never returns Frame[]
      */
     public function get_children()
     {


### PR DESCRIPTION
1. I added restriction to break before row, if page_break_before: avoid specified for <tr>.
2. I added logic to define if current row has spanned from previous rows cells, so one restricts page breaking on rows connected with rowspan. #1388