### PR TITLE
Fix table column widths after page break

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -547,18 +547,9 @@ class Cellmap
         $node = $frame->get_node();
 
         // Determine where this cell is going
-        $colspan = $node->getAttribute("colspan");
-        $rowspan = $node->getAttribute("rowspan");
+        $colspan = max((int) $node->getAttribute("colspan"), 1);
+        $rowspan = max((int) $node->getAttribute("rowspan"), 1);
 
-        if (!$colspan) {
-            $colspan = 1;
-            $node->setAttribute("colspan", 1);
-        }
-
-        if (!$rowspan) {
-            $rowspan = 1;
-            $node->setAttribute("rowspan", 1);
-        }
         $key = $frame->get_id();
 
         $bp = $style->get_border_properties();
@@ -646,7 +637,7 @@ class Cellmap
             $val = null;
             if (Helpers::is_percent($width) && $colspan === 1) {
                 $var = "percent";
-                $val = (float)rtrim($width, "% ") / $colspan;
+                $val = (float)rtrim($width, "% ");
             } else if ($width !== "auto" && $colspan === 1) {
                 $var = "absolute";
                 $val = $style->length_in_pt($frame_min);


### PR DESCRIPTION
Node attributes are always string, so when a table was laid out, and then a page break occurred before the table at a later point, `$colspan` and `$rowspan` would always be string values and fail the checks below, most notably the check where the minimum column width is set, so that all columns received `0` minimum width.

I don't think setting the `colspan` and `rowspan` attributes when they weren't specified served any useful purpose, as these attributes are only read at this point, so I simply removed that logic. If it was meant as an optimization in case the cell map is calculated again, it might be better instead to avoid the whole process unless necessary, e.g. by only recalculating the cell map if the width of the containing block for the table has changed since the last calculation.

Fixes #2395