### PR TITLE
Improve page break related to inline(-block) elements

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -717,15 +717,20 @@ abstract class AbstractFrameDecorator extends Frame
             $orig_style->page_break_before = "auto";
         }
 
-        // recalculate the float offsets after paging
         $this->get_parent()->insert_child_after($split, $this);
+
         if ($this instanceof Block) {
-            foreach ($this->get_line_boxes() as $index => $line_box) {
+            // Remove the frames that will be moved to the new split node from
+            // the line boxes
+            $this->remove_frames_from_line($child);
+
+            // recalculate the float offsets after paging
+            foreach ($this->get_line_boxes() as $line_box) {
                 $line_box->get_float_offsets();
             }
         }
 
-        // Add $frame and all following siblings to the new split node
+        // Add $child and all following siblings to the new split node
         $iter = $child;
         while ($iter) {
             $frame = $iter;
@@ -736,7 +741,7 @@ abstract class AbstractFrameDecorator extends Frame
 
             // recalculate the float offsets
             if ($frame instanceof Block) {
-                foreach ($frame->get_line_boxes() as $index => $line_box) {
+                foreach ($frame->get_line_boxes() as $line_box) {
                     $line_box->get_float_offsets();
                 }
             }

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -10,6 +10,7 @@ namespace Dompdf\FrameDecorator;
 use Dompdf\Dompdf;
 use Dompdf\Frame;
 use Dompdf\LineBox;
+use Dompdf\FrameDecorator\Text as TextFrameDecorator;
 
 /**
  * Decorates frames for block layout
@@ -280,10 +281,24 @@ class Block extends AbstractFrameDecorator
     /**
      * @param bool $br
      */
-    function add_line($br = false)
+    function add_line(bool $br = false)
     {
-        $this->_line_boxes[$this->_cl]->br = $br;
-        $y = $this->_line_boxes[$this->_cl]->y + $this->_line_boxes[$this->_cl]->h;
+        $line = $this->_line_boxes[$this->_cl];
+        $frames = $line->get_frames();
+
+        if (count($frames) > 0) {
+            $last_frame = $frames[count($frames) - 1];
+    
+            if ($last_frame instanceof TextFrameDecorator
+                && !$last_frame->is_pre()
+            ) {
+                $last_frame->get_reflower()->trim_trailing_ws();
+                $line->recalculate_width();
+            }
+        }
+
+        $line->br = $br;
+        $y = $line->y + $line->h;
 
         $new_line = new LineBox($this, $y);
 

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -32,6 +32,29 @@ class Inline extends AbstractFrameDecorator
         parent::__construct($frame, $dompdf);
     }
 
+    /**
+     * Vertical padding, border, and margin do not apply when determining the
+     * height for inline frames.
+     *
+     * http://www.w3.org/TR/CSS21/visudet.html#inline-non-replaced
+     *
+     * The vertical padding, border and margin of an inline, non-replaced box
+     * start at the top and bottom of the content area, not the
+     * 'line-height'. But only the 'line-height' is used to calculate the
+     * height of the line box.
+     *
+     * @return float
+     */
+    public function get_margin_height(): float
+    {
+        $style = $this->get_style();
+        $font = $style->font_family;
+        $size = $style->font_size;
+        $fontHeight = $this->_dompdf->getFontMetrics()->getFontHeight($font, $size);
+
+        return ($style->line_height / ($size > 0 ? $size : 1)) * $fontHeight;
+    }
+
     public function split(Frame $child = null, bool $force_pagebreak = false)
     {
         if (is_null($child)) {

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -174,7 +174,7 @@ class Page extends AbstractFrameDecorator
             return null;
         }
 
-        $block_types = ["block", "list-item", "table", "table-row", "inline"];
+        $block_types = ["block", "list-item", "table", "table-row", "inline", "inline-block"];
         $page_breaks = ["always", "left", "right"];
 
         $style = $frame->get_style();
@@ -353,7 +353,7 @@ class Page extends AbstractFrameDecorator
 
         } // Inline frames (2):
         else {
-            if (in_array($display, Style::$INLINE_TYPES)) {
+            if (in_array($display, ["inline", "inline-block"], true)) {
 
                 // Avoid breaks within table-cells
                 if ($this->_in_table) {

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -45,6 +45,7 @@ class Text extends AbstractFrameDecorator
     {
         parent::reset();
         $this->_text_spacing = null;
+        $this->_reflower->reset();
     }
 
     // Accessor methods

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -259,6 +259,38 @@ class LineBox
     }
 
     /**
+     * Remove the frame at the given index and all following frames from the
+     * line.
+     *
+     * @param int $index
+     */
+    public function remove_frames(int $index): void
+    {
+        $lastIndex = count($this->_frames) - 1;
+
+        if ($index < 0 || $index > $lastIndex) {
+            return;
+        }
+
+        for ($i = $lastIndex; $i >= $index; $i--) {
+            $f = $this->_frames[$i];
+            unset($this->_frames[$i]);
+            $this->w -= $f->get_margin_width();
+        }
+
+        // Reset array indices
+        $this->_frames = array_values($this->_frames);
+
+        // Recalculate the height of the line
+        $h = 0.0;
+        foreach ($this->_frames as $f) {
+            $h = max($h, $f->get_margin_height());
+        }
+
+        $this->h = $h;
+    }
+
+    /**
      * Recalculate LineBox width based on the contained frames total width.
      *
      * @return float


### PR DESCRIPTION
These are the main changes from #2497.

* Inline frames now properly report their height, the same as text frames. This resolves inline frames extending into the page margins instead of breaking onto a new page.
* The positioning of inline frames has also been improved, allowing line breaks within them in more instances (instead of breaking the whole frame).
* Allow line breaks and page breaks before inline-block elements, which were not allowed before.
* Trim trailing whitespace after line breaks in more cases, notably after inline and inline-block frames.

Nested inline frames with margin, border, or padding still cause bugs at line breaks, because they are added to the text children on-the-fly. To properly fix these cases, it would probably be best to refactor the code in such a way that margin, border, and padding are properly handled on the inline frame itself, instead of being added to first resp. last child. It might be even worth considering always containing text frames in an anonymous inline box if needed; that could allow handling these properties consistently while simplifying the code. But the changes should improve the situation for now, nonetheless.

Applies on top of #2547.