### PR TITLE
Fix "Box property calculation requires containing block width" for absolute positioned elements

### DIFF
--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -208,7 +208,7 @@ class Block extends AbstractFrameReflower
         $max_width = $style->length_in_pt($style->max_width, $cb["w"]);
 
         if ($max_width !== "none" && $min_width > $max_width) {
-            [$max_width, $min_width] = [$min_width, $max_width];
+            list($max_width, $min_width) = [$min_width, $max_width];
         }
 
         if ($max_width !== "none" && $width > $max_width) {
@@ -407,7 +407,7 @@ class Block extends AbstractFrameReflower
 
                 if ($max_height !== "none" && $min_height > $max_height) {
                     // Swap 'em
-                    [$max_height, $min_height] = [$min_height, $max_height];
+                    list($max_height, $min_height) = [$min_height, $max_height];
                 }
 
                 if ($max_height !== "none" && $height > $max_height) {
@@ -726,7 +726,7 @@ class Block extends AbstractFrameReflower
             }
 
             $line_box = $this->_frame->get_current_line_box();
-            [$old_x, $old_y] = $child->get_position();
+            list($old_x, $old_y) = $child->get_position();
 
             $float_x = $cb_x;
             $float_y = $old_y;
@@ -793,7 +793,7 @@ class Block extends AbstractFrameReflower
 
         // Determine the constraints imposed by this frame: calculate the width
         // of the content area:
-        [$w, $left_margin, $right_margin, $left, $right] = $this->_calculate_restricted_width();
+        list($w, $left_margin, $right_margin, $left, $right) = $this->_calculate_restricted_width();
 
         // Store the calculated properties
         $style->width = $w;
@@ -804,7 +804,7 @@ class Block extends AbstractFrameReflower
 
         // Update the position
         $this->_frame->position();
-        [$x, $y] = $this->_frame->get_position();
+        list($x, $y) = $this->_frame->get_position();
 
         // Adjust the first line based on the text-indent property
         $indent = (float)$style->length_in_pt($style->text_indent, $cb["w"]);
@@ -854,7 +854,7 @@ class Block extends AbstractFrameReflower
         }
 
         // Determine our height
-        [$height, $margin_top, $margin_bottom, $top, $bottom] = $this->_calculate_restricted_height();
+        list($height, $margin_top, $margin_bottom, $top, $bottom) = $this->_calculate_restricted_height();
         $style->height = $height;
         $style->margin_top = $margin_top;
         $style->margin_bottom = $margin_bottom;
@@ -903,9 +903,9 @@ class Block extends AbstractFrameReflower
 
         // Absolute positioning
         if ($needs_reposition) {
-            [$x, $y] = $this->_frame->get_position();
+            list($x, $y) = $this->_frame->get_position();
             $this->_frame->position();
-            [$new_x, $new_y] = $this->_frame->get_position();
+            list($new_x, $new_y) = $this->_frame->get_position();
             $this->_frame->move($new_x - $x, $new_y - $y, true);
         }
 

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -181,8 +181,9 @@ class Block extends AbstractFrameReflower
             $cb = $frame->get_root()->get_containing_block();
         }
 
