### PR TITLE
GD: Fix page count

### DIFF
--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -178,7 +178,7 @@ class GD implements Canvas
         $this->_actual_width = $this->_upscale($this->_width);
         $this->_actual_height = $this->_upscale($this->_height);
 
-        $this->_page_number = $this->_page_count = 1;
+        $this->_page_number = $this->_page_count = 0;
         $this->_page_text = [];
 
         if (is_null($bg_color) || !is_array($bg_color)) {


### PR DESCRIPTION
`new_page()` is called from the constructor, increasing page number and count by 1 immediately, which resulted in both of them being 2 for the first page.

Split out from #2510.