### PR TITLE
Fix undefined variable

### DIFF
--- a/lib/fonts/dompdf_font_family_cache.dist.php
+++ b/lib/fonts/dompdf_font_family_cache.dist.php
@@ -1,95 +1,97 @@
 <?php
-$distFontDir = $rootDir . '/lib/fonts';
-return [
-    'sans-serif' =>
-        [
-            'normal' => $distFontDir . '/Helvetica',
-            'bold' => $distFontDir . '/Helvetica-Bold',
-            'italic' => $distFontDir . '/Helvetica-Oblique',
-            'bold_italic' => $distFontDir . '/Helvetica-BoldOblique'
-        ],
-    'times' =>
-        [
-            'normal' => $distFontDir . '/Times-Roman',
-            'bold' => $distFontDir . '/Times-Bold',
-            'italic' => $distFontDir . '/Times-Italic',
-            'bold_italic' => $distFontDir . '/Times-BoldItalic'
-        ],
-    'times-roman' =>
-        [
-            'normal' => $distFontDir . '/Times-Roman',
-            'bold' => $distFontDir . '/Times-Bold',
-            'italic' => $distFontDir . '/Times-Italic',
-            'bold_italic' => $distFontDir . '/Times-BoldItalic'
-        ],
-    'courier' =>
-        [
-            'normal' => $distFontDir . '/Courier',
-            'bold' => $distFontDir . '/Courier-Bold',
-            'italic' => $distFontDir . '/Courier-Oblique',
-            'bold_italic' => $distFontDir . '/Courier-BoldOblique'
-        ],
-    'helvetica' =>
-        [
-            'normal' => $distFontDir . '/Helvetica',
-            'bold' => $distFontDir . '/Helvetica-Bold',
-            'italic' => $distFontDir . '/Helvetica-Oblique',
-            'bold_italic' => $distFontDir . '/Helvetica-BoldOblique'
-        ],
-    'zapfdingbats' =>
-        [
-            'normal' => $distFontDir . '/ZapfDingbats',
-            'bold' => $distFontDir . '/ZapfDingbats',
-            'italic' => $distFontDir . '/ZapfDingbats',
-            'bold_italic' => $distFontDir . '/ZapfDingbats'
-        ],
-    'symbol' =>
-        [
-            'normal' => $distFontDir . '/Symbol',
-            'bold' => $distFontDir . '/Symbol',
-            'italic' => $distFontDir . '/Symbol',
-            'bold_italic' => $distFontDir . '/Symbol'
-        ],
-    'serif' =>
-        [
-            'normal' => $distFontDir . '/Times-Roman',
-            'bold' => $distFontDir . '/Times-Bold',
-            'italic' => $distFontDir . '/Times-Italic',
-            'bold_italic' => $distFontDir . '/Times-BoldItalic'
-        ],
-    'monospace' =>
-        [
-            'normal' => $distFontDir . '/Courier',
-            'bold' => $distFontDir . '/Courier-Bold',
-            'italic' => $distFontDir . '/Courier-Oblique',
-            'bold_italic' => $distFontDir . '/Courier-BoldOblique'
-        ],
-    'fixed' =>
-        [
-            'normal' => $distFontDir . '/Courier',
-            'bold' => $distFontDir . '/Courier-Bold',
-            'italic' => $distFontDir . '/Courier-Oblique',
-            'bold_italic' => $distFontDir . '/Courier-BoldOblique'
-        ],
-    'dejavu sans' =>
-        [
-            'bold' => $distFontDir . '/DejaVuSans-Bold',
-            'bold_italic' => $distFontDir . '/DejaVuSans-BoldOblique',
-            'italic' => $distFontDir . '/DejaVuSans-Oblique',
-            'normal' => $distFontDir . '/DejaVuSans'
-        ],
-    'dejavu sans mono' =>
-        [
-            'bold' => $distFontDir . '/DejaVuSansMono-Bold',
-            'bold_italic' => $distFontDir . '/DejaVuSansMono-BoldOblique',
-            'italic' => $distFontDir . '/DejaVuSansMono-Oblique',
-            'normal' => $distFontDir . '/DejaVuSansMono'
-        ],
-    'dejavu serif' =>
-        [
-            'bold' => $distFontDir . '/DejaVuSerif-Bold',
-            'bold_italic' => $distFontDir . '/DejaVuSerif-BoldItalic',
-            'italic' => $distFontDir . '/DejaVuSerif-Italic',
-            'normal' => $distFontDir . '/DejaVuSerif'
-        ]
-];
+return function ($rootDir) {
+    $distFontDir = $rootDir . '/lib/fonts';
+    return [
+        'sans-serif' =>
+            [
+                'normal' => $distFontDir . '/Helvetica',
+                'bold' => $distFontDir . '/Helvetica-Bold',
+                'italic' => $distFontDir . '/Helvetica-Oblique',
+                'bold_italic' => $distFontDir . '/Helvetica-BoldOblique'
+            ],
+        'times' =>
+            [
+                'normal' => $distFontDir . '/Times-Roman',
+                'bold' => $distFontDir . '/Times-Bold',
+                'italic' => $distFontDir . '/Times-Italic',
+                'bold_italic' => $distFontDir . '/Times-BoldItalic'
+            ],
+        'times-roman' =>
+            [
+                'normal' => $distFontDir . '/Times-Roman',
+                'bold' => $distFontDir . '/Times-Bold',
+                'italic' => $distFontDir . '/Times-Italic',
+                'bold_italic' => $distFontDir . '/Times-BoldItalic'
+            ],
+        'courier' =>
+            [
+                'normal' => $distFontDir . '/Courier',
+                'bold' => $distFontDir . '/Courier-Bold',
+                'italic' => $distFontDir . '/Courier-Oblique',
+                'bold_italic' => $distFontDir . '/Courier-BoldOblique'
+            ],
+        'helvetica' =>
+            [
+                'normal' => $distFontDir . '/Helvetica',
+                'bold' => $distFontDir . '/Helvetica-Bold',
+                'italic' => $distFontDir . '/Helvetica-Oblique',
+                'bold_italic' => $distFontDir . '/Helvetica-BoldOblique'
+            ],
+        'zapfdingbats' =>
+            [
+                'normal' => $distFontDir . '/ZapfDingbats',
+                'bold' => $distFontDir . '/ZapfDingbats',
+                'italic' => $distFontDir . '/ZapfDingbats',
+                'bold_italic' => $distFontDir . '/ZapfDingbats'
+            ],
+        'symbol' =>
+            [
+                'normal' => $distFontDir . '/Symbol',
+                'bold' => $distFontDir . '/Symbol',
+                'italic' => $distFontDir . '/Symbol',
+                'bold_italic' => $distFontDir . '/Symbol'
+            ],
+        'serif' =>
+            [
+                'normal' => $distFontDir . '/Times-Roman',
+                'bold' => $distFontDir . '/Times-Bold',
+                'italic' => $distFontDir . '/Times-Italic',
+                'bold_italic' => $distFontDir . '/Times-BoldItalic'
+            ],
+        'monospace' =>
+            [
+                'normal' => $distFontDir . '/Courier',
+                'bold' => $distFontDir . '/Courier-Bold',
+                'italic' => $distFontDir . '/Courier-Oblique',
+                'bold_italic' => $distFontDir . '/Courier-BoldOblique'
+            ],
+        'fixed' =>
+            [
+                'normal' => $distFontDir . '/Courier',
+                'bold' => $distFontDir . '/Courier-Bold',
+                'italic' => $distFontDir . '/Courier-Oblique',
+                'bold_italic' => $distFontDir . '/Courier-BoldOblique'
+            ],
+        'dejavu sans' =>
+            [
+                'bold' => $distFontDir . '/DejaVuSans-Bold',
+                'bold_italic' => $distFontDir . '/DejaVuSans-BoldOblique',
+                'italic' => $distFontDir . '/DejaVuSans-Oblique',
+                'normal' => $distFontDir . '/DejaVuSans'
+            ],
+        'dejavu sans mono' =>
+            [
+                'bold' => $distFontDir . '/DejaVuSansMono-Bold',
+                'bold_italic' => $distFontDir . '/DejaVuSansMono-BoldOblique',
+                'italic' => $distFontDir . '/DejaVuSansMono-Oblique',
+                'normal' => $distFontDir . '/DejaVuSansMono'
+            ],
+        'dejavu serif' =>
+            [
+                'bold' => $distFontDir . '/DejaVuSerif-Bold',
+                'bold_italic' => $distFontDir . '/DejaVuSerif-BoldItalic',
+                'italic' => $distFontDir . '/DejaVuSerif-Italic',
+                'normal' => $distFontDir . '/DejaVuSerif'
+            ]
+    ];
+};

