### PR TITLE
Improve page break related to inline(-block) elements

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -465,42 +465,12 @@ class Frame
     //........................................................................
 
     /**
-     * Return the height of the margin box of the frame, in pt.  Meaningless
-     * unless the height has been calculated properly.
-     *
-     * @return float
-     */
-    public function get_margin_height()
-    {
-        $style = $this->_style;
-
-        return (
-            (float)$style->length_in_pt(
-                [
-                    $style->height,
-                    (float)$style->length_in_pt(
-                        [
-                            $style->border_top_width,
-                            $style->border_bottom_width,
-                            $style->margin_top,
-                            $style->margin_bottom,
-                            $style->padding_top,
-                            $style->padding_bottom
-                        ], $this->_containing_block["w"]
-                    )
-                ],
-                $this->_containing_block["h"]
-            )
-        );
-    }
-
-    /**
      * Return the width of the margin box of the frame, in pt.  Meaningless
      * unless the width has been calculated properly.
      *
      * @return float
      */
-    public function get_margin_width()
+    public function get_margin_width(): float
     {
         $style = $this->_style;
 
@@ -516,29 +486,30 @@ class Frame
     }
 
     /**
+     * Return the height of the margin box of the frame, in pt.  Meaningless
+     * unless the height has been calculated properly.
+     *
      * @return float
      */
-    public function get_break_margins()
+    public function get_margin_height(): float
     {
         $style = $this->_style;
 
-        return (
-            (float)$style->length_in_pt(
-                [
-                    //$style->height,
-                    (float)$style->length_in_pt(
-                        [
-                            $style->border_top_width,
-                            $style->border_bottom_width,
-                            $style->margin_top,
-                            $style->margin_bottom,
-                            $style->padding_top,
-                            $style->padding_bottom
-                        ], $this->_containing_block["w"]
-                    )
-                ],
-                $this->_containing_block["h"]
-            )
+        return (float)$style->length_in_pt(
+            [
+                $style->height,
+                (float)$style->length_in_pt(
+                    [
+                        $style->border_top_width,
+                        $style->border_bottom_width,
+                        $style->margin_top,
+                        $style->margin_bottom,
+                        $style->padding_top,
+                        $style->padding_bottom
+                    ], $this->_containing_block["w"]
+                )
+            ],
+            $this->_containing_block["h"]
         );
     }
 

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -909,14 +909,4 @@ abstract class AbstractFrameDecorator extends Frame
     {
         return $this->_reflower->get_min_max_width();
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    final function calculate_auto_width()
-    {
-        return $this->_reflower->calculate_auto_width();
-    }
 }

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -717,15 +717,20 @@ abstract class AbstractFrameDecorator extends Frame
             $orig_style->page_break_before = "auto";
         }
 
-        // recalculate the float offsets after paging
         $this->get_parent()->insert_child_after($split, $this);
