### PR TITLE
Fix rendering of zero-width blocks

### DIFF
--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -164,7 +164,7 @@ class Block extends AbstractFrameDecorator
 
         // FIXME: Why? Doesn't quite seem to be the correct thing to do,
         // but does appear to be necessary. Hack to handle wrapped white space?
-        if ($w == 0 && $frame->get_node()->nodeName !== "hr" && !$frame->is_pre()) {
+        if ($w === 0.0 && $frame->is_text_node() && !$frame->is_pre()) {
             return;
         }
 


### PR DESCRIPTION
Revealed by a slight modification of the test case from #2645:

<details>
<summary>HTML</summary>

```html
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style>
@page {
    size: 400pt 300pt;
    margin: 50pt;
}

body {
    outline: 0.5pt solid black;
}

.zero-1 {
    width: 0;
    outline: 1pt solid red;
}

.zero-2 {
    padding-right: 160pt;
    padding-left: 160pt;
    margin-right: auto;
    margin-left: auto;
    outline: 1pt solid red;
}
</style>
</head>

<body>
    <div class="zero-1">
        <p>Zero width</p>
    </div>

    <div class="zero-2">
        <p>Over-constrained</p>
    </div>
</body>

</html>
```
</details>

[zero-width-before.pdf](https://github.com/dompdf/dompdf/files/7556813/zero-width-before.pdf)
[zero-width-after.pdf](https://github.com/dompdf/dompdf/files/7556811/zero-width-after.pdf)