--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -92,7 +92,8 @@ class FontMetrics
     public function saveFontFamilies()
     {
         // replace the path to the DOMPDF font directories with the corresponding constants (allows for more portability)
-        $cacheData = sprintf("<?php return array (%s", PHP_EOL);
+        $cacheData = sprintf("<?php return function (%s) {%s", '$fontDir', PHP_EOL);
+        $cacheData .= sprintf("return array (%s", PHP_EOL);
         foreach ($this->fontLookup as $family => $variants) {
             $cacheData .= sprintf("  '%s' => array(%s", addslashes($family), PHP_EOL);
             foreach ($variants as $variant => $path) {
@@ -103,7 +104,8 @@ class FontMetrics
             }
             $cacheData .= sprintf("  ),%s", PHP_EOL);
         }
-        $cacheData .= ") ?>";
+        $cacheData .= ");" . PHP_EOL;
+        $cacheData .= "}; ?>";
         file_put_contents($this->getCacheFile(), $cacheData);
     }
 
@@ -130,14 +132,16 @@ class FontMetrics
         if (!defined("DOMPDF_FONT_DIR")) { define("DOMPDF_FONT_DIR", $fontDir); }
 
         $file = $rootDir . "/lib/fonts/dompdf_font_family_cache.dist.php";
-        $distFonts = require $file;
+        $distFontsClosure = require $file;
+        $distFonts = $distFontsClosure($rootDir);
 
         if (!is_readable($this->getCacheFile())) {
             $this->fontLookup = $distFonts;
             return;
         }
 
