### PR TITLE
Remove erroneous ‘degenerate’ case handling in `get_min_max_width`

### DIFF
--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -260,15 +260,6 @@ abstract class AbstractFrameReflower
         $cb_w = $this->_frame->get_containing_block("w");
         $delta = (float)$style->length_in_pt($dims, $cb_w);
 
-        // Handle degenerate case
-        if (!$this->_frame->get_first_child()) {
-            return $this->_min_max_cache = [
-                $delta, $delta,
-                "min" => $delta,
-                "max" => $delta,
-            ];
-        }
-
         $low = [];
         $high = [];
 


### PR DESCRIPTION
If the frame has no children, it might still have a fixed width set.

Fixes #2366