+
         if ($this instanceof Block) {
-            foreach ($this->get_line_boxes() as $index => $line_box) {
+            // Remove the frames that will be moved to the new split node from
+            // the line boxes
+            $this->remove_frames_from_line($child);
+
+            // recalculate the float offsets after paging
+            foreach ($this->get_line_boxes() as $line_box) {
                 $line_box->get_float_offsets();
             }
         }
 
-        // Add $frame and all following siblings to the new split node
+        // Add $child and all following siblings to the new split node
         $iter = $child;
         while ($iter) {
             $frame = $iter;
@@ -736,7 +741,7 @@ abstract class AbstractFrameDecorator extends Frame
 
             // recalculate the float offsets
             if ($frame instanceof Block) {
-                foreach ($frame->get_line_boxes() as $index => $line_box) {
+                foreach ($frame->get_line_boxes() as $line_box) {
                     $line_box->get_float_offsets();
                 }
             }

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -905,7 +905,7 @@ abstract class AbstractFrameDecorator extends Frame
     /**
      * @return array
      */
-    final function get_min_max_width()
+    final function get_min_max_width(): array
     {
         return $this->_reflower->get_min_max_width();
     }

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -638,18 +638,18 @@ abstract class AbstractFrameDecorator extends Frame
     }
 
     /**
-     * split this frame at $child.
+     * Split this frame at $child.
      * The current frame is cloned and $child and all children following
      * $child are added to the clone.  The clone is then passed to the
      * current frame's parent->split() method.
      *
-     * @param Frame $child
-     * @param boolean $force_pagebreak
+     * @param Frame|null $child
+     * @param bool $force_pagebreak
      *
      * @throws Exception
      * @return void
      */
-    function split(Frame $child = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         // decrement any counters that were incremented on the current node, unless that node is the body
         $style = $this->_frame->get_style();

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -258,20 +258,14 @@ abstract class AbstractFrameDecorator extends Frame
         return $this->_dompdf;
     }
 
-    /**
-     * @return float
-     */
-    function get_margin_height()
-    {
-        return $this->_frame->get_margin_height();
-    }
-
-    /**
-     * @return float
-     */
-    function get_margin_width()
+    public function get_margin_width(): float
     {
         return $this->_frame->get_margin_width();
+    }
+
+    public function get_margin_height(): float
+    {
+        return $this->_frame->get_margin_height();
     }
 
     /**

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -10,6 +10,7 @@ namespace Dompdf\FrameDecorator;
 use Dompdf\Dompdf;
 use Dompdf\Frame;
 use Dompdf\LineBox;
+use Dompdf\FrameDecorator\Text as TextFrameDecorator;
 
 /**
  * Decorates frames for block layout
@@ -280,10 +281,24 @@ class Block extends AbstractFrameDecorator
     /**
      * @param bool $br
      */
-    function add_line($br = false)
+    function add_line(bool $br = false)
     {
-        $this->_line_boxes[$this->_cl]->br = $br;
-        $y = $this->_line_boxes[$this->_cl]->y + $this->_line_boxes[$this->_cl]->h;
+        $line = $this->_line_boxes[$this->_cl];
+        $frames = $line->get_frames();
+
+        if (count($frames) > 0) {
+            $last_frame = $frames[count($frames) - 1];
+    
+            if ($last_frame instanceof TextFrameDecorator
+                && !$last_frame->is_pre()
+            ) {
+                $last_frame->get_reflower()->trim_trailing_ws();
+                $line->recalculate_width();
+            }
+        }
+
+        $line->br = $br;
+        $y = $line->y + $line->h;
 
         $new_line = new LineBox($this, $y);
 

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -32,6 +32,29 @@ class Inline extends AbstractFrameDecorator
         parent::__construct($frame, $dompdf);
     }
 
+    /**
+     * Vertical padding, border, and margin do not apply when determining the
+     * height for inline frames.
+     *
+     * http://www.w3.org/TR/CSS21/visudet.html#inline-non-replaced
+     *
+     * The vertical padding, border and margin of an inline, non-replaced box
+     * start at the top and bottom of the content area, not the
+     * 'line-height'. But only the 'line-height' is used to calculate the
+     * height of the line box.
+     *
+     * @return float
+     */
+    public function get_margin_height(): float
+    {
+        $style = $this->get_style();
+        $font = $style->font_family;
+        $size = $style->font_size;
+        $fontHeight = $this->_dompdf->getFontMetrics()->getFontHeight($font, $size);
+
+        return ($style->line_height / ($size > 0 ? $size : 1)) * $fontHeight;
+    }
+
     public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         if (is_null($child)) {

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -32,19 +32,14 @@ class Inline extends AbstractFrameDecorator
         parent::__construct($frame, $dompdf);
     }
 
-    /**
-     * @param Frame|null $frame
-     * @param bool $force_pagebreak
-     * @throws Exception
-     */
-    function split(Frame $frame = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
-        if (is_null($frame)) {
+        if (is_null($child)) {
             $this->get_parent()->split($this, $force_pagebreak);
             return;
         }
 
-        if ($frame->get_parent() !== $this) {
+        if ($child->get_parent() !== $this) {
             throw new Exception("Unable to split: frame is not a child of this one.");
         }
 
@@ -76,16 +71,16 @@ class Inline extends AbstractFrameDecorator
         $style->border_left_width = 0;
 
         //On continuation of inline element on next line,
-        //don't repeat non-vertically repeatble background images
-        //See e.g. in testcase image_variants, long desriptions
+        //don't repeat non-vertically repeatable background images
+        //See e.g. in testcase image_variants, long descriptions
         if (($url = $style->background_image) && $url !== "none"
             && ($repeat = $style->background_repeat) && $repeat !== "repeat" && $repeat !== "repeat-y"
         ) {
             $style->background_image = "none";
         }
 
-        // Add $frame and all following siblings to the new split node
-        $iter = $frame;
+        // Add $child and all following siblings to the new split node
+        $iter = $child;
         while ($iter) {
             $frame = $iter;
             $iter = $iter->get_next_sibling();

--- a/src/FrameDecorator/ListBullet.php
+++ b/src/FrameDecorator/ListBullet.php
@@ -38,14 +38,14 @@ class ListBullet extends AbstractFrameDecorator
     }
 
     /**
-     * @return float|int
+     * @return float
      */
-    function get_margin_width()
+    public function get_margin_width(): float
     {
         $style = $this->_frame->get_style();
 
         if ($style->list_style_type === "none") {
-            return 0;
+            return 0.0;
         }
 
         return $style->font_size * self::BULLET_SIZE + 2 * self::BULLET_PADDING;
@@ -54,14 +54,14 @@ class ListBullet extends AbstractFrameDecorator
     /**
      * hits only on "inset" lists items, to increase height of box
      *
-     * @return float|int
+     * @return float
      */
-    function get_margin_height()
+    public function get_margin_height(): float
     {
         $style = $this->_frame->get_style();
 
         if ($style->list_style_type === "none") {
-            return 0;
+            return 0.0;
         }
 
         return $style->font_size * self::BULLET_SIZE + 2 * self::BULLET_PADDING;

--- a/src/FrameDecorator/ListBulletImage.php
+++ b/src/FrameDecorator/ListBulletImage.php
@@ -124,7 +124,7 @@ class ListBulletImage extends AbstractFrameDecorator
      *
      * @return int
      */
-    function get_margin_width()
+    public function get_margin_width(): float
     {
         //ignore image width, use same width as on predefined bullet ListBullet
         //for proper alignment of bullet image and text. Allow image to not fitting on left border.
@@ -136,7 +136,7 @@ class ListBulletImage extends AbstractFrameDecorator
         // Small hack to prevent indenting of list text
         // Image might not exist, then position like on list_bullet_frame_decorator fallback to none.
         if ($this->_frame->get_style()->list_style_position === "outside" || $this->_width == 0) {
-            return 0;
+            return 0.0;
         }
         //This aligns the "inside" image position with the text.
         //The text starts to the right of the image.
@@ -149,9 +149,9 @@ class ListBulletImage extends AbstractFrameDecorator
     /**
      * Override get_margin_height()
      *
-     * @return int
+     * @return float
      */
-    function get_margin_height()
+    public function get_margin_height(): float
     {
         //Hits only on "inset" lists items, to increase height of box
         //based on image height

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -174,7 +174,7 @@ class Page extends AbstractFrameDecorator
             return null;
         }
 
-        $block_types = ["block", "list-item", "table", "table-row", "inline"];
+        $block_types = ["block", "list-item", "table", "table-row", "inline", "inline-block"];
         $page_breaks = ["always", "left", "right"];
 
         $style = $frame->get_style();
@@ -353,7 +353,7 @@ class Page extends AbstractFrameDecorator
 
         } // Inline frames (2):
         else {
-            if (in_array($display, Style::$INLINE_TYPES)) {
+            if (in_array($display, ["inline", "inline-block"], true)) {
 
                 // Avoid breaks within table-cells
                 if ($this->_in_table) {

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -649,11 +649,7 @@ class Page extends AbstractFrameDecorator
 
     //........................................................................
 
-    /**
-     * @param Frame|null $frame
-     * @param bool $force_pagebreak
-     */
-    function split(Frame $frame = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         // Do nothing
     }

--- a/src/FrameDecorator/Table.php
+++ b/src/FrameDecorator/Table.php
@@ -110,16 +110,16 @@ class Table extends AbstractFrameDecorator
     //........................................................................
 
     /**
-     * split the table at $row.  $row and all subsequent rows will be
-     * added to the clone.  This method is overidden in order to remove
+     * Split the table at $row.  $row and all subsequent rows will be
+     * added to the clone.  This method is overridden in order to remove
      * frames from the cellmap properly.
      *
-     * @param Frame $child
+     * @param Frame|null $child
      * @param bool $force_pagebreak
      *
      * @return void
      */
-    public function split(Frame $child = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         if (is_null($child)) {
             parent::split();

--- a/src/FrameDecorator/TableRow.php
+++ b/src/FrameDecorator/TableRow.php
@@ -54,7 +54,7 @@ class TableRow extends AbstractFrameDecorator
         }
     }
 
-    function split(Frame $child = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         $this->_already_pushed = true;
         

--- a/src/FrameDecorator/TableRowGroup.php
+++ b/src/FrameDecorator/TableRowGroup.php
@@ -34,12 +34,12 @@ class TableRowGroup extends AbstractFrameDecorator
     /**
      * Override split() to remove all child rows and this element from the cellmap
      *
-     * @param Frame $child
+     * @param Frame|null $child
      * @param bool $force_pagebreak
      *
      * @return void
      */
-    function split(Frame $child = null, $force_pagebreak = false)
+    public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         if (is_null($child)) {
             parent::split();

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -45,6 +45,7 @@ class Text extends AbstractFrameDecorator
     {
         parent::reset();
         $this->_text_spacing = null;
+        $this->_reflower->reset();
     }
 
     // Accessor methods

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -82,35 +82,28 @@ class Text extends AbstractFrameDecorator
     //........................................................................
 
     /**
-     * Vertical margins & padding do not apply to text frames
+     * Vertical padding, border, and margin do not apply when determining the
+     * height for inline frames.
      *
-     * http://www.w3.org/TR/CSS21/visudet.html#inline-non-replaced:
+     * http://www.w3.org/TR/CSS21/visudet.html#inline-non-replaced
      *
      * The vertical padding, border and margin of an inline, non-replaced box
      * start at the top and bottom of the content area, not the
      * 'line-height'. But only the 'line-height' is used to calculate the
      * height of the line box.
      *
-     * @return float|int
+     * @return float
      */
-    function get_margin_height()
+    public function get_margin_height(): float
     {
-        // This function is called in add_frame_to_line() and is used to
-        // determine the line height, so we actually want to return the
-        // 'line-height' property, not the actual margin box
+        // This function is also called in add_frame_to_line() and is used to
+        // determine the line height
         $style = $this->get_style();
         $font = $style->font_family;
         $size = $style->font_size;
+        $fontHeight = $this->_dompdf->getFontMetrics()->getFontHeight($font, $size);
 
-        /*
-        Helpers::pre_r('-----');
-        Helpers::pre_r($style->line_height);
-        Helpers::pre_r($style->font_size);
-        Helpers::pre_r($this->_dompdf->getFontMetrics()->getFontHeight($font, $size));
-        Helpers::pre_r(($style->line_height / $size) * $this->_dompdf->getFontMetrics()->getFontHeight($font, $size));
-        */
-
-        return ($style->line_height / ($size > 0 ? $size : 1)) * $this->_dompdf->getFontMetrics()->getFontHeight($font, $size);
+        return ($style->line_height / ($size > 0 ? $size : 1)) * $fontHeight;
     }
 
     /**

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -558,14 +558,4 @@ abstract class AbstractFrameReflower
             $frame->append_child($new_frame);
         }
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        return $this->_frame->get_margin_width();
-    }
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -893,12 +893,12 @@ class Block extends AbstractFrameReflower
         $style->top = $top;
         $style->bottom = $bottom;
 
-        $orig_style = $this->_frame->get_original_style();
-
         $needs_reposition = ($style->position === "absolute" && ($style->right !== "auto" || $style->bottom !== "auto"));
 
         // Absolute positioning measurement
         if ($needs_reposition) {
+            $orig_style = $this->_frame->get_original_style();
+
             if ($orig_style->width === "auto" && ($orig_style->left === "auto" || $orig_style->right === "auto")) {
                 $width = 0;
                 foreach ($this->_frame->get_line_boxes() as $line) {
@@ -935,33 +935,5 @@ class Block extends AbstractFrameReflower
                 $block->add_line();
             }
         }
-    }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        $width = 0;
-
-        foreach ($this->_frame->get_line_boxes() as $line) {
-            $line_width = 0;
-
-            foreach ($line->get_frames() as $frame) {
-                if ($frame->get_original_style()->width == 'auto') {
-                    $line_width += $frame->calculate_auto_width();
-                } else {
-                    $line_width += $frame->get_margin_width();
-                }
-            }
-
-            $width = max($line_width, $width);
-        }
-
-        $this->_frame->get_style()->width = $width;
-
-        return $this->_frame->get_margin_width();
     }
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -239,12 +239,9 @@ class Block extends AbstractFrameReflower
         $right =  $calculate_width['right'];
 
         // Handle min/max width
+        // https://www.w3.org/TR/CSS21/visudet.html#min-max-widths
         $min_width = $style->length_in_pt($style->min_width, $cb["w"]);
         $max_width = $style->length_in_pt($style->max_width, $cb["w"]);
-
-        if ($max_width !== "none" && $min_width > $max_width) {
-            list($max_width, $min_width) = [$min_width, $max_width];
-        }
 
         if ($max_width !== "none" && $width > $max_width) {
             extract($this->_calculate_width($max_width));

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -146,6 +146,21 @@ class Block extends AbstractFrameReflower
                     $rm = $diff;
                 }
 
+            } else if ($style->float !== "none" || $style->display === "inline-block") {
+                // Shrink-to-fit width for float and inline block:
+                // https://www.w3.org/TR/CSS21/visudet.html#float-width
+                // https://www.w3.org/TR/CSS21/visudet.html#inlineblock-width
+
+                if ($width === "auto") {
+                    [$min, $max] = $this->get_min_max_content_width();
+                    $width = min(max($min, $diff), $max);
+                }
+                if ($lm === "auto") {
+                    $lm = 0;
+                }
+                if ($rm === "auto") {
+                    $rm = 0;
+                }
             } else {
                 // Find auto properties and get them to take up the slack
                 if ($width === "auto") {
@@ -894,25 +909,6 @@ class Block extends AbstractFrameReflower
 
             $style->left = $orig_style->left;
             $style->right = $orig_style->right;
-        }
-
-        // Calculate inline-block / float auto-widths
-        if (($style->display === "inline-block" || $style->float !== 'none') && $orig_style->width === 'auto') {
-            $width = 0;
-
-            foreach ($this->_frame->get_line_boxes() as $line) {
-                $line->recalculate_width();
-
-                $width = max($line->w, $width);
-            }
-
-            if ($width === 0) {
-                foreach ($this->_frame->get_children() as $child) {
-                    $width += $child->calculate_auto_width();
-                }
-            }
-
-            $style->width = $width;
         }
 
         $this->_text_align();

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -229,12 +229,7 @@ class Block extends AbstractFrameReflower
             throw new Exception("Box property calculation requires containing block width");
         }
 
-        // Treat width 100% as auto
-        if ($style->width === "100%") {
-            $width = "auto";
-        } else {
-            $width = $style->length_in_pt($style->width, $cb["w"]);
-        }
+        $width = $style->length_in_pt($style->width, $cb["w"]);
 
         $calculate_width = $this->_calculate_width($width);
         $margin_left = $calculate_width['margin_left'];

--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -54,10 +54,7 @@ class Image extends AbstractFrameReflower
         }
     }
 
-    /**
-     * @return array
-     */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         $frame = $this->_frame;
 

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -95,28 +95,6 @@ class Inline extends AbstractFrameReflower
     }
 
     /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        $width = 0;
-
-        foreach ($this->_frame->get_children() as $child) {
-            if ($child->get_original_style()->width == 'auto') {
-                $width += $child->calculate_auto_width();
-            } else {
-                $width += $child->get_margin_width();
-            }
-        }
-
-        $this->_frame->get_style()->width = $width;
-
-        return $this->_frame->get_margin_width();
-    }
-
-    /**
      * Get the minimum width needed for the first line of the frame, including
      * the margin box.
      *

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -514,10 +514,7 @@ class Table extends AbstractFrameReflower
         }
     }
 
-    /**
-     * @return array|null
-     */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         if (!is_null($this->_min_max_cache)) {
             return $this->_min_max_cache;

--- a/src/FrameReflower/TableRow.php
+++ b/src/FrameReflower/TableRow.php
@@ -73,7 +73,7 @@ class TableRow extends AbstractFrameReflower
     /**
      * @throws Exception
      */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         throw new Exception("Min/max width is undefined for table rows");
     }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -418,7 +418,7 @@ class Text extends AbstractFrameReflower
 
     //........................................................................
 
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         /*if ( !is_null($this->_min_max_cache)  )
           return $this->_min_max_cache;*/

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -607,14 +607,4 @@ class Text extends AbstractFrameReflower
     {
         return $this->fontMetrics;
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        return $this->_frame->recalculate_width();
-    }
 }

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -300,7 +300,7 @@ class LineBox
         $width = 0;
 
         foreach ($this->get_frames() as $frame) {
-            $width += $frame->calculate_auto_width();
+            $width += $frame->get_margin_width();
         }
 
         return $this->w = $width;

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -259,6 +259,38 @@ class LineBox
     }
 
     /**
+     * Remove the frame at the given index and all following frames from the
+     * line.
+     *
+     * @param int $index
+     */
+    public function remove_frames(int $index): void
+    {
+        $lastIndex = count($this->_frames) - 1;
+
+        if ($index < 0 || $index > $lastIndex) {
+            return;
+        }
+
+        for ($i = $lastIndex; $i >= $index; $i--) {
+            $f = $this->_frames[$i];
+            unset($this->_frames[$i]);
+            $this->w -= $f->get_margin_width();
+        }
+
+        // Reset array indices
+        $this->_frames = array_values($this->_frames);
+
+        // Recalculate the height of the line
+        $h = 0.0;
+        foreach ($this->_frames as $f) {
+            $h = max($h, $f->get_margin_height());
+        }
+
+        $this->h = $h;
+    }
+
+    /**
      * Recalculate LineBox width based on the contained frames total width.
      *
      * @return float

--- a/src/Positioner/Inline.php
+++ b/src/Positioner/Inline.php
@@ -58,12 +58,12 @@ class Inline extends AbstractPositioner
                 $line = $p->get_current_line_box();
             }
         } elseif ($frame->is_inline_block()) {
-            $min_max = $reflower->get_min_max_width();
+            $width = $frame->get_margin_width();
 
             // If an inline-block frame doesn't fit in the current line, it
             // should break to a new line. Inline-block elements are formatted
             // as atomic inline boxes
-            if ($min_max["min"] > ($cb["w"] - $line->left - $line->w - $line->right)) {
+            if ($width > ($cb["w"] - $line->left - $line->w - $line->right)) {
                 $p->add_line();
                 $line = $p->get_current_line_box();
             }


### PR DESCRIPTION
* Inline frames now properly report their height, the same as text frames. This resolves inline frames extending into the page margins instead of breaking onto a new page.
* The positioning of inline frames has also been improved, allowing line breaks within them in more instances (instead of breaking the whole frame).
* Allow line breaks and page breaks before inline-block elements, which were not allowed before.

Nested inline frames with margin, border, or padding still cause bugs at line breaks, because they are added to the text children on-the-fly. To properly fix these cases, it would probably be best to refactor the code in such a way that margin, border, and padding are properly handled on the inline frame itself, instead of being added to first resp. last child. It might be even worth considering always containing text frames in an anonymous inline box if needed; that could allow handling these properties consistently while simplifying the code. But the changes should improve the situation for now, nonetheless.

I have a few test cases in preparation that will demonstrate several broken scenarios that are fixed by this PR.