### PR TITLE
silence iconv

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -187,7 +187,7 @@ class FontMetrics
         $prefix = preg_replace("/[^\\pL\d]+/u", "-", $prefix);
         $prefix = trim($prefix, "-");
         if (function_exists('iconv')) {
-            $prefix = iconv('utf-8', 'us-ascii//TRANSLIT', $prefix);
+            $prefix = @iconv('utf-8', 'us-ascii//TRANSLIT', $prefix);
         }
         $prefix = preg_replace("/[^-\w]+/", "", $prefix);
         


### PR DESCRIPTION
I had trouble using this (on Alpine Linux). From what i can gather it's related to the slashes in the param of the iconv call, so i silenced it. Not the neatest fix, but the same approach is used in InputStream.php, with a comment saying "non-conforming". It could indicate this gave the same problem i ran into?