### PR TITLE
Fix logic error in `add_frame_to_line` function

### DIFF
--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -177,8 +177,10 @@ class Block extends AbstractFrameDecorator
         */
         // End debugging
 
+        // The containing block of `$frame` is the current block frame
+        $available_width = $frame->get_containing_block("w");
         $line = $this->_line_boxes[$this->_cl];
-        if ($line->left + $line->w + $line->right + $w > $this->get_containing_block("w")) {
+        if ($line->left + $line->w + $line->right + $w > $available_width) {
             $this->add_line();
         }
 


### PR DESCRIPTION
As far as I can see, the block should check its own content-box width, not the content-box width of its containing block when placing child frames. I am not completely sure that I haven't overlooked anything that might give reason to the original code, but it looks like an obvious logic error now.

Fixes erroneous line breaks after inline frames when a block has a larger width than its parent block. See #2476.