### PR TITLE
Fix justification of last line before page break

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -160,7 +160,7 @@ class Frame
     public $_float_next_line = false;
 
     /**
-     * Tells whether the frame was split
+     * Whether the frame is a split-off frame
      *
      * @var bool
      */

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -83,6 +83,13 @@ abstract class AbstractFrameDecorator extends Frame
     private $_positionned_parent;
 
     /**
+     * Whether the frame has been split
+     *
+     * @var bool
+     */
+    public $is_split = false;
+
+    /**
      * Cache for the get_parent while loop results
      *
      * @var Frame
@@ -697,6 +704,7 @@ abstract class AbstractFrameDecorator extends Frame
         $split = $this->copy($node->cloneNode());
         $split->reset();
         $split->get_original_style()->text_indent = 0;
+        $this->is_split = true;
         $split->_splitted = true;
         $split->_already_pushed = true;
 

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -464,7 +464,7 @@ class Block extends AbstractFrameReflower
                         }
                     }
                 }
-                return;
+                break;
 
             case "right":
                 foreach ($this->_frame->get_line_boxes() as $line) {
@@ -480,11 +480,13 @@ class Block extends AbstractFrameReflower
                 break;
 
             case "justify":
-                // We justify all lines except the last one
-                $lines = $this->_frame->get_line_boxes(); // needs to be a variable (strict standards)
-                $last_line = array_pop($lines);
+                // We justify all lines except the last one, unless the frame
+                // has been split, in which case the actual last line is part of
+                // the split-off frame
+                $lines = $this->_frame->get_line_boxes();
+                $last_line_index = $this->_frame->is_split ? null : count($lines) - 1;
 
-                foreach ($lines as $line) {
+                foreach ($lines as $i => $line) {
                     if ($line->left) {
                         foreach ($line->get_frames() as $frame) {
                             if ($frame->get_positioner() instanceof InlinePositioner) {
@@ -493,7 +495,7 @@ class Block extends AbstractFrameReflower
                         }
                     }
 
-                    if ($line->br) {
+                    if ($line->br || $i === $last_line_index) {
                         continue;
                     }
 
@@ -531,15 +533,6 @@ class Block extends AbstractFrameReflower
 
                     // The line (should) now occupy the entire width
                     $line->w = $width;
-                }
-
-                // Adjust the last line if necessary
-                if ($last_line->left) {
-                    foreach ($last_line->get_frames() as $frame) {
-                        if ($frame->get_positioner() instanceof InlinePositioner) {
-                            $frame->move($last_line->left, 0);
-                        }
-                    }
                 }
                 break;
 


### PR DESCRIPTION
Before 1b8f3edc3f8d0e60914dc4d66fa200e87904a722, lines were not removed from line boxes after a split, and thus the actual last line was still contained in the list of of the original frame’s line boxes, so the issue was essentially masked.

I think the description of `$_splitted` was misleading, does the wording make sense now in contrast to `$is_split`? I did not rename the property to preserve backwards compatibility, though it would be nice to clean that up, too.