### PR TITLE
Clean up `add_frame_to_line`

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -732,7 +732,7 @@ class Cellmap
     {
         $key = $row->get_id();
         if (!isset($this->_frames[$key])) {
-            return; // Presumably this row has alredy been removed
+            return; // Presumably this row has already been removed
         }
 
         $this->__row = $this->_num_rows--;
@@ -780,7 +780,7 @@ class Cellmap
     {
         $key = $group->get_id();
         if (!isset($this->_frames[$key])) {
-            return; // Presumably this row has alredy been removed
+            return; // Presumably this row has already been removed
         }
 
         $iter = $group->get_first_child();
@@ -802,10 +802,15 @@ class Cellmap
     public function update_row_group(Frame $group, Frame $last_row)
     {
         $g_key = $group->get_id();
-        $r_key = $last_row->get_id();
 
-        $r_rows = $this->_frames[$g_key]["rows"];
-        $this->_frames[$g_key]["rows"] = range($this->_frames[$g_key]["rows"][0], end($r_rows));
+        $first_index = $this->_frames[$g_key]["rows"][0];
+        $last_index = $first_index;
+        $row = $last_row;
+        while ($row = $row->get_prev_sibling()) {
+            $last_index++;
+        }
+
+        $this->_frames[$g_key]["rows"] = range($first_index, $last_index);
     }
 
     /**

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -164,7 +164,7 @@ class Block extends AbstractFrameDecorator
 
         // FIXME: Why? Doesn't quite seem to be the correct thing to do,
         // but does appear to be necessary. Hack to handle wrapped white space?
-        if ($w == 0 && $frame->get_node()->nodeName !== "hr" && !$frame->is_pre()) {
+        if ($w === 0.0 && $frame->is_text_node() && !$frame->is_pre()) {
             return;
         }
 

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -108,12 +108,6 @@ class Block extends AbstractFrameDecorator
      */
     function add_frame_to_line(Frame $frame)
     {
-        if (!$frame->is_in_flow()) {
-            return;
-        }
-
-        $style = $frame->get_style();
-
         $frame->set_containing_line($this->_line_boxes[$this->_cl]);
 
         /*
@@ -136,6 +130,7 @@ class Block extends AbstractFrameDecorator
         if ($frame instanceof Inline) {
             // Handle line breaks
             if ($frame->get_node()->nodeName === "br") {
+                $style = $frame->get_style();
                 $this->maximize_line_height($style->line_height, $frame);
                 $this->add_line(true);
 
@@ -162,8 +157,7 @@ class Block extends AbstractFrameDecorator
 
         $w = $frame->get_margin_width();
 
-        // FIXME: Why? Doesn't quite seem to be the correct thing to do,
-        // but does appear to be necessary. Hack to handle wrapped white space?
+        // FIXME: Hack to handle wrapped white space
         if ($w === 0.0 && $frame->is_text_node() && !$frame->is_pre()) {
             return;
         }

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -149,8 +149,8 @@ class Text extends AbstractFrameDecorator
     // Text manipulation methods
 
     /**
-     * split the text in this frame at the offset specified.  The remaining
-     * text is added a sibling frame following this one and is returned.
+     * Split the text in this frame at the offset specified.  The remaining
+     * text is added as a sibling frame following this one and is returned.
      *
      * @param int $offset
      * @return Frame|null

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -280,7 +280,6 @@ abstract class AbstractFrameReflower
 
     /**
      * @param Block|null $block
-     * @return mixed
      */
     abstract function reflow(Block $block = null);
 

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -779,7 +779,6 @@ class Block extends AbstractFrameReflower
 
     /**
      * @param BlockFrameDecorator $block
-     * @return mixed|void
      */
     function reflow(BlockFrameDecorator $block = null)
     {
@@ -858,7 +857,6 @@ class Block extends AbstractFrameReflower
 
         // Set the containing blocks and reflow each child
         foreach ($this->_frame->get_children() as $child) {
-
             // Bail out if the page is full
             if ($page->is_full()) {
                 break;
@@ -876,6 +874,12 @@ class Block extends AbstractFrameReflower
             }
 
             $this->process_float($child, $cb_x, $width);
+        }
+
+        // Stop reflow if a page break has occurred before the frame, in which
+        // case it has been reset, including its position
+        if ($page->is_full() && $this->_frame->get_position("x") === null) {
+            return;
         }
 
         // Determine our height

--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -49,10 +49,11 @@ class Image extends AbstractFrameReflower
         $this->get_min_max_width();
         $this->resolve_margins();
 
-        $this->_frame->position();
+        $frame = $this->_frame;
+        $frame->position();
 
-        if ($block) {
-            $block->add_frame_to_line($this->_frame);
+        if ($block && $frame->is_in_flow()) {
+            $block->add_frame_to_line($frame);
         }
     }
 

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -85,7 +85,7 @@ class Inline extends AbstractFrameReflower
         $cb = $frame->get_containing_block();
 
         if ($block) {
-            $block->add_frame_to_line($this->_frame);
+            $block->add_frame_to_line($frame);
         }
 
         // Set the containing blocks and reflow each child.  The containing
@@ -96,7 +96,7 @@ class Inline extends AbstractFrameReflower
         }
 
         // Handle relative positioning
-        foreach ($this->_frame->get_children() as $child) {
+        foreach ($frame->get_children() as $child) {
             $this->position_relative($child);
         }
     }

--- a/src/FrameReflower/ListBullet.php
+++ b/src/FrameReflower/ListBullet.php
@@ -32,14 +32,15 @@ class ListBullet extends AbstractFrameReflower
      */
     function reflow(BlockFrameDecorator $block = null)
     {
-        $style = $this->_frame->get_style();
+        $frame = $this->_frame;
+        $style = $frame->get_style();
 
-        $style->width = $this->_frame->get_width();
-        $this->_frame->position();
+        $style->width = $frame->get_width();
+        $frame->position();
 
         if ($style->list_style_position === "inside") {
-            $p = $this->_frame->find_block_parent();
-            $p->add_frame_to_line($this->_frame);
+            $p = $frame->find_block_parent();
+            $p->add_frame_to_line($frame);
         }
     }
 }

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -358,7 +358,7 @@ class Table extends AbstractFrameReflower
     }
 
     /**
-     * @param BlockFrameDecorator $block
+     * @param BlockFrameDecorator|null $block
      */
     function reflow(BlockFrameDecorator $block = null)
     {
@@ -487,7 +487,13 @@ class Table extends AbstractFrameReflower
                 // Check if a split has occurred
                 $page->check_page_break($child);
             }
+        }
 
