### PR TITLE
PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "phenx/php-font-lib": "^0.5.2",


### PR DESCRIPTION
I tried to install on php 8 and got this error:
```
- Root composer.json requires dompdf/dompdf ^0.8.6 -> satisfiable by dompdf/dompdf[v0.8.6].
    - dompdf/dompdf v0.8.6 requires php ^7.1 -> your php version (8.0.0) does not satisfy that requirement.
```
I don't know about compatibility but I installed this version from php 7.4 then run on php 8 and working fine.