### PR TITLE
Use shrink-to-fit width resolution for float and inline-block

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -930,7 +930,7 @@ abstract class AbstractFrameDecorator extends Frame
     /**
      * @return array
      */
-    final function get_min_max_width()
+    final function get_min_max_width(): array
     {
         return $this->_reflower->get_min_max_width();
     }

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -197,6 +197,7 @@ abstract class AbstractFrameDecorator extends Frame
     function reset()
     {
         $this->_frame->reset();
+        $this->_reflower->reset();
         $this->reset_generated_content();
         $this->revert_counter_increment();
 

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -935,14 +935,4 @@ abstract class AbstractFrameDecorator extends Frame
     {
         return $this->_reflower->get_min_max_width();
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    final function calculate_auto_width()
-    {
-        return $this->_reflower->calculate_auto_width();
-    }
 }

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -46,7 +46,6 @@ class Text extends AbstractFrameDecorator
     {
         parent::reset();
         $this->_text_spacing = null;
-        $this->_reflower->reset();
     }
 
     // Accessor methods

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -61,6 +61,11 @@ abstract class AbstractFrameReflower
         return $this->_frame->get_dompdf();
     }
 
+    public function reset(): void
+    {
+        $this->_min_max_cache = null;
+    }
+
     /**
      * Collapse frames margins
      * http://www.w3.org/TR/CSS2/box.html#collapsing-margins
@@ -257,7 +262,7 @@ abstract class AbstractFrameReflower
             // Add all adjacent inline widths together to calculate max width
             while ($iter->valid() && in_array($iter->current()->get_style()->display, Style::$INLINE_TYPES)) {
                 $child = $iter->current();
-
+                $child->get_reflower()->_set_content();
                 $minmax = $child->get_min_max_width();
 
                 if (in_array($iter->current()->get_style()->white_space, ["pre", "nowrap"])) {
@@ -278,7 +283,9 @@ abstract class AbstractFrameReflower
             }
 
             if ($iter->valid()) {
-                list($low[], $high[]) = $iter->current()->get_min_max_width();
+                $child = $iter->current();
+                $child->get_reflower()->_set_content();
+                list($low[], $high[]) = $child->get_min_max_width();
                 continue;
             }
         }

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -563,14 +563,4 @@ abstract class AbstractFrameReflower
 
         $frame->content_set = true;
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        return $this->_frame->get_margin_width();
-    }
 }

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -33,7 +33,7 @@ abstract class AbstractFrameReflower
     protected $_frame;
 
     /**
-     * Cached min/max size
+     * Cached min/max (content) size
      *
      * @var array
      */
@@ -233,31 +233,19 @@ abstract class AbstractFrameReflower
     abstract function reflow(Block $block = null);
 
     /**
-     * Required for table layout: Returns an array(0 => min, 1 => max, "min"
-     * => min, "max" => max) of the minimum and maximum widths of this frame.
-     * This provides a basic implementation.  Child classes should override
-     * this if necessary.
+     * Get the minimum and maximum width of the content of this frame.
      *
-     * @return array|null
+     * @return array An array [0 => min, 1 => max, "min" => min, "max" => max]
+     * of the min and max width.
      */
-    function get_min_max_width()
+    function get_min_max_content_width(): array
     {
         if (!is_null($this->_min_max_cache)) {
             return $this->_min_max_cache;
         }
 
         $style = $this->_frame->get_style();
-
-        // Account for margins & padding
-        $dims = [$style->padding_left,
-            $style->padding_right,
-            $style->border_left_width,
-            $style->border_right_width,
-            $style->margin_left,
-            $style->margin_right];
-
         $cb_w = $this->_frame->get_containing_block("w");
-        $delta = (float)$style->length_in_pt($dims, $cb_w);
 
         $low = [];
         $high = [];
@@ -310,9 +298,37 @@ abstract class AbstractFrameReflower
             }
         }
 
