### PR TITLE
PHP 8 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "phenx/php-font-lib": "^0.5.2",

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5543,7 +5543,7 @@ EOT;
      * @param bool $mask true if the image is masked
      * @throws Exception
      */
-    function addImagePng($file, $x, $y, $w = 0.0, $h = 0.0, &$img, $is_mask = false, $mask = null)
+    function addImagePng($file, $x, $y, $w = 0.0, $h = 0.0, &$img = null, $is_mask = false, $mask = null)
     {
         if (!function_exists("imagepng")) {
             throw new \Exception("The PHP GD extension is required, but is not installed.");
@@ -5889,7 +5889,7 @@ EOT;
      * @param bool $is_mask
      * @param null $mask
      */
-    function addPngFromBuf($file, $x, $y, $w = 0.0, $h = 0.0, &$data, $is_mask = false, $mask = null)
+    function addPngFromBuf($file, $x, $y, $w = 0.0, $h = 0.0, &$data = null, $is_mask = false, $mask = null)
     {
         if (isset($this->imagelist[$file])) {
             $data = null;
@@ -6239,10 +6239,10 @@ EOT;
         $y,
         $w = 0,
         $h = 0,
-        $imageWidth,
-        $imageHeight,
+        $imageWidth = 0,
+        $imageHeight = 0,
         $channels = 3,
-        $imgname
+        $imgname = null
     ) {
         if ($this->image_iscached($imgname)) {
             $label = $this->imagelist[$imgname]['label'];

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -180,7 +180,7 @@ class CPDF implements Canvas
      * @param string $orientation The orientation of the document (either 'landscape' or 'portrait')
      * @param Dompdf $dompdf The Dompdf instance
      */
-    public function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf)
+    public function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf = null)
     {
         if (is_array($paper)) {
             $size = $paper;

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -138,7 +138,8 @@ class GD implements Canvas
      * @param float $aa_factor Anti-aliasing factor, 1 for no AA
      * @param array $bg_color Image background color: array(r,g,b,a), 0 <= r,g,b,a <= 1
      */
-    public function __construct($size = 'letter', $orientation = "portrait", Dompdf $dompdf, $aa_factor = 1.0, $bg_color = [1, 1, 1, 0])
+    public function __construct($size = 'letter', $orientation = "portrait", Dompdf $dompdf = null, $aa_factor = 1.0,
+                                $bg_color = [1, 1, 1, 0])
     {
 
         if (!is_array($size)) {

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -205,7 +205,7 @@ class PDFLib implements Canvas
      * @param string $orientation The orientation of the document (either 'landscape' or 'portrait')
      * @param Dompdf $dompdf
      */
-    public function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf)
+    public function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf = null)
     {
         if (is_array($paper)) {
             $size = $paper;

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -24,7 +24,7 @@ namespace Dompdf;
  */
 interface Canvas
 {
-    function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf);
+    function __construct($paper = "letter", $orientation = "portrait", Dompdf $dompdf = null);
 
     /**
      * @return Dompdf

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -3301,7 +3301,7 @@ class Style
         $this->_props_computed["z_index"] = null;
         $this->_prop_cache["z_index"] = null;
 
-        if (round($val) != $val && $val !== "auto") {
+        if (round((float)$val) != $val && $val !== "auto") {
             return;
         }
 

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -845,7 +845,8 @@ abstract class AbstractRenderer
      *
      * @var $top
      */
-    protected function _border_line($x, $y, $length, $color, $widths, $side, $corner_style = "bevel", $pattern_name, $r1 = 0, $r2 = 0)
+    protected function _border_line($x, $y, $length, $color, $widths, $side, $corner_style = "bevel", $pattern_name =
+    null, $r1 = 0, $r2 = 0)
     {
         /** used by $$side */
         list($top, $right, $bottom, $left) = $widths;

--- a/src/Renderer/Inline.php
+++ b/src/Renderer/Inline.php
@@ -69,8 +69,12 @@ class Inline extends AbstractRenderer
         }
 
         // Add the border widths
-        $w += (float)$widths[1] + (float)$widths[3];
-        $h += (float)$widths[0] + (float)$widths[2];
+        if ($w != 'auto') {
+            $w += (float)$widths[1] + (float)$widths[3];
+        }
+        if ($h != 'auto') {
+            $h += (float)$widths[0] + (float)$widths[2];
+        }
 
         // If this is the first row, draw the left border too
         if ($bp["left"]["style"] !== "none" && $bp["left"]["color"] !== "transparent" && $widths[3] > 0) {

--- a/src/Renderer/Inline.php
+++ b/src/Renderer/Inline.php
@@ -69,10 +69,14 @@ class Inline extends AbstractRenderer
         }
 
         // Add the border widths
-        if ($w != 'auto') {
+        if ($w == 'auto') {
+            $w = (float)$widths[1] + (float)$widths[3]; // Mimics PHP 7 behaviour in PHP 8
+        } else {
             $w += (float)$widths[1] + (float)$widths[3];
         }
-        if ($h != 'auto') {
+        if ($h == 'auto') {
+            $h = (float)$widths[0] + (float)$widths[2]; // Mimics PHP 7 behaviour in PHP 8
+        } else {
             $h += (float)$widths[0] + (float)$widths[2];
         }
 


### PR DESCRIPTION
I found that running v0.8.6 under PHP 8 triggered several issues.

- Unsupported operand types: string + float
- Required parameter follows optional parameter

I am not familiar with how this package works, so I've attempted to quell the above with minimal code changes. It renders, but I'm sure further changes will be required.

Of note, in order to fix the problems with the required/optional parameter order, I have simply given the out of place required parameters default values making them optional. This is probably not desired, but arguably better than breaking backwards compatibility by changing the order of the arguments. It might be worth throwing an exception if these parameters have their default values. In the case of the object typed parameters, the default value I've added (null) would probably throw anyway as I didn't include the optional ? operator.

Also, there appears to be an issue where the width or the height is 'auto' (string) and it then attempts to add borders (float|int). Obviously a string and a number cannot be added together and even if they could it would not produce the desired result. My update attempts to mimic the behaviour of PHP 7 in this situation (the string value is discarded). I expect what needs to happen is that the 'auto' value is resolved to a numeric value first, before the border is added.

So far from perfect, but it's an honest attempt at getting it to run. I fully expect that this pull request won't be merged as is, but many developers prefer a pull request to an issue, it's a start.