-        $cacheData = require $this->getCacheFile();
+        $cacheDataClosure = require $this->getCacheFile();
+        $cacheData = $cacheDataClosure($fontDir);
 
         $this->fontLookup = [];
         if (is_array($this->fontLookup)) {
@@ -195,7 +199,7 @@ class FontMetrics
         mb_substitute_character($substchar);
         $prefix = preg_replace("[\W]", "_", $prefix);
         $prefix = preg_replace("/[^-_\w]+/", "", $prefix);
-        
+
         $localFile = $fontDir . "/" . $prefix . "_" . $remoteHash;
 
         if (isset($entry[$styleString]) && $localFile == $entry[$styleString]) {
@@ -227,7 +231,7 @@ class FontMetrics
                         break;
                     }
                 }
-                if ($chrootValid !== true) {    
+                if ($chrootValid !== true) {
                     Helpers::record_warnings(E_USER_WARNING, "Permission denied on $remoteFile. The file could not be found under the paths specified by Options::chroot.", __FILE__, __LINE__);
                     return false;
                 }


### PR DESCRIPTION
Closes #2465

I prepared a fix that works for me. Could you review it @bsweeney? Basically I have the cache file (both dist and generated) return a closure instead of an array. That way I can pass the variable into the closure and the file no longer needs to be loaded in a context where the variable exists.