### PR TITLE
reset counter parent instead create local one

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -755,7 +755,7 @@ abstract class AbstractFrameDecorator extends Frame
      */
     function reset_counter($id = self::DEFAULT_COUNTER, $value = 0)
     {
-        $this->get_parent()->_counters[$id] = intval($value);
+        $this->lookup_counter_frame($vars[0])->_counters[$id] = intval($value);
     }
 
     /**


### PR DESCRIPTION
Hi I had a problem in counter numbers, when they were reset, after one page they were erased, I found this, before that create on counter in the frame instead take parent's one.