### PR TITLE
Add support for webp images

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -606,7 +606,7 @@ class CPDF implements Canvas
     }
 
     /**
-     * Convert a GIF or BMP image to a PNG image
+     * Convert image to a PNG image
      *
      * @param string $image_url
      * @param int $type
@@ -614,7 +614,7 @@ class CPDF implements Canvas
      * @throws Exception
      * @return string The url of the newly converted image
      */
-    protected function _convert_gif_bmp_to_png($image_url, $type)
+    protected function _convert_to_png($image_url, $type)
     {
         $func_name = "imagecreatefrom$type";
 
@@ -859,12 +859,14 @@ class CPDF implements Canvas
                 $this->_pdf->addJpegFromFile($img, $x, $this->y($y) - $h, $w, $h);
                 break;
 
+            case "webp":
+            /** @noinspection PhpMissingBreakStatementInspection */
             case "gif":
             /** @noinspection PhpMissingBreakStatementInspection */
             case "bmp":
-                if ($debug_png) print '!!!bmp or gif!!!';
-                // @todo use cache for BMP and GIF
-                $img = $this->_convert_gif_bmp_to_png($img, $type);
+                if ($debug_png) print "!!!{$type}!!!";
+                // @todo use cache for converted images (BMP/GIF/WebP)
+                $img = $this->_convert_to_png($img, $type);
 
             case "png":
                 if ($debug_png) print '!!!png!!!';

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -637,6 +637,7 @@ class Helpers
             IMAGETYPE_GIF  => "gif",
             IMAGETYPE_BMP  => "bmp",
             IMAGETYPE_PNG  => "png",
+            IMAGETYPE_WEBP => "webp",
         ];
 
         $type = isset($types[$type]) ? $types[$type] : null;

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -159,7 +159,7 @@ class Cache
                 list($width, $height, $type) = Helpers::dompdf_getimagesize($resolved_url, $dompdf->getHttpContext());
 
                 // Known image type
-                if ($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg"])) {
+                if ($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg","webp"])) {
                     //Don't put replacement image into cache - otherwise it will be deleted on cache cleanup.
                     //Only execute on successful caching of remote image.
                     if ($enable_remote && $remote || $data_uri) {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -277,6 +277,10 @@ abstract class AbstractRenderer
                     $src = imagecreatefromjpeg($img);
                     break;
 
+                case "webp":
+                    $src = imagecreatefromwebp($img);
+                    break;
+
                 case "gif":
                     $src = imagecreatefromgif($img);
                     break;


### PR DESCRIPTION
WebP is supported by PHP7.1+ which is also the current minimum requirement for dompdf.

This PR utilizes the same methods used for converting GIF & BMP to PNG, adding support for webp.

closes #1276

