### PR TITLE
Allow legacy installed font info distribution file

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -133,8 +133,7 @@ class FontMetrics
 
         $file = $rootDir . "/lib/fonts/dompdf_font_family_cache.dist.php";
         $distFontsClosure = require $file;
-        $distFonts = $distFontsClosure($rootDir);
-
+        $distFonts = is_array($distFontsClosure) ? $distFontsClosure : $distFontsClosure($rootDir);
         if (!is_readable($this->getCacheFile())) {
             $this->fontLookup = $distFonts;
             return;


### PR DESCRIPTION
Because Dompdf allows some customization of its operational parameters a user may load a custom dompdf_font_family_cache.dist.php. If a user has created and is loading such a file, and is using a pre-1.1.0 format, Dompdf will fail to run. This change allows Dompdf to utilize the file regardless of which format it is in.

fixes #2648