### PR TITLE
Introduce notion of outer display type

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -77,18 +77,52 @@ class Style
         "super", "text-bottom", "text-top", "top"];
 
     /**
-     * List of all inline types.  Should really be a constant.
+     * List of all block-level (outer) display types.
+     * * https://www.w3.org/TR/css-display-3/#display-type
+     * * https://www.w3.org/TR/css-display-3/#block-level
+     */
+    public const BLOCK_LEVEL_TYPES = [
+        "block",
+        // "flow-root",
+        "list-item",
+        "flex",
+        // "grid",
+        "table"
+    ];
+
+    /**
+     * List of all inline-level (outer) display types.
+     * * https://www.w3.org/TR/css-display-3/#display-type
+     * * https://www.w3.org/TR/css-display-3/#inline-level
+     */
+    public const INLINE_LEVEL_TYPES = [
+        "inline",
+        "inline-block",
+        "inline-flex",
+        // "inline-grid",
+        "inline-table"
+    ];
+
+    /**
+     * List of all inline (inner) display types.  Should really be a constant.
      *
      * @var array
      */
     static $INLINE_TYPES = ["inline"];
 
     /**
-     * List of all block types.  Should really be a constant.
+     * List of all block (inner) display types.  Should really be a constant.
      *
      * @var array
      */
     static $BLOCK_TYPES = ["block", "inline-block", "table-cell", "list-item"];
+
+    /**
+     * List of all table (inner) display types.  Should really be a constant.
+     *
+     * @var array
+     */
+    static $TABLE_TYPES = ["table", "inline-table"];
 
     /**
      * List of all positioned types.  Should really be a constant.
@@ -96,13 +130,6 @@ class Style
      * @var array
      */
     static $POSITIONNED_TYPES = ["relative", "absolute", "fixed"];
-
-    /**
-     * List of all table types.  Should really be a constant.
-     *
-     * @var array
-     */
-    static $TABLE_TYPES = ["table", "inline-table"];
 
     /**
      * List of valid border styles.  Should also really be a constant.

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -45,7 +45,7 @@ class Frame
 
     /**
      * Unique id counter
-     * 
+     *
      * @var int
      */
     public static $ID_COUNTER = 0; /*protected*/
@@ -841,7 +841,7 @@ class Frame
 
         $position = $this->get_style()->position;
 
-        return $this->_is_cache["positionned"] = in_array($position, Style::$POSITIONNED_TYPES);
+        return $this->_is_cache["positionned"] = in_array($position, Style::$POSITIONNED_TYPES, true);
     }
 
     /**
@@ -859,6 +859,8 @@ class Frame
     }
 
     /**
+     * Whether the frame is a block container.
+     *
      * @return bool
      */
     public function is_block()
@@ -867,7 +869,39 @@ class Frame
             return $this->_is_cache["block"];
         }
 
-        return $this->_is_cache["block"] = in_array($this->get_style()->display, Style::$BLOCK_TYPES);
+        return $this->_is_cache["block"] = in_array($this->get_style()->display, Style::$BLOCK_TYPES, true);
+    }
+
+    /**
+     * Whether the frame has a block-level display type.
+     *
+     * @return bool
+     */
+    public function is_block_level(): bool
+    {
+        if (isset($this->_is_cache["block_level"])) {
+            return $this->_is_cache["block_level"];
+        }
+
+        $display = $this->get_style()->display;
+
+        return $this->_is_cache["block_level"] = in_array($display, Style::BLOCK_LEVEL_TYPES, true);
+    }
+
+    /**
+     * Whether the frame has an inline-level display type.
+     *
+     * @return bool
+     */
+    public function is_inline_level(): bool
+    {
+        if (isset($this->_is_cache["inline_level"])) {
+            return $this->_is_cache["inline_level"];
+        }
+
+        $display = $this->get_style()->display;
+
+        return $this->_is_cache["inline_level"] = in_array($display, Style::INLINE_LEVEL_TYPES, true);
     }
 
     /**
@@ -879,7 +913,7 @@ class Frame
             return $this->_is_cache["inline_block"];
         }
 
-        return $this->_is_cache["inline_block"] = ($this->get_style()->display === 'inline-block');
+        return $this->_is_cache["inline_block"] = ($this->get_style()->display === "inline-block");
     }
 
     /**
@@ -890,6 +924,7 @@ class Frame
         if (isset($this->_is_cache["in_flow"])) {
             return $this->_is_cache["in_flow"];
         }
+
         return $this->_is_cache["in_flow"] = !($this->get_style()->float !== "none" || $this->is_absolute());
     }
 
@@ -904,7 +939,7 @@ class Frame
 
         $white_space = $this->get_style()->white_space;
 
-        return $this->_is_cache["pre"] = in_array($white_space, ["pre", "pre-wrap"]);
+        return $this->_is_cache["pre"] = in_array($white_space, ["pre", "pre-wrap"], true);
     }
 
     /**
@@ -918,7 +953,7 @@ class Frame
 
         $display = $this->get_style()->display;
 
-        return $this->_is_cache["table"] = in_array($display, Style::$TABLE_TYPES);
+        return $this->_is_cache["table"] = in_array($display, Style::$TABLE_TYPES, true);
     }
 
 

--- a/src/Frame/Factory.php
+++ b/src/Frame/Factory.php
@@ -60,7 +60,7 @@ class Factory
      *
      * @param Frame $frame   The frame to decorate
      * @param Dompdf $dompdf The dompdf instance
-     * @param Frame $root    The frame to decorate
+     * @param Frame $root    The root of the frame
      *
      * @throws Exception
      * @return AbstractFrameDecorator
@@ -68,19 +68,30 @@ class Factory
      */
     static function decorate_frame(Frame $frame, Dompdf $dompdf, Frame $root = null)
     {
-        if (is_null($dompdf)) {
-            throw new Exception("The DOMPDF argument is required");
-        }
-
         $style = $frame->get_style();
+        $display = $style->display;
 
         // Floating (and more generally out-of-flow) elements are blocks
-        // http://coding.smashingmagazine.com/2007/05/01/css-float-theory-things-you-should-know/
-        if (!$frame->is_in_flow() && in_array($style->display, Style::$INLINE_TYPES)) {
-            $style->display = "block";
-        }
+        // https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo
+        if (!$frame->is_in_flow()
+            && in_array($display, Style::INLINE_LEVEL_TYPES, true)
+        ) {
+            switch ($display) {
+                case "inline-flex":
+                    $display = "flex";
+                    break;
+                case "inline-table":
+                    $display = "table";
+                    break;
+                default:
+                    $display = "block";
+            }
 
-        $display = $style->display;
+            // The original style needs to be modified, too, here, as the style
+            // gets reset to the original style after a page break
+            $frame->get_original_style()->display = $display;
+            $style->display = $display;
+        }
 
         switch ($display) {
 


### PR DESCRIPTION
… and use that to:

* Fix `display` of out-of-flow frames in more cases (also fixes the value being lost after a page break)
* Make the logic regarding forced page-breaks a bit clearer
* Prevent margin collapsing with inline-level (and out-of-flow) elements

The existing methods `is_block()` and `is_table()` effectively check the inner display type.
See https://www.w3.org/TR/css-display-3#display-type.

Addresses #2271
Partially addresses #1946