### PR TITLE
Small updates to `min-width`/`max-width` support for table cells

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -640,6 +640,7 @@ class Cellmap
             if ($min_width !== "auto" && !Helpers::is_percent($min_width)) {
                 $specified_min = (float) $style->length_in_pt($min_width);
                 $frame_min = max($frame_min, $specified_min);
+                $frame_max = max($frame_max, $frame_min);
             }
 
             if ($max_width !== "none" && !Helpers::is_percent($max_width)) {

--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -644,10 +644,10 @@ class Cellmap
             }
 
             if ($max_width !== "none" && !Helpers::is_percent($max_width)) {
-                // `min-width` and the natural minimum width take precedence
-                // over `max-width` here
+                // `min-width` takes precedence over `max-width` here
                 $specified_max = (float) $style->length_in_pt($max_width);
-                $frame_max = max(min($frame_max, $specified_max), $frame_min);
+                $frame_max = max(min($frame_max, $specified_max), $specified_min ?? 0);
+                $frame_min = min($frame_min, $frame_max);
             }
 
             $width = $style->width;


### PR DESCRIPTION
* Fix min-width not being honored on table cell in case its natural max width is smaller. Small oversight from #2591.
* Let `max-width` take precedence over natural minimum width. Closer to browser handling and very handy in combination with `overflow-wrap: break-word` (see #2626).