-        //if ( $style->position === "absolute" )
-        //  $cb = $frame->find_positionned_parent()->get_containing_block();
+        if ($style->position === "absolute") {
+            $cb = $frame->find_positionned_parent()->get_containing_block();
+        }
 
         if (!isset($cb["w"])) {
             throw new Exception("Box property calculation requires containing block width");
@@ -207,7 +208,7 @@ class Block extends AbstractFrameReflower
         $max_width = $style->length_in_pt($style->max_width, $cb["w"]);
 
         if ($max_width !== "none" && $min_width > $max_width) {
-            list($max_width, $min_width) = [$min_width, $max_width];
+            [$max_width, $min_width] = [$min_width, $max_width];
         }
 
         if ($max_width !== "none" && $width > $max_width) {
@@ -406,7 +407,7 @@ class Block extends AbstractFrameReflower
 
                 if ($max_height !== "none" && $min_height > $max_height) {
                     // Swap 'em
-                    list($max_height, $min_height) = [$min_height, $max_height];
+                    [$max_height, $min_height] = [$min_height, $max_height];
                 }
 
                 if ($max_height !== "none" && $height > $max_height) {
@@ -725,7 +726,7 @@ class Block extends AbstractFrameReflower
             }
 
             $line_box = $this->_frame->get_current_line_box();
-            list($old_x, $old_y) = $child->get_position();
+            [$old_x, $old_y] = $child->get_position();
 
             $float_x = $cb_x;
             $float_y = $old_y;
@@ -792,7 +793,7 @@ class Block extends AbstractFrameReflower
 
         // Determine the constraints imposed by this frame: calculate the width
         // of the content area:
-        list($w, $left_margin, $right_margin, $left, $right) = $this->_calculate_restricted_width();
+        [$w, $left_margin, $right_margin, $left, $right] = $this->_calculate_restricted_width();
 
         // Store the calculated properties
         $style->width = $w;
@@ -803,7 +804,7 @@ class Block extends AbstractFrameReflower
 
         // Update the position
         $this->_frame->position();
-        list($x, $y) = $this->_frame->get_position();
+        [$x, $y] = $this->_frame->get_position();
 
         // Adjust the first line based on the text-indent property
         $indent = (float)$style->length_in_pt($style->text_indent, $cb["w"]);
@@ -853,7 +854,7 @@ class Block extends AbstractFrameReflower
         }
 
         // Determine our height
-        list($height, $margin_top, $margin_bottom, $top, $bottom) = $this->_calculate_restricted_height();
+        [$height, $margin_top, $margin_bottom, $top, $bottom] = $this->_calculate_restricted_height();
         $style->height = $height;
         $style->margin_top = $margin_top;
         $style->margin_bottom = $margin_bottom;
@@ -902,9 +903,9 @@ class Block extends AbstractFrameReflower
 
         // Absolute positioning
         if ($needs_reposition) {
-            list($x, $y) = $this->_frame->get_position();
+            [$x, $y] = $this->_frame->get_position();
             $this->_frame->position();
-            list($new_x, $new_y) = $this->_frame->get_position();
+            [$new_x, $new_y] = $this->_frame->get_position();
             $this->_frame->move($new_x - $x, $new_y - $y, true);
         }
 


### PR DESCRIPTION
This PR fixes a problem related to #1578 where absolute positioned elements trigger this error inside a table that has `table-layout: fixed` as CSS.

Test case:

```
<?php

$html = <<<HTML
<table style="table-layout: fixed">
    <tr>
        <td>
            <div style="position: relative">
                <div style="position: absolute">
                    test
                </div>
            </div>
        </td>
    </tr>
</table>
HTML;

include 'vendor/autoload.php';
$domPdf = new \Dompdf\Dompdf();
$domPdf->loadHtml($html);

$domPdf->render();
$rendered = $domPdf->output();
file_put_contents('output.pdf', $rendered);
```

**Before this PR:**

```
PHP Fatal error:  Uncaught Dompdf\Exception: Box property calculation requires containing block width in /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php:189
Stack trace:
#0 /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php(796): Dompdf\FrameReflower\Block->_calculate_restricted_width()
#1 /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(895): Dompdf\FrameReflower\Block->reflow(Object(Dompdf\FrameDecorator\Block))
#2 /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php(846): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\Block))
#3 /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(895): Dompdf\FrameReflower\Block->reflow(Object(Dompdf\FrameDecorator\TableCell))
#4 /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/TableCell.php(95): Dompdf\FrameDecorator\AbstractFrameDecorator->reflow(Object(Dompdf\FrameDecorator\TableCell))
#5 /Users/bobkruitho in /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php on line 189

Fatal error: Uncaught Dompdf\Exception: Box property calculation requires containing block width in /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php on line 189

Dompdf\Exception: Box property calculation requires containing block width in /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php on line 189

Call Stack:
    0.0004     355848   1. {main}() /Users/halfpastfouram/PhpstormProjects/dompdf/test.php:0
    0.0257    3010136   2. Dompdf\Dompdf->render() /Users/halfpastfouram/PhpstormProjects/dompdf/test.php:21
    0.0726    4618608   3. Dompdf\FrameDecorator\Page->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/Dompdf.php:841
    0.0726    4618608   4. Dompdf\FrameReflower\Page->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0730    4626056   5. Dompdf\FrameDecorator\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Page.php:141
    0.0730    4626056   6. Dompdf\FrameReflower\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0741    4632072   7. Dompdf\FrameDecorator\Table->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php:846
    0.0741    4632072   8. Dompdf\FrameReflower\Table->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0762    4652704   9. Dompdf\FrameDecorator\TableRowGroup->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Table.php:489
    0.0762    4652704  10. Dompdf\FrameReflower\TableRowGroup->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0762    4652912  11. Dompdf\FrameDecorator\TableRow->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/TableRowGroup.php:51
    0.0762    4652912  12. Dompdf\FrameReflower\TableRow->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0763    4653120  13. Dompdf\FrameDecorator\TableCell->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/TableRow.php:52
    0.0763    4653120  14. Dompdf\FrameReflower\TableCell->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0786    4711592  15. Dompdf\FrameDecorator\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/TableCell.php:95
    0.0786    4711592  16. Dompdf\FrameReflower\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0821    4730400  17. Dompdf\FrameDecorator\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php:846
    0.0821    4730400  18. Dompdf\FrameReflower\Block->reflow() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameDecorator/AbstractFrameDecorator.php:895
    0.0822    4732320  19. Dompdf\FrameReflower\Block->_calculate_restricted_width() /Users/halfpastfouram/PhpstormProjects/dompdf/src/FrameReflower/Block.php:796
```

**After this PR**

[output.pdf](https://github.com/dompdf/dompdf/files/5689240/output.pdf)
