### PR TITLE
open_basedir restriction in effect. File(/.ufm) is not within the allowed path(s)

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3537,6 +3537,10 @@ EOT;
      */
     function selectFont($fontName, $encoding = '', $set = true, $isSubsetting = true)
     {
+        if ($fontName === null || $fontName === '') {
+            return $this->currentFontNum;
+        }
+
         $ext = substr($fontName, -4);
         if ($ext === '.afm' || $ext === '.ufm') {
             $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);


### PR DESCRIPTION
Hello!

So I had a weird error in my Laravel project using the libs `dompdf/dompdf`, `barryvdh/laravel-dompdf` and `laraveldaily/laravel-invoices` 

The function `Dompdf\\Cpdf->openFont()` were called with an empty $font, it was on shared hosting with open_basedir restrictions.

Here is the full stacktrace: 

```
[2021-10-20 20:23:47] production.INFO: FONT LOADED: /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/fonts/Helvetica  
[2021-10-20 20:23:47] production.INFO: FONT LOADED: /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/fonts/DejaVuSans  
[2021-10-20 20:23:47] production.INFO: FONT LOADED: /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/fonts/Times-Bold  
[2021-10-20 20:23:47] production.INFO: FONT LOADED: /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/fonts/DejaVuSans-Bold  
[2021-10-20 20:23:47] production.INFO: FONT LOADED:   
[2021-10-20 20:23:47] production.ERROR: file_exists(): open_basedir restriction in effect. File(/.ufm) is not within the allowed path(s): (/:/tmp/) {"userId":1,"exception":"[object] (ErrorException(code: 0): file_exists(): open_basedir restriction in effect. File(/.ufm) is not within the allowed path(s): (/:/tmp/) at /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/Cpdf.php:3341)
[stacktrace]
#0 [internal function]: Illuminate\\Foundation\\Bootstrap\\HandleExceptions->handleError()
#1 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/Cpdf.php(3341): file_exists()
#2 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/lib/Cpdf.php(3549): Dompdf\\Cpdf->openFont()
#3 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/Adapter/CPDF.php(1030): Dompdf\\Cpdf->selectFont()
#4 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/FontMetrics.php(327): Dompdf\\Adapter\\CPDF->get_text_width()
#5 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/FontMetrics.php(294): Dompdf\\FontMetrics->getTextWidth()
#6 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/PhpEvaluator.php(53) : eval()'d code(6): Dompdf\\FontMetrics->get_text_width()
#7 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/PhpEvaluator.php(53): eval()
#8 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/PhpEvaluator.php(61): Dompdf\\PhpEvaluator->evaluate()
#9 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/Renderer.php(293): Dompdf\\PhpEvaluator->render()
#10 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/Renderer.php(138): Dompdf\\Renderer->_render_frame()
#11 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/Renderer.php(194): Dompdf\\Renderer->render()
#12 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/FrameReflower/Page.php(148): Dompdf\\Renderer->render()
#13 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/FrameDecorator/AbstractFrameDecorator.php(895): Dompdf\\FrameReflower\\Page->reflow()
#14 /httpdocs/plugins/invoicepro/vendor/dompdf/dompdf/src/Dompdf.php(838): Dompdf\\FrameDecorator\\AbstractFrameDecorator->reflow()
#15 /httpdocs/plugins/invoicepro/vendor/barryvdh/laravel-dompdf/src/PDF.php(208): Dompdf\\Dompdf->render()
#16 /httpdocs/plugins/invoicepro/vendor/barryvdh/laravel-dompdf/src/PDF.php(155): Barryvdh\\DomPDF\\PDF->render()
```

The `FONT LOADED` part was to log the current font and was placed just above where the error was at `Cpdf.php(3341)`

Adding this little if empty fixed the error