### PR TITLE
Clear border radius between split frames

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -729,11 +729,15 @@ abstract class AbstractFrameDecorator extends Frame
             $style->margin_bottom = 0;
             $style->padding_bottom = 0;
             $style->border_bottom = 0;
+            $style->border_bottom_left_radius = 0;
+            $style->border_bottom_right_radius = 0;
 
             // second
             $split_style->margin_top = 0;
             $split_style->padding_top = 0;
             $split_style->border_top = 0;
+            $split_style->border_top_left_radius = 0;
+            $split_style->border_top_right_radius = 0;
             $split_style->page_break_before = "auto";
         }
 


### PR DESCRIPTION
When frames are split across pages, the border radius is still applied at the split point:

![Screen Shot 2021-09-29 at 3 05 15 PM](https://user-images.githubusercontent.com/89411225/135348394-422a5af3-ba67-4567-8fdd-ade7e32f8a3c.png)

PDF document: [before.pdf](https://github.com/dompdf/dompdf/files/7255034/before.pdf)

This PR introduces a change such that border radius is cleared at the split point: 

![Screen Shot 2021-09-29 at 3 05 38 PM](https://user-images.githubusercontent.com/89411225/135348429-9d74ee24-2f87-42e0-b73d-59b3d4d8d849.png)
PDF document: [after.pdf](https://github.com/dompdf/dompdf/files/7255038/after.pdf)

This can be reproduced with the following: 

HTML markup: [example-html.txt](https://github.com/dompdf/dompdf/files/7255021/examplehtml.txt)
Config: default

