### PR TITLE
Fix logic for preventing duplicate ID values

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -161,6 +161,11 @@ abstract class AbstractFrameDecorator extends Frame
         $frame = new Frame($node);
         $frame->set_style(clone $this->_frame->get_original_style());
 
+        if ($node instanceof DOMElement && $node->hasAttribute("id")) {
+            $node->setAttribute("data-dompdf-original-id", $node->getAttribute("id"));
+            $node->removeAttribute("id");
+        }
+
         return Factory::decorate_frame($frame, $this->_dompdf, $this->_root);
     }
 
@@ -171,15 +176,14 @@ abstract class AbstractFrameDecorator extends Frame
      */
     function deep_copy()
     {
-        $node = $this->_frame->get_node();
+        $node = $this->_frame->get_node()->cloneNode();
+        $frame = new Frame($node);
+        $frame->set_style(clone $this->_frame->get_original_style());
 
         if ($node instanceof DOMElement && $node->hasAttribute("id")) {
             $node->setAttribute("data-dompdf-original-id", $node->getAttribute("id"));
             $node->removeAttribute("id");
         }
-
-        $frame = new Frame($node->cloneNode());
-        $frame->set_style(clone $this->_frame->get_original_style());
 
         $deco = Factory::decorate_frame($frame, $this->_dompdf, $this->_root);
 
@@ -711,14 +715,8 @@ abstract class AbstractFrameDecorator extends Frame
             throw new Exception("Unable to split: frame is not a child of this one.");
         }
 
-        $node = $this->_frame->get_node();
-
-        if ($node instanceof DOMElement && $node->hasAttribute("id")) {
-            $node->setAttribute("data-dompdf-original-id", $node->getAttribute("id"));
-            $node->removeAttribute("id");
-        }
-
         $this->revert_counter_increment();
+        $node = $this->_frame->get_node();
         $split = $this->copy($node->cloneNode());
 
         $style = $this->_frame->get_style();

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -66,14 +66,8 @@ class Inline extends AbstractFrameDecorator
             throw new Exception("Unable to split: frame is not a child of this one.");
         }
 
-        $node = $this->_frame->get_node();
-
-        if ($node instanceof DOMElement && $node->hasAttribute("id")) {
-            $node->setAttribute("data-dompdf-original-id", $node->getAttribute("id"));
-            $node->removeAttribute("id");
-        }
-
         $this->revert_counter_increment();
+        $node = $this->_frame->get_node();
         $split = $this->copy($node->cloneNode());
         // if this is a generated node don't propagate the content style
         if ($split->get_node()->nodeName == "dompdf_generated") {


### PR DESCRIPTION
If a frame was split, its ID was removed before copying, so the ID was effectively removed completely. I think the intention here was to only remove the ID from the split-off node, so that any links would point to the first occurrence of the original node.

Fixes #2356