### PR TITLE
Stylesheet: Improve return-value check

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -995,7 +995,7 @@ class Stylesheet
                 // Retrieve the nodes, limit to body for generated content
                 //TODO: If we use a context node can we remove the leading dot?
                 $nodes = @$xp->query('.' . $query["query"]);
-                if ($nodes == null) {
+                if ($nodes === false) {
                     Helpers::record_warnings(E_USER_WARNING, "The CSS selector '$selector' is not valid", __FILE__, __LINE__);
                     continue;
                 }
@@ -1036,7 +1036,7 @@ class Stylesheet
 
                 // Retrieve the nodes
                 $nodes = @$xp->query($query["query"]);
-                if ($nodes == null) {
+                if ($nodes === false) {
                     Helpers::record_warnings(E_USER_WARNING, "The CSS selector '$selector' is not valid", __FILE__, __LINE__);
                     continue;
                 }


### PR DESCRIPTION
Small drive-by improvement for clarity. `DOMXPath::query` will return `false` in case of failure, so explicitly check for that (also checked that it actually does). Avoids unnecessary type juggling.

https://www.php.net/manual/en/domxpath.query.php