### PR TITLE
Fix table borders when table is moved after reflow

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -350,21 +350,23 @@ class Cellmap
             throw new Exception("Frame not found in cellmap");
         }
 
+        // Positions are stored relative to the table position
+        [$table_x, $table_y] = $this->_table->get_position();
         $col = $this->_frames[$key]["columns"][0];
         $row = $this->_frames[$key]["rows"][0];
 
         if (!isset($this->_columns[$col])) {
             $_dompdf_warnings[] = "Frame not found in columns array.  Check your table layout for missing or extra TDs.";
-            $x = 0;
+            $x = $table_x;
         } else {
-            $x = $this->_columns[$col]["x"];
+            $x = $table_x + $this->_columns[$col]["x"];
         }
 
         if (!isset($this->_rows[$row])) {
             $_dompdf_warnings[] = "Frame not found in row array.  Check your table layout for missing or extra TDs.";
-            $y = 0;
+            $y = $table_y;
         } else {
-            $y = $this->_rows[$row]["y"];
+            $y = $table_y + $this->_rows[$row]["y"];
         }
 
         return [$x, $y, "x" => $x, "y" => $y];

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -455,11 +455,17 @@ class Table extends AbstractFrameReflower
         list($x, $y) = $frame->get_position();
 
         // Determine the content edge
-        $content_x = $x + (float)$left + (float)$style->length_in_pt([$style->padding_left,
-                $style->border_left_width], $cb["w"]);
-        $content_y = $y + (float)$style->length_in_pt([$style->margin_top,
-                $style->border_top_width,
-                $style->padding_top], $cb["w"]);
+        $offset_x = (float)$left + (float)$style->length_in_pt([
+            $style->padding_left,
+            $style->border_left_width
+        ], $cb["w"]);
+        $offset_y = (float)$style->length_in_pt([
+            $style->margin_top,
+            $style->border_top_width,
+            $style->padding_top
+        ], $cb["w"]);
+        $content_x = $x + $offset_x;
+        $content_y = $y + $offset_y;
 
         if (isset($cb["h"])) {
             $h = $cb["h"];
@@ -469,10 +475,10 @@ class Table extends AbstractFrameReflower
 
         $cellmap = $frame->get_cellmap();
         $col =& $cellmap->get_column(0);
-        $col["x"] = $content_x;
+        $col["x"] = $offset_x;
 
         $row =& $cellmap->get_row(0);
-        $row["y"] = $content_y;
+        $row["y"] = $offset_y;
 
         $cellmap->assign_x_positions();
 

--- a/src/Renderer/TableCell.php
+++ b/src/Renderer/TableCell.php
@@ -91,14 +91,16 @@ class TableCell extends Block
             $draw_bottom = false;
         }
 
+        [$table_x, $table_y] = $table->get_position();
+
         // Draw the horizontal borders
         $border_function_calls = [];
         foreach ($cells["columns"] as $j) {
             $bp = $cellmap->get_border_properties($i, $j);
             $col = $cellmap->get_column($j);
 
-            $x = $col["x"] - $bp["left"]["width"] / 2;
-            $y = $top_row["y"] - $bp["top"]["width"] / 2;
+            $x = $table_x + $col["x"] - $bp["left"]["width"] / 2;
+            $y = $table_y + $top_row["y"] - $bp["top"]["width"] / 2;
             $w = $col["used-width"] + ($bp["left"]["width"] + $bp["right"]["width"]) / 2;
 
             if ($bp["top"]["width"] > 0) {
@@ -128,7 +130,7 @@ class TableCell extends Block
                     (float)$bp["left"]["width"]
                 ];
 
-                $y = $bottom_row["y"] + $bottom_row["height"] + $bp["bottom"]["width"] / 2;
+                $y = $table_y + $bottom_row["y"] + $bottom_row["height"] + $bp["bottom"]["width"] / 2;
                 $border_bottom_width = max($border_bottom_width, $widths[2]);
 
                 $method = "_border_" . $bp["bottom"]["style"];
@@ -155,8 +157,8 @@ class TableCell extends Block
             $bp = $cellmap->get_border_properties($i, $j);
             $row = $cellmap->get_row($i);
 
-            $x = $left_col["x"] - $bp["left"]["width"] / 2;
-            $y = $row["y"] - $bp["top"]["width"] / 2;
+            $x = $table_x + $left_col["x"] - $bp["left"]["width"] / 2;
+            $y = $table_y + $row["y"] - $bp["top"]["width"] / 2;
             $h = $row["height"] + ($bp["top"]["width"] + $bp["bottom"]["width"]) / 2;
 
             if ($bp["left"]["width"] > 0) {
@@ -186,7 +188,7 @@ class TableCell extends Block
                     (float)$bp["left"]["width"]
                 ];
 
-                $x = $right_col["x"] + $right_col["used-width"] + $bp["right"]["width"] / 2;
+                $x = $table_x + $right_col["x"] + $right_col["used-width"] + $bp["right"]["width"] / 2;
                 $border_right_width = max($border_right_width, $widths[1]);
 
                 $method = "_border_" . $bp["right"]["style"];


### PR DESCRIPTION
This can happen with collapsed borders due to vertical alignment, float, or absolute positioning.

Collapsed table borders are drawn using the positions from the cell map. As the cell map stored global positions, moving a table after reflow did not update the positions in the cell map; children were moved correctly though, so the positions of cell contents and borders did not match anymore. Instead of updating the cell map after a move, simply make it store position values that are relative to the table position.

Fixes #1900
Fixes #2165