### PR TITLE
Fix `z` missing from alpha numbering

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -884,11 +884,11 @@ abstract class AbstractFrameDecorator extends Frame
 
             case "lower-latin":
             case "lower-alpha":
-                return chr(($value % 26) + ord('a') - 1);
+                return chr((($value - 1) % 26) + ord('a'));
 
             case "upper-latin":
             case "upper-alpha":
-                return chr(($value % 26) + ord('A') - 1);
+                return chr((($value - 1) % 26) + ord('A'));
 
             case "lower-greek":
                 return Helpers::unichr($value + 944);

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -105,7 +105,7 @@ class ListBullet extends AbstractRenderer
             case "lower-alpha":
             case "lower-latin":
             case "a":
-                $text = chr(($n % 26) + ord('a') - 1);
+                $text = chr((($n - 1) % 26) + ord('a'));
                 break;
 
             case "upper-roman":


### PR DESCRIPTION
Just a quick fix, that code could use a more thorough cleanup.

Partially addresses #1545