### PR TITLE
Change width measurements to not be case-sensitive

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -620,23 +620,23 @@ class Style
                 continue;
             }
 
-            if (($i = mb_strpos($l, "px")) !== false) {
+            if (($i = mb_stripos($l, "px")) !== false) {
                 $dpi = $this->_stylesheet->get_dompdf()->getOptions()->getDpi();
                 $ret += ((float)mb_substr($l, 0, $i) * 72) / $dpi;
                 continue;
             }
 
-            if (($i = mb_strpos($l, "pt")) !== false) {
+            if (($i = mb_stripos($l, "pt")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i);
                 continue;
             }
 
-            if (($i = mb_strpos($l, "%")) !== false) {
+            if (($i = mb_stripos($l, "%")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) / 100 * (float)$ref_size;
                 continue;
             }
 
-            if (($i = mb_strpos($l, "rem")) !== false) {
+            if (($i = mb_stripos($l, "rem")) !== false) {
                 if ($this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style() === null) {
                     // Interpreting it as "em", see https://github.com/dompdf/dompdf/issues/1406
                     $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size");
@@ -646,33 +646,33 @@ class Style
                 continue;
             }
 
-            if (($i = mb_strpos($l, "em")) !== false) {
+            if (($i = mb_stripos($l, "em")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size");
                 continue;
             }
 
-            if (($i = mb_strpos($l, "cm")) !== false) {
+            if (($i = mb_stripos($l, "cm")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * 72 / 2.54;
                 continue;
             }
 
-            if (($i = mb_strpos($l, "mm")) !== false) {
+            if (($i = mb_stripos($l, "mm")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * 72 / 25.4;
                 continue;
             }
 
             // FIXME: em:ex ratio?
-            if (($i = mb_strpos($l, "ex")) !== false) {
+            if (($i = mb_stripos($l, "ex")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size") / 2;
                 continue;
             }
 
-            if (($i = mb_strpos($l, "in")) !== false) {
+            if (($i = mb_stripos($l, "in")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * 72;
                 continue;
             }
 
-            if (($i = mb_strpos($l, "pc")) !== false) {
+            if (($i = mb_stripos($l, "pc")) !== false) {
                 $ret += (float)mb_substr($l, 0, $i) * 12;
                 continue;
             }

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dompdf\Tests\Css;
+
+use Dompdf\Dompdf;
+use Dompdf\Css\Style;
+use Dompdf\Css\Stylesheet;
+use Dompdf\Tests\TestCase;
+
+class StyleTest extends TestCase
+{
+
+    public function testLengthInPt()
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $s = new Style($sheet);
+
+        // PX
+        $length = $s->length_in_pt('100px');
+        $this->assertEquals(75, $length);
+
+        // also check caps
+        $length = $s->length_in_pt('100PX');
+        $this->assertEquals(75, $length);
+
+        // PT
+        $length = $s->length_in_pt('100pt');
+        $this->assertEquals(100, $length);
+
+        // %
+        $length = $s->length_in_pt('100%');
+        $this->assertEquals(12, $length);
+    }
+
+}


### PR DESCRIPTION
I don't *think* there's any requirement for the width scale (like 'px' after the unit) to be lower-case in the spec. Web browsers seem to treat it them same too. But in dompdf it will ignore it if it's written in uppercase.

I couldn't see an issue for this raised, so thought I'd open a PR.

```html
<!doctype html>
<html>
<head>
  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
  <title>0px example</title>
</head>
<body>
  <p style="width:150PX; border: 1px solid red;">example in caps</p>
  <p style="width:150px; border: 1px solid red;">example in lower-case</p>
</body>
</html>
```

Example 
![Screenshot - download](https://user-images.githubusercontent.com/902607/91562530-40ec7c00-e935-11ea-9c01-0106fde6bbd3.png)

I tested this against the `develop` branch.