### PR TITLE
Fix (out of range) for roman numerals

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -157,14 +157,19 @@ class Helpers
     }
 
     /**
-     * Converts decimal numbers to roman numerals
+     * Converts decimal numbers to roman numerals.
      *
-     * @param int $num
+     * As numbers larger than 3999 (and smaller than 1) cannot be represented in
+     * the standard form of roman numerals, those are left in decimal form.
+     * 
+     * See https://en.wikipedia.org/wiki/Roman_numerals#Standard_form
+     *
+     * @param int|string $num
      *
      * @throws Exception
      * @return string
      */
-    public static function dec2roman($num)
+    public static function dec2roman($num): string
     {
 
         static $ones = ["", "i", "ii", "iii", "iv", "v", "vi", "vii", "viii", "ix"];
@@ -176,8 +181,8 @@ class Helpers
             throw new Exception("dec2roman() requires a numeric argument.");
         }
 
-        if ($num > 4000 || $num < 0) {
-            return "(out of range)";
+        if ($num >= 4000 || $num <= 0) {
+            return (string) $num;
         }
 
         $num = strrev((string)$num);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -20,4 +20,26 @@ AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
             base64_decode($imageParts['data'])
         );
     }
+
+    public function dec2RomanProvider(): array
+    {
+        return [
+            [-5, "-5"],
+            [0, "0"],
+            [1, "i"],
+            [5, "v"],
+            [3999, "mmmcmxcix"],
+            [4000, "4000"],
+            [50000, "50000"],
+        ];
+    }
+
+    /**
+     * @dataProvider dec2RomanProvider
+     */
+    public function testDec2Roman($number, $expected)
+    {
+        $roman = Helpers::dec2roman($number);
+        $this->assertSame($expected, $roman);
+    }
 }


### PR DESCRIPTION
Fixes #2348, reasoning provided there.

Also fixed the range to be consistent with how the numbers are displayed in Firefox and Chrome. Previously, 0 and 4000 would result in an empty string. Added some documentation and tests. Test cases don't really cover the actual conversion, because I didn't touch that. They can be easily extended though, when the need arises.