### PR TITLE
Resolved error in PHP 7.4 compatibility

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -195,7 +195,8 @@ class CPDF implements Canvas
 
         $this->_dompdf = $dompdf;
 
-        $this->_pdf = new \Dompdf\Cpdf(
+        $cpdf_class_var = "\Dompdf\Cpdf";
+        $this->_pdf = new $cpdf_class_var(
             $size,
             true,
             $dompdf->getOptions()->getFontCache(),


### PR DESCRIPTION
phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.4 dompdf


FILE: /Users/ravikantmane/Desktop/patch/dompdf/src/Adapter/CPDF.php
FOUND 1 ERROR AFFECTING 1 LINE
198 | ERROR | Extension 'cpdf' is removed since PHP 5.1; Use pecl/pdflib instead
