### PR TITLE
RTL Language Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "ext-dom": "*",
         "ext-mbstring": "*",
         "phenx/php-font-lib": "^0.5.1",
-        "phenx/php-svg-lib": "^0.3.3"
+        "phenx/php-svg-lib": "^0.3.3",
+        "tecnickcom/tc-lib-unicode": "~1.3.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -61,6 +61,7 @@ class AttributeTranslator
             ],
             'rules' => '!set_table_rules',
             'width' => 'width: %s;',
+            'dir' => 'direction: %s;'
         ],
         'hr' => [
             'align' => '!set_hr_align', // Need to grab width to set 'left' & 'right' correctly
@@ -70,6 +71,7 @@ class AttributeTranslator
         ],
         'div' => [
             'align' => 'text-align: %s;',
+            'dir' => 'direction: %s;'
         ],
         'h1' => [
             'align' => 'text-align: %s;',
@@ -95,6 +97,7 @@ class AttributeTranslator
         ],
         'p' => [
             'align' => 'text-align: %s;',
+            'dir' => 'direction: %s;'
         ],
 //    'col' => array(
 //      'align'  => '',
@@ -115,6 +118,7 @@ class AttributeTranslator
             'nowrap' => 'white-space: nowrap;',
             'valign' => 'vertical-align: %s;',
             'width' => 'width: %s;',
+            'dir' => 'direction: %s;'
         ],
         'tfoot' => [
             'align' => '!set_table_row_align',
@@ -127,6 +131,7 @@ class AttributeTranslator
             'nowrap' => 'white-space: nowrap;',
             'valign' => 'vertical-align: %s;',
             'width' => 'width: %s;',
+            'dir' => 'direction: %s;'
         ],
         'thead' => [
             'align' => '!set_table_row_align',
@@ -142,6 +147,7 @@ class AttributeTranslator
             'bgcolor' => '!set_background_color',
             'link' => '!set_body_link',
             'text' => '!set_color',
+            'dir' => 'direction: %s;'
         ],
         'br' => [
             'clear' => 'clear: %s;',
@@ -177,6 +183,7 @@ class AttributeTranslator
         'li' => [
             'type' => 'list-style-type: %s;',
             'value' => 'counter-reset: -dompdf-default-counter %d;',
+            'dir' => 'direction: %s;'
         ],
         'pre' => [
             'width' => 'width: %s;',

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1992,6 +1992,15 @@ class Style
         $this->_props_computed[$prop] = (is_array($munged_color) ? $munged_color["hex"] : $munged_color);
     }
 
+    public function set_direction($direction)
+    {
+        $this->_props["direction"] = $direction;
+        $this->_prop_cache["direction"] = null;
+        if ($direction === 'rtl') {
+            $this->text_align = 'right';
+        }
+    }
+
     /**
      * Sets color
      *

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -8,6 +8,7 @@
  */
 namespace Dompdf\FrameReflower;
 
+use Com\Tecnick\Unicode\Bidi;
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Text as TextFrameDecorator;
 use Dompdf\FontMetrics;
@@ -219,7 +220,15 @@ class Text extends AbstractFrameReflower
         switch ($style->white_space) {
             default:
             case "normal":
-                $frame->set_text($text = $this->_collapse_white_space($text));
+                $text = $this->_collapse_white_space($text);
+
+                if ($style->direction === 'rtl') {
+                    $bidi = new Bidi($text, null, null, 'R', false);
+                    $text = $bidi->getString();
+                }
+
+                $frame->set_text($text);
+
                 if ($text == "") {
                     break;
                 }
@@ -228,15 +237,32 @@ class Text extends AbstractFrameReflower
                 break;
 
             case "pre":
+                if ($style->direction === 'rtl') {
+                    $bidi = new Bidi($text, null, null, 'R', false);
+                    $text = $bidi->getString();
+                }
+
                 $split = $this->_newline_break($text);
                 $add_line = $split !== false;
                 break;
 
             case "nowrap":
-                $frame->set_text($text = $this->_collapse_white_space($text));
+                $text = $this->_collapse_white_space($text);
+
+                if ($style->direction === 'rtl') {
+                    $bidi = new Bidi($text, null, null, 'R', false);
+                    $text = $bidi->getString();
+                }
+
+                $frame->set_text($text);
                 break;
 
             case "pre-wrap":
+                if ($style->direction === 'rtl') {
+                    $bidi = new Bidi($text, null, null, 'R', false);
+                    $text = $bidi->getString();
+                }
+
                 $split = $this->_newline_break($text);
 
                 if (($tmp = $this->_line_break($text)) !== false) {
@@ -249,7 +275,13 @@ class Text extends AbstractFrameReflower
 
             case "pre-line":
                 // Collapse white-space except for \n
-                $frame->set_text($text = preg_replace("/[ \t]+/u", " ", $text));
+                $text = preg_replace("/[ \t]+/u", " ", $text);
+
+                if ($style->direction === 'rtl') {
+                    $bidi = new Bidi($text, null, null, 'R', false);
+                    $text = $bidi->getString();
+                }
+                $frame->set_text($text);
 
                 if ($text == "") {
                     break;


### PR DESCRIPTION
This feature adds:
- Text is aligned right when direction is set to RTL
- Text of RTL languages is reordered while LTR languages should be untouched
- Dir attribute is supported beside the direction style on the most important elements

This does not use the ar-php library which was unstable in my tests and provided often wrong results. Instead it includes https://github.com/tecnickcom/tc-lib-unicode which looks promising.

I have zero knowledge of all languages like Arabic, Hebrew, Persian this supports. If someone has some more insights and could find flaws of this implementation or on the use of this library instead of ar-php please let us know here.