### PR TITLE
Fix text-width calulation with letter spacing

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5131,11 +5131,11 @@ EOT;
      * calculate how wide a given text string will be on a page, at a given size.
      * this can be called externally, but is also used by the other class functions
      *
-     * @param $size
-     * @param $text
-     * @param int $word_spacing
-     * @param int $char_spacing
-     * @return float|int
+     * @param float $size
+     * @param string $text
+     * @param float $word_spacing
+     * @param float $char_spacing
+     * @return float
      */
     function getTextWidth($size, $text, $word_spacing = 0, $char_spacing = 0)
     {

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5161,7 +5161,6 @@ EOT;
         $cf = $this->currentFont;
         $current_font = $this->fonts[$cf];
         $space_scale = 1000 / ($size > 0 ? $size : 1);
-        $n_spaces = 0;
 
         if ($current_font['isUnicode']) {
             // for Unicode, use the code points array to calculate width rather
@@ -5183,14 +5182,13 @@ EOT;
                     // add additional padding for space
                     if (isset($current_font['codeToName'][$char]) && $current_font['codeToName'][$char] === 'space') {  // Space
                         $w += $word_spacing * $space_scale;
-                        $n_spaces++;
                     }
                 }
             }
 
             // add additional char spacing
             if ($char_spacing != 0) {
-                $w += $char_spacing * $space_scale * (count($unicode) + $n_spaces);
+                $w += $char_spacing * $space_scale * count($unicode);
             }
 
         } else {
@@ -5219,14 +5217,13 @@ EOT;
                     // add additional padding for space
                     if (isset($current_font['codeToName'][$char]) && $current_font['codeToName'][$char] === 'space') {  // Space
                         $w += $word_spacing * $space_scale;
-                        $n_spaces++;
                     }
                 }
             }
 
             // add additional char spacing
             if ($char_spacing != 0) {
-                $w += $char_spacing * $space_scale * ($len + $n_spaces);
+                $w += $char_spacing * $space_scale * $len;
             }
         }
 

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -1021,9 +1021,9 @@ class CPDF implements Canvas
      * @param string $text
      * @param string $font
      * @param float $size
-     * @param int $word_spacing
-     * @param int $char_spacing
-     * @return float|int
+     * @param float $word_spacing
+     * @param float $char_spacing
+     * @return float
      */
     public function get_text_width($text, $font, $size, $word_spacing = 0, $char_spacing = 0)
     {

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1335,7 +1335,7 @@ class PDFLib implements Canvas
 
         if ($letter_spacing) {
             $num_chars = mb_strlen($text);
-            $delta += ($num_chars - $num_spaces) * $letter_spacing;
+            $delta += $num_chars * $letter_spacing;
         }
 
         return $this->_pdf->stringwidth($text, $fh, $size) + $delta;

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1321,8 +1321,8 @@ class PDFLib implements Canvas
      * @param string $text
      * @param string $font
      * @param float  $size
-     * @param int    $word_spacing
-     * @param int    $letter_spacing
+     * @param float  $word_spacing
+     * @param float  $letter_spacing
      * @return mixed
      */
     public function get_text_width($text, $font, $size, $word_spacing = 0, $letter_spacing = 0)

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -333,7 +333,7 @@ interface Canvas
      * @param string $font the desired font
      * @param float $size the desired font size
      * @param float $word_spacing word spacing, if any
-     * @param float $char_spacing
+     * @param float $char_spacing char spacing, if any
      *
      * @return float
      */


### PR DESCRIPTION
The letter spacing was counted twice for every space character. Not sure, if there was a reason for that, but it seems to be wrong and leads to a different width compared to what is drawn. Support for letter spacing was introduced in commit 4bbb5feae6163409726b1544acf2fc13b2d706cd and the logic hasn't changed since then.

Sample HTML that visualizes the issue:
```
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style type="text/css">
@page {
	size: 400pt 300pt;
	margin: 50pt;
}

body {
	font-family: sans-serif;
	font-size: 1em;
}

p {
	margin: 0;
}

span {
	display: inline-block;
	border: 1pt solid red;
}

.c2 {
	letter-spacing: 2pt;
}

.c3 {
	letter-spacing: 2pt;
	word-spacing: 5pt;
}

.c4 {
	letter-spacing: 5pt;
}
</style>
</head>

<body>
	<p>
		<span class="c1">Lorem ipsum dolor sit amet</span><br>
		<span class="c2">Lorem ipsum dolor sit amet</span><br>
		<span class="c3">Lorem ipsum dolor sit amet</span><br>
		<span class="c4">L o r e m i p s u m</span><br>
	</p>
</body>

</html>
```

Before: [output-before.pdf](https://github.com/dompdf/dompdf/files/6134323/output-before.pdf)
After: [output-after.pdf](https://github.com/dompdf/dompdf/files/6134324/output-after.pdf)

Fixes #2404