+        // Stop reflow if a page break has occurred before the frame, in which
+        // case it has been reset, including its position
+        if ($page->is_full() && $frame->get_position("x") === null) {
+            $page->table_reflow_end();
+            return;
         }
 
         // Assign heights to our cells:

--- a/src/FrameReflower/TableRowGroup.php
+++ b/src/FrameReflower/TableRowGroup.php
@@ -9,6 +9,7 @@ namespace Dompdf\FrameReflower;
 
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Table as TableFrameDecorator;
+use Dompdf\FrameDecorator\TableRowGroup as TableRowGroupFrameDecorator;
 
 /**
  * Reflows table row groups (e.g. tbody tags)
@@ -20,9 +21,9 @@ class TableRowGroup extends AbstractFrameReflower
 
     /**
      * TableRowGroup constructor.
-     * @param \Dompdf\Frame $frame
+     * @param TableRowGroupFrameDecorator $frame
      */
-    function __construct($frame)
+    function __construct(TableRowGroupFrameDecorator $frame)
     {
         parent::__construct($frame);
     }
@@ -32,37 +33,40 @@ class TableRowGroup extends AbstractFrameReflower
      */
     function reflow(BlockFrameDecorator $block = null)
     {
-        $page = $this->_frame->get_root();
+        /** @var TableRowGroupFrameDecorator */
+        $frame = $this->_frame;
 
-        $style = $this->_frame->get_style();
+        $page = $frame->get_root();
 
-        // Our width is equal to the width of our parent table
-        $table = TableFrameDecorator::find_parent_table($this->_frame);
+        $style = $frame->get_style();
+        $cb = $frame->get_containing_block();
 
-        $cb = $this->_frame->get_containing_block();
-
-        foreach ($this->_frame->get_children() as $child) {
+        foreach ($frame->get_children() as $child) {
             // Bail if the page is full
             if ($page->is_full()) {
-                return;
+                break;
             }
 
             $child->set_containing_block($cb["x"], $cb["y"], $cb["w"], $cb["h"]);
             $child->reflow();
 
-            // Check if a split has occured
+            // Check if a split has occurred
             $page->check_page_break($child);
         }
 
-        if ($page->is_full()) {
+        $table = TableFrameDecorator::find_parent_table($frame);
+        $cellmap = $table->get_cellmap();
+
+        // Stop reflow if a page break has occurred before the frame, in which
+        // case it is not part of its parent table's cell map yet
+        if ($page->is_full() && !$cellmap->frame_exists_in_cellmap($frame)) {
             return;
         }
 
-        $cellmap = $table->get_cellmap();
-        $style->width = $cellmap->get_frame_width($this->_frame);
-        $style->height = $cellmap->get_frame_height($this->_frame);
+        $style->width = $cellmap->get_frame_width($frame);
+        $style->height = $cellmap->get_frame_height($frame);
 
-        $this->_frame->set_position($cellmap->get_frame_position($this->_frame));
+        $frame->set_position($cellmap->get_frame_position($frame));
 
         if ($table->get_style()->border_collapse === "collapse") {
             // Unset our borders because our cells are now using them

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -394,7 +394,7 @@ class Text extends AbstractFrameReflower
         if ($block) {
             $block->add_frame_to_line($frame);
 
-            if ($add_line === true) {
+            if ($add_line) {
                 $block->add_line();
             }
         }

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -313,7 +313,7 @@ class LineBox
      */
     public function recalculate_width()
     {
-        $width = 0;
+        $width = 0.0;
 
         foreach ($this->_frames as $frame) {
             $width += $frame->get_margin_width();


### PR DESCRIPTION
The <del>first</del> second commit is a followup to #2647, which breaks the following test case:

<details>
<summary>HTML</summary>

```html
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style>
@page {
    size: 400pt 300pt;
    margin: 50pt;
}

div {
    outline: 2pt solid red;
}

p {
    margin: 0;
    height: 100pt;
    background-color: lightblue;
}
</style>
</head>

<body>
    <div>
        <p>First</p>
        <p>Second</p>
        <p>Third</p>
        <p>Fourth</p>
    </div>
</body>

</html>
```
</details>

[line-boxes-before.pdf](https://github.com/dompdf/dompdf/files/7577042/line-boxes-before.pdf)
[line-boxes-after.pdf](https://github.com/dompdf/dompdf/files/7577043/line-boxes-after.pdf)

The zero-width check in the `add_frame_to_line` method was not only used for handling wrapped white space, but also for preventing frames which were moved to the next page from being added to the line box on the previous page. This worked because of the style reset after a page break, unless they had a specified width, in which case the check failed (can be observed by adding a specific width to the `p` elements in the test case).

Following that, the second commit cleans up the white-space-trimming logic, which includes addressing #2638.

Fixes #1259
Fixes #2638