### PR TITLE
Add support for any inline-positioned frames in text alignment

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -57,7 +57,7 @@ abstract class AbstractFrameDecorator extends Frame
     /**
      * Reflower object used to calculate frame dimensions (Strategy pattern)
      *
-     * @var \Dompdf\FrameReflower\AbstractFrameReflower
+     * @var AbstractFrameReflower
      */
     protected $_reflower;
 
@@ -567,7 +567,15 @@ abstract class AbstractFrameDecorator extends Frame
     }
 
     /**
-     * @return \Dompdf\FrameReflower\AbstractFrameReflower
+     * @return AbstractPositioner
+     */
+    function get_positioner()
+    {
+        return $this->_positioner;
+    }
+
+    /**
+     * @return AbstractFrameReflower
      */
     function get_reflower()
     {

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -12,6 +12,7 @@ use Dompdf\Frame;
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\TableCell as TableCellFrameDecorator;
 use Dompdf\FrameDecorator\Text as TextFrameDecorator;
+use Dompdf\Positioner\Inline as InlinePositioner;
 use Dompdf\Exception;
 use Dompdf\Css\Style;
 
@@ -441,10 +442,9 @@ class Block extends AbstractFrameReflower
                     }
 
                     foreach ($line->get_frames() as $frame) {
-                        if ($frame instanceof BlockFrameDecorator) {
-                            continue;
+                        if ($frame->get_positioner() instanceof InlinePositioner) {
+                            $frame->move($line->left, 0);
                         }
-                        $frame->set_position($frame->get_position("x") + $line->left);
                     }
                 }
                 return;
@@ -455,12 +455,9 @@ class Block extends AbstractFrameReflower
                     $dx = $width - $line->w - $line->right;
 
                     foreach ($line->get_frames() as $frame) {
-                        // Block frames are not aligned by text-align
-                        if ($frame instanceof BlockFrameDecorator) {
-                            continue;
+                        if ($frame->get_positioner() instanceof InlinePositioner) {
+                            $frame->move($dx, 0);
                         }
-
-                        $frame->set_position($frame->get_position("x") + $dx);
                     }
                 }
                 break;
@@ -476,43 +473,48 @@ class Block extends AbstractFrameReflower
                     }
                 }
 
-                // One space character's width. Will be used to get a more accurate spacing
-                $space_width = $this->get_dompdf()->getFontMetrics()->getTextWidth(" ", $style->font_family, $style->font_size);
-
                 foreach ($lines as $line) {
-                    if ($line->left) {
-                        foreach ($line->get_frames() as $frame) {
-                            if (!$frame instanceof TextFrameDecorator) {
-                                continue;
-                            }
+                    $other_frame_count = 0;
 
-                            $frame->set_position($frame->get_position("x") + $line->left);
+                    foreach ($line->get_frames() as $frame) {
+                        if (!($frame instanceof TextFrameDecorator)) {
+                            $other_frame_count++;
                         }
                     }
 
+                    if ($line->left) {
+                        foreach ($line->get_frames() as $frame) {
+                            if ($frame->get_positioner() instanceof InlinePositioner) {
+                                $frame->move($line->left, 0);
+                            }
+                        }
+                    }
+
+                    $word_count = $line->wc + $other_frame_count;
+
                     // Set the spacing for each child
-                    if ($line->wc > 1) {
-                        $spacing = ($width - ($line->left + $line->w + $line->right)) / ($line->wc - 1);
+                    if ($word_count > 1) {
+                        $spacing = ($width - ($line->left + $line->w + $line->right)) / ($word_count - 1);
                     } else {
                         $spacing = 0;
                     }
 
                     $dx = 0;
                     foreach ($line->get_frames() as $frame) {
-                        if (!$frame instanceof TextFrameDecorator) {
-                            continue;
+                        if ($frame instanceof TextFrameDecorator) {
+                            $text = $frame->get_text();
+                            $spaces = mb_substr_count($text, " ");
+
+                            $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
+                            $_spacing = $spacing + $char_spacing;
+
+                            $frame->move($dx, 0);
+                            $frame->set_text_spacing($_spacing);
+
+                            $dx += $spaces * $_spacing;
+                        } else {
+                            $frame->move($dx, 0);
                         }
-
-                        $text = $frame->get_text();
-                        $spaces = mb_substr_count($text, " ");
-
-                        $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
-                        $_spacing = $spacing + $char_spacing;
-
-                        $frame->set_position($frame->get_position("x") + $dx);
-                        $frame->set_text_spacing($_spacing);
-
-                        $dx += $spaces * $_spacing;
                     }
 
                     // The line (should) now occupy the entire width
@@ -522,10 +524,9 @@ class Block extends AbstractFrameReflower
                 // Adjust the last line if necessary
                 if ($last_line->left) {
                     foreach ($last_line->get_frames() as $frame) {
-                        if ($frame instanceof BlockFrameDecorator) {
-                            continue;
+                        if ($frame->get_positioner() instanceof InlinePositioner) {
+                            $frame->move($last_line->left, 0);
                         }
-                        $frame->set_position($frame->get_position("x") + $last_line->left);
                     }
                 }
                 break;
@@ -537,12 +538,9 @@ class Block extends AbstractFrameReflower
                     $dx = ($width + $line->left - $line->w - $line->right) / 2;
 
                     foreach ($line->get_frames() as $frame) {
-                        // Block frames are not aligned by text-align
-                        if ($frame instanceof BlockFrameDecorator) {
-                            continue;
+                        if ($frame->get_positioner() instanceof InlinePositioner) {
+                            $frame->move($dx, 0);
                         }
-
-                        $frame->set_position($frame->get_position("x") + $dx);
                     }
                 }
                 break;

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -505,13 +505,10 @@ class Block extends AbstractFrameReflower
                             $text = $frame->get_text();
                             $spaces = mb_substr_count($text, " ");
 
-                            $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
-                            $_spacing = $spacing + $char_spacing;
-
                             $frame->move($dx, 0);
-                            $frame->set_text_spacing($_spacing);
+                            $frame->set_text_spacing($spacing);
 
-                            $dx += $spaces * $_spacing;
+                            $dx += $spaces * $spacing;
                         } else {
                             $frame->move($dx, 0);
                         }


### PR DESCRIPTION
This notably adds support for inline-block.

The second commit needs #2414 to work properly. What the old code did, was basically undo the error in text-width calculation with letter spacing for the CPDF backend when text was justify aligned.

Fixes #1761