### PR TITLE
CSS: Reduce code duplication

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1233,7 +1233,7 @@ class Style
      */
     function get_background_image()
     {
-        return $this->_image($this->_props_computed["background_image"]);
+        return $this->_stylesheet->resolve_url($this->_props_computed["background_image"]);
     }
 
     /**
@@ -1585,7 +1585,7 @@ class Style
      */
     function get_list_style_image()
     {
-        return $this->_image($this->_props_computed["list_style_image"]);
+        return $this->_stylesheet->resolve_url($this->_props_computed["list_style_image"]);
     }
 
     /**
@@ -1803,45 +1803,6 @@ class Style
         }
     }
 
-    /**
-     * @param $val
-     * @return string
-     */
-    protected function _image($val)
-    {
-        $DEBUGCSS = $this->_stylesheet->get_dompdf()->getOptions()->getDebugCss();
-        $parsed_url = "none";
-
-        if (empty($val) || $val === "none") {
-            $path = "none";
-        } elseif (mb_strpos($val, "url") === false) {
-            $path = "none"; //Don't resolve no image -> otherwise would prefix path and no longer recognize as none
-        } else {
-            $val = preg_replace("/url\(\s*['\"]?([^'\")]+)['\"]?\s*\)/", "\\1", trim($val));
-
-            // Resolve the url now in the context of the current stylesheet
-            $parsed_url = Helpers::explode_url($val);
-            $path = Helpers::build_url($this->_stylesheet->get_protocol(),
-                $this->_stylesheet->get_host(),
-                $this->_stylesheet->get_base_path(),
-                $val);
-            if (($parsed_url["protocol"] == "" || $parsed_url["protocol"] == "file://") && ($this->_stylesheet->get_protocol() == "" || $this->_stylesheet->get_protocol() == "file://")) {
-                $path = realpath($path);
-                // If realpath returns FALSE then specifically state that there is no background image
-                if (!$path) {
-                    $path = 'none';
-                }
-            }
-        }
-        if ($DEBUGCSS) {
-            print "<pre>[_image\n";
-            print_r($parsed_url);
-            print $this->_stylesheet->get_protocol() . "\n" . $this->_stylesheet->get_base_path() . "\n" . $path . "\n";
-            print "_image]</pre>";;
-        }
-        return $path;
-    }
-
     /*======================*/
 
     protected function set_prop_color($prop, $color)
@@ -1892,7 +1853,7 @@ class Style
     function set_background_image($val)
     {
         $this->_props["background_image"] = $val;
-        $parsed_val = $this->_image($val);
+        $parsed_val = $this->_stylesheet->resolve_url($val);
         if ($parsed_val === "none") {
             $this->_props_computed["background_image"] = "none";
         } else {
@@ -2923,7 +2884,7 @@ class Style
     function set_list_style_image($val)
     {
         $this->_props["list_style_image"] = $val;
-        $parsed_val = $this->_image($val);
+        $parsed_val = $this->_stylesheet->resolve_url($val);
         if ($parsed_val === "none") {
             $this->_props_computed["list_style_image"] = "none";
         } else {

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1013,7 +1013,7 @@ class Stylesheet
                             continue;
                         }
 
-                        if (($src = $this->_image($style->get_prop('content'))) !== "none") {
+                        if (($src = $this->_resolve_url($style->get_prop('content'))) !== "none") {
                             $new_node = $node->ownerDocument->createElement("img_generated");
                             $new_node->setAttribute("src", $src);
                         } else {
@@ -1418,12 +1418,13 @@ class Stylesheet
     }
 
     /**
-     * See also style.cls Style::_image(), refactoring?, works also for imported css files
+     * Resolve the given `url()` declaration to an absolute URL.
      *
-     * @param $val
-     * @return string
+     * @param string|null $val The declaration to resolve in the context of the stylesheet.
+     * @return string The resolved URL, or `none`, if the value is `none`,
+     *         invalid, or points to a non-existent local file.
      */
-    protected function _image($val)
+    protected function _resolve_url($val): string
     {
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();
         $parsed_url = "none";
@@ -1444,8 +1445,8 @@ class Stylesheet
             if (($parsed_url["protocol"] == "" || $parsed_url["protocol"] == "file://") && ($this->_protocol == "" || $this->_protocol == "file://")) {
                 $path = realpath($path);
                 // If realpath returns FALSE then specifically state that there is no background image
-                if (!$path) {
-                    $path = 'none';
+                if ($path === false) {
+                    $path = "none";
                 }
             }
         }
@@ -1498,7 +1499,7 @@ class Stylesheet
             // Above does not work for subfolders and absolute urls.
             // Todo: As above, do we need to replace php or file to an empty protocol for local files?
 
-            $url = $this->_image($url);
+            $url = $this->_resolve_url($url);
 
             $this->load_css_file($url);
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1013,7 +1013,7 @@ class Stylesheet
                             continue;
                         }
 
-                        if (($src = $this->_resolve_url($style->get_prop('content'))) !== "none") {
+                        if (($src = $this->resolve_url($style->get_prop('content'))) !== "none") {
                             $new_node = $node->ownerDocument->createElement("img_generated");
                             $new_node->setAttribute("src", $src);
                         } else {
@@ -1424,7 +1424,7 @@ class Stylesheet
      * @return string The resolved URL, or `none`, if the value is `none`,
      *         invalid, or points to a non-existent local file.
      */
-    protected function _resolve_url($val): string
+    public function resolve_url($val): string
     {
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();
         $parsed_url = "none";
@@ -1499,7 +1499,7 @@ class Stylesheet
             // Above does not work for subfolders and absolute urls.
             // Todo: As above, do we need to replace php or file to an empty protocol for local files?
 
-            $url = $this->_resolve_url($url);
+            $url = $this->resolve_url($url);
 
             $this->load_css_file($url);
 


### PR DESCRIPTION
After commit 0546e8198cc67d4a74d17e423faf962846f074f6 the `_image` method in `Style` basically calls the `_image` method of its parent stylesheet object. Make it actually do that to reduce the code duplication. The method needs to become `public` for that. I tried to improve its name and documentation, so that it is clear what it does. Does it make sense like that?

With the changes, it now seems to me that it might be unnecessary to resolve the URL on get _and_ set of background-image/list-style-image, but that might be something for another day; the method still strips the `url()` on get.