### PR TITLE
Add support for subsequent-sibling combinator

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -446,7 +446,9 @@ class Stylesheet
 
         $d = min(mb_substr_count($selector, " ") +
             mb_substr_count($selector, ">") +
-            mb_substr_count($selector, "+"), 255);
+            mb_substr_count($selector, "+") +
+            mb_substr_count($selector, "~") -
+            mb_substr_count($selector, "~="), 255);
 
         //If a normal element name is at the beginning of the string,
         //a leading whitespace might have been removed on whitespace collapsing and removal
@@ -454,7 +456,7 @@ class Stylesheet
         //this can lead to a too small specificity
         //see _css_selector_to_xpath
 
-        if (!in_array($selector[0], [" ", ">", ".", "#", "+", ":", "["]) && $selector !== "*") {
+        if (!in_array($selector[0], [" ", ">", ".", "#", "+", "~", ":", "["]) && $selector !== "*") {
             $d++;
         }
 
@@ -498,7 +500,7 @@ class Stylesheet
         // Parse the selector
         //$s = preg_split("/([ :>.#+])/", $selector, -1, PREG_SPLIT_DELIM_CAPTURE);
 
-        $delimiters = [" ", ">", ".", "#", "+", ":", "[", "("];
+        $delimiters = [" ", ">", ".", "#", "+", "~", ":", "[", "("];
 
         // Add an implicit * at the beginning of the selector
         // if it begins with an attribute selector
@@ -601,7 +603,10 @@ class Stylesheet
                     break;
 
                 case "+":
-                    // All sibling elements that follow the current token
+                case "~":
+                    // Next-sibling combinator
+                    // Subsequent-sibling combinator
+                    // https://www.w3.org/TR/selectors-3/#sibling-combinators
                     if (mb_substr($query, -1, 1) !== "/") {
                         $query .= "/";
                     }
@@ -614,6 +619,11 @@ class Stylesheet
                     }
 
                     $query .= "following-sibling::$tok";
+
+                    if ($s === "+") {
+                        $query .= "[1]";
+                    }
+
                     $tok = "";
                     break;
 
@@ -1658,9 +1668,9 @@ class Stylesheet
     private function _parse_sections($str, $media_queries = [])
     {
         // Pre-process: collapse all whitespace and strip whitespace around '>',
-        // '.', ':', '+', '#'
+        // '.', ':', '+', '~', '#'
 
-        $patterns = ["/[\\s\n]+/", "/\\s+([>.:+#])\\s+/"];
+        $patterns = ["/[\\s\n]+/", "/\\s+([>.:+~#])\\s+/"];
         $replacements = [" ", "\\1"];
         $str = preg_replace($patterns, $replacements, $str);
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();


### PR DESCRIPTION
The next-sibling combinator worked like the subsequent-sibling combinator is intended to work. So this also fixes the next-sibling combinator to work as intended.

https://www.w3.org/TR/selectors-3/#sibling-combinators

Here is a quick test sample:

```html
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style>
@page {
    size: 400pt 300pt;
    margin: 50pt;
}

span {
    text-decoration: underline;
}

h4 + .test,
h4 + .another {
    color: blue;
}

h4 + span.test {
    font-weight: bold;
}

h4 ~ .test {
    font-style: italic;
}
</style>
</head>

<body>
    <h4>Heading</h4>

    <span class="test">Test</span>
    Test
    <span class="test">Test</span>
    Test
    <span class="another">Test</span>
</body>

</html>
```

Applies on top of #2592.