### PR TITLE
Fix inconsistency in calculation of line-box height

### DIFF
--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -267,7 +267,7 @@ class Block extends AbstractFrameDecorator
     }
 
     /**
-     * @param $val
+     * @param float $val
      * @param Frame $frame
      */
     function maximize_line_height($val, Frame $frame)

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -313,7 +313,7 @@ class Text extends AbstractFrameReflower
                 // Trim newlines from the beginning of the line
                 //$this->_frame->set_text(ltrim($text, "\n\r"));
 
-                $this->_block_parent->maximize_line_height($style->height, $frame);
+                $this->_block_parent->maximize_line_height($frame->get_margin_height(), $frame);
                 $this->_block_parent->add_line();
                 $frame->position();
 


### PR DESCRIPTION
Use the same method as in `FrameDecorator\Block::add_frame_to_line()`.

Fixes #1646