### PR TITLE
One more auto-resolve fix plus some cleanup

### DIFF
--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -162,8 +162,8 @@ class Image extends AbstractFrameReflower
             print $width . ' ' . $height . ';';
         }
 
-        $style->width = $width . "pt";
-        $style->height = $height . "pt";
+        $style->width = $width;
+        $style->height = $height;
 
         $style->min_width = "none";
         $style->max_width = "none";

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -437,17 +437,19 @@ class Table extends AbstractFrameReflower
             } else {
                 $left = $right = $diff / 2;
             }
-
-            $style->margin_left = $left;
-            $style->margin_right = $right;
         } else {
             if ($left === "auto") {
-                $left = (float)$style->length_in_pt($cb["w"], $cb["w"]) - (float)$style->length_in_pt($right, $cb["w"]) - (float)$style->length_in_pt($width, $cb["w"]);
+                $right = (float)$style->length_in_pt($right, $cb["w"]);
+                $left = $diff - $right;
             }
             if ($right === "auto") {
                 $left = (float)$style->length_in_pt($left, $cb["w"]);
+                $right = $diff - $left;
             }
         }
+
+        $style->margin_left = $left;
+        $style->margin_right = $right;
 
         list($x, $y) = $frame->get_position();
 

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -343,11 +343,6 @@ class Table extends AbstractFrameReflower
                 }
             }
 
-            if ($max_height !== "none" && $max_height !== "auto" && (float)$min_height > (float)$max_height) {
-                // Swap 'em
-                list($max_height, $min_height) = [$min_height, $max_height];
-            }
-
             if ($max_height !== "none" && $max_height !== "auto" && $height > (float)$max_height) {
                 $height = $max_height;
             }

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -438,8 +438,8 @@ class Table extends AbstractFrameReflower
                 $left = $right = $diff / 2;
             }
 
-            $style->margin_left = sprintf("%Fpt", $left);
-            $style->margin_right = sprintf("%Fpt", $right);
+            $style->margin_left = $left;
+            $style->margin_right = $right;
         } else {
             if ($left === "auto") {
                 $left = (float)$style->length_in_pt($cb["w"], $cb["w"]) - (float)$style->length_in_pt($right, $cb["w"]) - (float)$style->length_in_pt($width, $cb["w"]);

--- a/tests/FrameReflower/ImageTest.php
+++ b/tests/FrameReflower/ImageTest.php
@@ -23,8 +23,8 @@ class ImageTest extends TestCase
 
         $expectedWidth = 1966.08;
 
-        $this->assertEquals($expectedWidth . 'pt', $style->width);
-        $this->assertEquals('1474.56' . 'pt', $style->height);
+        $this->assertEquals($expectedWidth, $style->width);
+        $this->assertEquals(1474.56, $style->height);
 
         $this->assertEquals([$expectedWidth, $expectedWidth, 'min' => $expectedWidth, 'max' => $expectedWidth], $result);
     }
@@ -40,8 +40,8 @@ class ImageTest extends TestCase
 
         $expectedWidth = 75;
 
-        $this->assertEquals($expectedWidth . 'pt', $style->width);
-        $this->assertEquals('150' . 'pt', $style->height);
+        $this->assertEquals($expectedWidth, $style->width);
+        $this->assertEquals(150, $style->height);
 
         $this->assertEquals([$expectedWidth, $expectedWidth, 'min' => $expectedWidth, 'max' => $expectedWidth], $result);
     }
@@ -60,9 +60,9 @@ class ImageTest extends TestCase
         $expectedWidth = 75;
 
         // 400px * 0.75 (dpi) * 0.50 (imageFrame) * 0.50 (rootFrame)
-        $this->assertEquals($expectedWidth . 'pt', $style->width);
+        $this->assertEquals($expectedWidth, $style->width);
         // 800px * 0.75 (dpi) * 0.75 (imageFrame) * 0.75 (rootFrame)
-        $this->assertEquals('337.5' . 'pt', $style->height);
+        $this->assertEquals(337.5, $style->height);
 
         $this->assertEquals([$expectedWidth, $expectedWidth, 'min' => $expectedWidth, 'max' => $expectedWidth], $result);
     }
@@ -78,8 +78,8 @@ class ImageTest extends TestCase
 
         $expectedWidth = 0;
 
-        $this->assertEquals($expectedWidth . 'pt', $style->width);
-        $this->assertEquals(0 . 'pt', $style->height);
+        $this->assertEquals($expectedWidth, $style->width);
+        $this->assertEquals(0, $style->height);
 
         $this->assertEquals([$expectedWidth, $expectedWidth, 'min' => $expectedWidth, 'max' => $expectedWidth], $result);
     }
@@ -103,8 +103,8 @@ class ImageTest extends TestCase
         $style = $frame->get_style();
 
 
-        $this->assertEquals('300pt', $style->width);
-        $this->assertEquals('375pt', $style->height);
+        $this->assertEquals(300, $style->width);
+        $this->assertEquals(375, $style->height);
 
         $this->assertEquals(['300', '300', 'min' => '300', 'max' => '300'], $result);
     }


### PR DESCRIPTION
Fixes the following sample:

```html
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style>
@page {
    size: 400pt 300pt;
    margin: 50pt;
}

table {
    border: 1px solid black;
    border-collapse: separate;
}

hr {
    border: 1pt solid black;
}
</style>
</head>

<body>

    <table style="margin-left: auto; margin-right: 0;">
        <tr><td>dompdf</td></tr>
    </table>
    <hr>
    <table style="margin-left: 0; margin-right: auto;">
        <tr><td>dompdf</td></tr>
    </table>
    <hr>
    <table style="margin-left: auto; margin-right: auto;">
        <tr><td>dompdf</td></tr>
    </table>
    <hr>

</body>

</html>
```