+        return $this->_min_max_cache = [$min, $max, "min" => $min, "max" => $max];
+    }
+
+    /**
+     * Required for table layout: Get the minimum and maximum width of this
+     * frame.  This provides a basic implementation.  Child classes should
+     * override this if necessary.
+     *
+     * @return array An array [0 => min, 1 => max, "min" => min, "max" => max]
+     * of the min and max width.
+     */
+    function get_min_max_width(): array
+    {
+        $style = $this->_frame->get_style();
+
+        // Account for margins & padding
+        $dims = [$style->padding_left,
+            $style->padding_right,
+            $style->border_left_width,
+            $style->border_right_width,
+            $style->margin_left,
+            $style->margin_right];
+
+        $cb_w = $this->_frame->get_containing_block("w");
+        $delta = (float)$style->length_in_pt($dims, $cb_w);
+
+        [$min, $max] = $this->get_min_max_content_width();
+
         $min += $delta;
         $max += $delta;
-        return $this->_min_max_cache = [$min, $max, "min" => $min, "max" => $max];
+        return [$min, $max, "min" => $min, "max" => $max];
     }
 
     /**

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -882,12 +882,12 @@ class Block extends AbstractFrameReflower
         $style->top = $top;
         $style->bottom = $bottom;
 
-        $orig_style = $this->_frame->get_original_style();
-
         $needs_reposition = ($style->position === "absolute" && ($style->right !== "auto" || $style->bottom !== "auto"));
 
         // Absolute positioning measurement
         if ($needs_reposition) {
+            $orig_style = $this->_frame->get_original_style();
+
             if ($orig_style->width === "auto" && ($orig_style->left === "auto" || $orig_style->right === "auto")) {
                 $width = 0;
                 foreach ($this->_frame->get_line_boxes() as $line) {
@@ -924,33 +924,5 @@ class Block extends AbstractFrameReflower
                 $block->add_line();
             }
         }
-    }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        $width = 0;
-
-        foreach ($this->_frame->get_line_boxes() as $line) {
-            $line_width = 0;
-
-            foreach ($line->get_frames() as $frame) {
-                if ($frame->get_original_style()->width == 'auto') {
-                    $line_width += $frame->calculate_auto_width();
-                } else {
-                    $line_width += $frame->get_margin_width();
-                }
-            }
-
-            $width = max($line_width, $width);
-        }
-
-        $this->_frame->get_style()->width = $width;
-
-        return $this->_frame->get_margin_width();
     }
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -146,6 +146,21 @@ class Block extends AbstractFrameReflower
                     $rm = $diff;
                 }
 
+            } else if ($style->float !== "none" || $style->display === "inline-block") {
+                // Shrink-to-fit width for float and inline block:
+                // https://www.w3.org/TR/CSS21/visudet.html#float-width
+                // https://www.w3.org/TR/CSS21/visudet.html#inlineblock-width
+
+                if ($width === "auto") {
+                    [$min, $max] = $this->get_min_max_content_width();
+                    $width = min(max($min, $diff), $max);
+                }
+                if ($lm === "auto") {
+                    $lm = 0;
+                }
+                if ($rm === "auto") {
+                    $rm = 0;
+                }
             } else {
                 // Find auto properties and get them to take up the slack
                 if ($width === "auto") {
@@ -883,25 +898,6 @@ class Block extends AbstractFrameReflower
 
             $style->left = $orig_style->left;
             $style->right = $orig_style->right;
-        }
-
-        // Calculate inline-block / float auto-widths
-        if (($style->display === "inline-block" || $style->float !== 'none') && $orig_style->width === 'auto') {
-            $width = 0;
-
-            foreach ($this->_frame->get_line_boxes() as $line) {
-                $line->recalculate_width();
-
-                $width = max($line->w, $width);
-            }
-
-            if ($width === 0) {
-                foreach ($this->_frame->get_children() as $child) {
-                    $width += $child->calculate_auto_width();
-                }
-            }
-
-            $style->width = $width;
         }
 
         $this->_text_align();

--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -54,10 +54,7 @@ class Image extends AbstractFrameReflower
         }
     }
 
-    /**
-     * @return array
-     */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         $frame = $this->_frame;
 

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -95,28 +95,6 @@ class Inline extends AbstractFrameReflower
     }
 
     /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        $width = 0;
