### PR TITLE
Fix clone

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5672,19 +5672,12 @@ EOT;
         }
         // Use PECL imagick + ImageMagic to process transparent PNG images
         elseif (extension_loaded("imagick")) {
-            // Native cloning was added to pecl-imagick in svn commit 263814
-            // the first version containing it was 3.0.1RC1
-            static $imagickClonable = null;
-            if ($imagickClonable === null) {
-                $imagickClonable = version_compare(\Imagick::IMAGICK_EXTVER, '3.0.1rc1') > 0;
-            }
-
             $imagick = new \Imagick($file);
             $imagick->setFormat('png');
 
             // Get opacity channel (negative of alpha channel)
             if ($imagick->getImageAlphaChannel() !== 0) {
-                $alpha_channel = $imagickClonable ? clone $imagick : $imagick->clone();
+                $alpha_channel = clone $imagick;
                 $alpha_channel->separateImageChannel(\Imagick::CHANNEL_ALPHA);
                 // Since ImageMagick7 negate invert transparency as default
                 if (\Imagick::getVersion()['versionNumber'] < 1800) {


### PR DESCRIPTION
I'm using php 8, Imagic Mage 7.0.48

And I'm in error.

Because it is something that bugs depending on the version and we just want to clone it, then we can use the clone. Even with "gmagick" it is done like this.

I think we can use the same thing here.