### PR TITLE
Fix next-sibling selector with unqualified class

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -606,6 +606,13 @@ class Stylesheet
                         $query .= "/";
                     }
 
+                    // Tag names are case-insensitive
+                    $tok = strtolower($tok);
+
+                    if (!$tok) {
+                        $tok = "*";
+                    }
+
                     $query .= "following-sibling::$tok";
                     $tok = "";
                     break;


### PR DESCRIPTION
Handle it the same as the descendant and child selectors.

Fixes #1509