### PR TITLE
Add `loadDOM` method

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -416,8 +416,6 @@ class Dompdf
     }
 
     public function loadDOM($doc, $quirksmode = false) {
-        $this->saveLocale();
-
         // Remove #text children nodes in nodes that shouldn't have
         $tag_names = ["html", "head", "table", "tbody", "thead", "tfoot", "tr"];
         foreach ($tag_names as $tag_name) {


### PR DESCRIPTION
Gives the opportunity to users using a `DOMDocument` object to skip the string conversion and re-parsing steps.

In my use case, I am building an HTML document from several sources, and I am using the PHP DOM API to do so. I figure it would be way more efficient to pass the `DOMDocument` instance straight to DOMPDF rather than passing a string that needs parsing to turn back to a `DOMDocument`.