### PR TITLE
`overflow-wrap` and `get_min_max_width` fixes

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -406,6 +406,7 @@ class Style
             $d["outline_offset"] = "0";
             $d["outline"] = "";
             $d["overflow"] = "visible";
+            $d["overflow_wrap"] = "normal";
             $d["padding_top"] = "0";
             $d["padding_right"] = "0";
             $d["padding_bottom"] = "0";
@@ -443,7 +444,6 @@ class Style
             $d["voice_family"] = "";
             $d["volume"] = "medium";
             $d["white_space"] = "normal";
-            $d["word_wrap"] = "normal";
             $d["widows"] = "2";
             $d["width"] = "auto";
             $d["word_spacing"] = "normal";
@@ -492,6 +492,7 @@ class Style
                 "list_style_type",
                 "list_style",
                 "orphans",
+                "overflow_wrap",
                 "pitch_range",
                 "pitch",
                 "quotes",
@@ -509,7 +510,6 @@ class Style
                 "voice_family",
                 "volume",
                 "white_space",
-                "word_wrap",
                 "widows",
                 "word_spacing",
             ];
@@ -905,6 +905,11 @@ class Style
     {
         $prop = str_replace("-", "_", $prop);
 
+        // Legacy property aliases
+        if ($prop === "word_wrap") {
+            $prop = "overflow_wrap";
+        }
+
         if (!isset(self::$_defaults[$prop])) {
             global $_dompdf_warnings;
             $_dompdf_warnings[] = "'$prop' is not a recognized CSS property.";
@@ -960,6 +965,11 @@ class Style
      */
     function __get($prop)
     {
+        // Legacy property aliases
+        if ($prop === "word_wrap") {
+            $prop = "overflow_wrap";
+        }
+
         //FIXME: need to get shorthand from component properties
         if (!isset(self::$_defaults[$prop])) {
             throw new Exception("'$prop' is not a recognized CSS property.");
@@ -1027,6 +1037,11 @@ class Style
     {
         $prop = str_replace("-", "_", $prop);
 
+        // Legacy property aliases
+        if ($prop === "word_wrap") {
+            $prop = "overflow_wrap";
+        }
+
         if (!isset(self::$_defaults[$prop])) {
             global $_dompdf_warnings;
             $_dompdf_warnings[] = "'$prop' is not a recognized CSS property.";
@@ -1055,6 +1070,11 @@ class Style
      */
     function get_prop($prop)
     {
+        // Legacy property aliases
+        if ($prop === "word_wrap") {
+            $prop = "overflow_wrap";
+        }
+
         if (!isset(self::$_defaults[$prop])) {
             throw new Exception("'$prop' is not a recognized CSS property.");
         }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -165,7 +165,9 @@ class Text extends AbstractFrameReflower
             $str .= $word;
         }
 
-        $break_word = ($style->word_wrap === "break-word");
+        // https://www.w3.org/TR/css-text-3/#overflow-wrap-property
+        $wrap = $style->overflow_wrap;
+        $break_word = $wrap === "anywhere" || $wrap === "break-word";
 
         // The first word has overflowed.   Force it onto the line
         if ($current_line_width == 0 && $width == 0) {
@@ -515,7 +517,10 @@ class Text extends AbstractFrameReflower
         $min_word = $min;
         $max += $delta;
 
-        if ($style->word_wrap === 'break-word') {
+        // https://www.w3.org/TR/css-text-3/#overflow-wrap-property
+        if ($style->overflow_wrap === "anywhere"
+            && !in_array($style->white_space, ["pre", "nowrap"], true)
+        ) {
             // If it is allowed to break words, the min width is the widest character.
             // But for performance reasons, we only check the first character.
             $char = mb_substr($str, 0, 1);
@@ -546,7 +551,10 @@ class Text extends AbstractFrameReflower
         $word_spacing = (float)$style->length_in_pt($style->word_spacing);
         $char_spacing = (float)$style->length_in_pt($style->letter_spacing);
 
-        if ($style->word_wrap === 'break-word' && !in_array($style->white_space, ["pre", "nowrap"], true)) {
+        // https://www.w3.org/TR/css-text-3/#overflow-wrap-property
+        if ($style->overflow_wrap === "anywhere"
+            && !in_array($style->white_space, ["pre", "nowrap"], true)
+        ) {
             // If it is allowed to break words, the min width is the widest character.
             // But for performance reasons, we only check the first character.
             $char = mb_substr($str, 0, 1);


### PR DESCRIPTION
* Add support for `overflow-wrap`, including the `anywhere` keyword
* Fix `break-word` to not affect min-content width
* Make `word-wrap` an alias of `overflow-wrap`
* Improve handling of fixed `width` in `get_min_max_width`
  * Honor fixed widths on frames other than table cells
  * For table cells, make a fixed width override the natural max width

See https://www.w3.org/TR/css-text-3/#overflow-wrap-property

Addresses #382
Addresses #1017
Addresses #2248