### PR TITLE
Improve support for relative positioning

### DIFF
--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -193,6 +193,41 @@ abstract class AbstractFrameReflower
     }
 
     /**
+     * Handle relative positioning according to
+     * https://www.w3.org/TR/CSS21/visuren.html#relative-positioning.
+     *
+     * @param Frame $frame The frame to handle.
+     */
+    protected function position_relative(Frame $frame): void
+    {
+        $style = $frame->get_style();
+
+        if ($style->position === "relative") {
+            $cb = $frame->get_containing_block();
+            $top = $style->length_in_pt($style->top, $cb["h"]);
+            $right = $style->length_in_pt($style->right, $cb["w"]);
+            $bottom = $style->length_in_pt($style->bottom, $cb["h"]);
+            $left = $style->length_in_pt($style->left, $cb["w"]);
+
+            // FIXME RTL case:
+            // if ($left !== "auto" && $right !== "auto") $left = -$right;
+            if ($left === "auto" && $right === "auto") {
+                $left = 0;
+            } elseif ($left === "auto") {
+                $left = -(float) $right;
+            }
+
+            if ($top === "auto" && $bottom === "auto") {
+                $top = 0;
+            } elseif ($top === "auto") {
+                $top = -(float) $bottom;
+            }
+
+            $frame->move((float) $left, (float) $top);
+        }
+    }
+
+    /**
      * @param Block|null $block
      * @return mixed
      */

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -908,6 +908,11 @@ class Block extends AbstractFrameReflower
             $this->_frame->move($new_x - $x, $new_y - $y, true);
         }
 
+        // Handle relative positioning
+        foreach ($this->_frame->get_children() as $child) {
+            $this->position_relative($child);
+        }
+
         if ($block && $this->_frame->is_in_flow()) {
             $block->add_frame_to_line($this->_frame);
 

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -77,6 +77,11 @@ class Inline extends AbstractFrameReflower
             $child->set_containing_block($cb);
             $child->reflow($block);
         }
+
+        // Handle relative positioning
+        foreach ($this->_frame->get_children() as $child) {
+            $this->position_relative($child);
+        }
     }
 
     /**

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -117,5 +117,10 @@ class TableCell extends Block
         $style->height = $height;
         $this->_text_align();
         $this->vertical_align();
+
+        // Handle relative positioning
+        foreach ($this->_frame->get_children() as $child) {
+            $this->position_relative($child);
+        }
     }
 }

--- a/src/Positioner/Block.php
+++ b/src/Positioner/Block.php
@@ -32,23 +32,11 @@ class Block extends AbstractPositioner
                 $p->add_line(true);
             }
             $y = $p->get_current_line_box()->y;
-
         } else {
             $y = $cb["y"];
         }
 
         $x = $cb["x"];
-
-        // Relative positionning
-        if ($style->position === "relative") {
-            $top = (float)$style->length_in_pt($style->top, $cb["h"]);
-            //$right =  (float)$style->length_in_pt($style->right,  $cb["w"]);
-            //$bottom = (float)$style->length_in_pt($style->bottom, $cb["h"]);
-            $left = (float)$style->length_in_pt($style->left, $cb["w"]);
-
-            $x += $left;
-            $y += $top;
-        }
 
         $frame->set_position($x, $y);
     }


### PR DESCRIPTION
* Move handling of relative positioning to after the reflow process, so
that it does not affect layout.
* Handle `right` and `bottom` properties plus `auto` values (except for
RTL language support, which is an easy FIXME).
* As a side-effect, this adds support for relative positioning on inline
and inline-block elements.

Fixes #516