### PR TITLE
Clean up handling of counters involving page breaks

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -324,14 +324,6 @@ class Frame
         $this->_style = null;
         unset($this->_style);
         $this->_style = clone $this->_original_style;
-
-        // If this represents a generated node then child nodes represent generated content.
-        // Remove the children since the content will be generated next time this frame is reflowed.
-        if ($this->_node->nodeName === "dompdf_generated" && $this->_style->content != "normal") {
-            foreach ($this->get_children() as $child) {
-                $this->remove_child($child);
-            }
-        }
     }
 
     /**

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -73,6 +73,7 @@ class Inline extends AbstractFrameDecorator
             $node->removeAttribute("id");
         }
 
+        $this->revert_counter_increment();
         $split = $this->copy($node->cloneNode());
         // if this is a generated node don't propagate the content style
         if ($split->get_node()->nodeName == "dompdf_generated") {

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -509,12 +509,16 @@ abstract class AbstractFrameReflower
     protected function _set_content()
     {
         $frame = $this->_frame;
+
+        if ($frame->content_set) {
+            return;
+        }
+
         $style = $frame->get_style();
 
-        // if the element was pushed to a new page use the saved counter value, otherwise use the CSS reset value
         if ($style->counter_reset && ($reset = $style->counter_reset) !== "none") {
             $vars = preg_split('/\s+/', trim($reset), 2);
-            $frame->reset_counter($vars[0], (isset($frame->_counters['__' . $vars[0]]) ? $frame->_counters['__' . $vars[0]] : (isset($vars[1]) ? $vars[1] : 0)));
+            $frame->reset_counter($vars[0], isset($vars[1]) ? $vars[1] : 0);
         }
 
         if ($style->counter_increment && ($increment = $style->counter_increment) !== "none") {
@@ -534,6 +538,8 @@ abstract class AbstractFrameReflower
             Factory::decorate_frame($new_frame, $frame->get_dompdf(), $frame->get_root());
             $frame->append_child($new_frame);
         }
+
+        $frame->content_set = true;
     }
 
     /**


### PR DESCRIPTION
The `content_set` property is introduced in preparation for allowing to set generated content early when calculating shrink-to-fit widths.

Fixes #2167
Fixes #2558