-
-        foreach ($this->_frame->get_children() as $child) {
-            if ($child->get_original_style()->width == 'auto') {
-                $width += $child->calculate_auto_width();
-            } else {
-                $width += $child->get_margin_width();
-            }
-        }
-
-        $this->_frame->get_style()->width = $width;
-
-        return $this->_frame->get_margin_width();
-    }
-
-    /**
      * Get the minimum width needed for the first line of the frame, including
      * the margin box.
      *

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -511,10 +511,7 @@ class Table extends AbstractFrameReflower
         }
     }
 
-    /**
-     * @return array|null
-     */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         if (!is_null($this->_min_max_cache)) {
             return $this->_min_max_cache;

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -45,8 +45,9 @@ class Table extends AbstractFrameReflower
     /**
      * State is held here so it needs to be reset along with the decorator
      */
-    function reset()
+    public function reset(): void
     {
+        parent::reset();
         $this->_state = null;
         $this->_min_max_cache = null;
     }

--- a/src/FrameReflower/TableRow.php
+++ b/src/FrameReflower/TableRow.php
@@ -73,7 +73,7 @@ class TableRow extends AbstractFrameReflower
     /**
      * @throws Exception
      */
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         throw new Exception("Min/max width is undefined for table rows");
     }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -428,7 +428,7 @@ class Text extends AbstractFrameReflower
 
     //........................................................................
 
-    function get_min_max_width()
+    function get_min_max_width(): array
     {
         /*if ( !is_null($this->_min_max_cache)  )
           return $this->_min_max_cache;*/

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -417,6 +417,8 @@ class Text extends AbstractFrameReflower
 
     public function reset(): void
     {
+        parent::reset();
+
         // Restore trimmed trailing whitespace, as the frame will go through
         // another reflow and line breaks might be different after a split
         if ($this->trailingWs !== null) {

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -619,14 +619,4 @@ class Text extends AbstractFrameReflower
     {
         return $this->fontMetrics;
     }
-
-    /**
-     * Determine current frame width based on contents
-     *
-     * @return float
-     */
-    public function calculate_auto_width()
-    {
-        return $this->_frame->recalculate_width();
-    }
 }

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -297,7 +297,7 @@ class LineBox
         $width = 0;
 
         foreach ($this->get_frames() as $frame) {
-            $width += $frame->calculate_auto_width();
+            $width += $frame->get_margin_width();
         }
 
         return $this->w = $width;

--- a/src/Positioner/Inline.php
+++ b/src/Positioner/Inline.php
@@ -55,12 +55,12 @@ class Inline extends AbstractPositioner
                 $line = $p->get_current_line_box();
             }
         } elseif ($frame->is_inline_block()) {
-            $min_max = $reflower->get_min_max_width();
+            $width = $frame->get_margin_width();
 
             // If an inline-block frame doesn't fit in the current line, it
             // should break to a new line. Inline-block elements are formatted
             // as atomic inline boxes
-            if ($min_max["min"] > ($cb["w"] - $line->left - $line->w - $line->right)) {
+            if ($width > ($cb["w"] - $line->left - $line->w - $line->right)) {
                 $p->add_line();
                 $line = $p->get_current_line_box();
             }


### PR DESCRIPTION
As per spec.

<del>The problem right now is that generated content is only set on reflow of the actual frame, so it is not yet set for any descendants when `get_min_max_content_width` is called. As a result, generated content is not honored when calculating the minimum and maximum width. This  is very apparent with elements that only contain generated content, e.g. an `input` button, as reported in https://github.com/dompdf/dompdf/pull/2497#issuecomment-917504662.</del>

<del>Applies on top of #2548.</del>
Applies on top of #2559.