### PR TITLE
Remove obsolete font-subsetting handling for generated content

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -1032,15 +1032,6 @@ class CPDF implements Canvas
     }
 
     /**
-     * @param $font
-     * @param $string
-     */
-    public function register_string_subset($font, $string)
-    {
-        $this->_pdf->registerText($font, $string);
-    }
-
-    /**
      * @param string $font
      * @param float $size
      * @return float|int

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -532,13 +532,6 @@ abstract class AbstractFrameReflower
 
         if ($style->content && $frame->get_node()->nodeName === "dompdf_generated") {
             $content = $this->_parse_content();
-            // add generated content to the font subset
-            // FIXME: This is currently too late because the font subset has already been generated.
-            //        See notes in issue #750.
-            if ($frame->get_dompdf()->getOptions()->getIsFontSubsettingEnabled() && $frame->get_dompdf()->get_canvas() instanceof CPDF) {
-                $frame->get_dompdf()->get_canvas()->register_string_subset($style->font_family, $content);
-            }
-
             $node = $frame->get_node()->ownerDocument->createTextNode($content);
 
             $new_style = $style->get_stylesheet()->create_style();


### PR DESCRIPTION
This should not be needed anymore since #2149. The text is registered when it is added to the canvas, as with regular text nodes.