### PR TITLE
Clean up min/max width/height code

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -397,8 +397,8 @@ class Style
             $d["margin"] = "";
             $d["max_height"] = "none";
             $d["max_width"] = "none";
-            $d["min_height"] = "0";
-            $d["min_width"] = "0";
+            $d["min_height"] = "auto";
+            $d["min_width"] = "auto";
             $d["orphans"] = "2";
             $d["outline_color"] = ""; // "invert" special color is not supported
             $d["outline_style"] = "none";

--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -111,12 +111,11 @@ class Image extends AbstractFrameReflower
         }
 
         // Handle min/max width/height
-        if ($style->min_width !== "none" ||
+        if ($style->min_width !== "auto" ||
             $style->max_width !== "none" ||
-            $style->min_height !== "none" ||
+            $style->min_height !== "auto" ||
             $style->max_height !== "none"
         ) {
-
             list( /*$x*/, /*$y*/, $w, $h) = $frame->get_containing_block();
 
             $min_width = $style->length_in_pt($style->min_width, $w);
@@ -124,36 +123,36 @@ class Image extends AbstractFrameReflower
             $min_height = $style->length_in_pt($style->min_height, $h);
             $max_height = $style->length_in_pt($style->max_height, $h);
 
-            if ($max_width !== "none" && $max_width !== "auto" && $width > (float)$max_width) {
+            if ($max_width !== "none" && $max_width !== "auto" && $width > $max_width) {
                 if (!$height_forced) {
-                    $height *= (float)$max_width / $width;
+                    $height *= $max_width / $width;
                 }
 
-                $width = (float)$max_width;
+                $width = $max_width;
             }
 
-            if ($min_width !== "none" && $min_width !== "auto" && $width < (float)$min_width) {
+            if ($min_width !== "auto" && $min_width !== "none" && $width < $min_width) {
                 if (!$height_forced) {
-                    $height *= (float)$min_width / $width;
+                    $height *= $min_width / $width;
                 }
 
-                $width = (float)$min_width;
+                $width = $min_width;
             }
 
-            if ($max_height !== "none" && $max_height !== "auto" && $height > (float)$max_height) {
+            if ($max_height !== "none" && $max_height !== "auto" && $height > $max_height) {
                 if (!$width_forced) {
-                    $width *= (float)$max_height / $height;
+                    $width *= $max_height / $height;
                 }
 
-                $height = (float)$max_height;
+                $height = $max_height;
             }
 
-            if ($min_height !== "none" && $min_height !== "auto" && $height < (float)$min_height) {
+            if ($min_height !== "auto" && $min_height !== "none" && $height < $min_height) {
                 if (!$width_forced) {
-                    $width *= (float)$min_height / $height;
+                    $width *= $min_height / $height;
                 }
 
-                $height = (float)$min_height;
+                $height = $min_height;
             }
         }
 
@@ -164,9 +163,9 @@ class Image extends AbstractFrameReflower
         $style->width = $width;
         $style->height = $height;
 
-        $style->min_width = "none";
+        $style->min_width = "auto";
         $style->max_width = "none";
-        $style->min_height = "none";
+        $style->min_height = "auto";
         $style->max_height = "none";
 
         return [$width, $width, "min" => $width, "max" => $width];

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -9,6 +9,7 @@ namespace Dompdf\FrameReflower;
 
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Table as TableFrameDecorator;
+use Dompdf\Helpers;
 
 /**
  * Reflows tables
@@ -288,70 +289,60 @@ class Table extends AbstractFrameReflower
     /**
      * Determine the frame's height based on min/max height
      *
-     * @return float|int|mixed|string
+     * @return float
      */
     protected function _calculate_height()
     {
-        $style = $this->_frame->get_style();
-        $height = $style->height;
+        $frame = $this->_frame;
+        $style = $frame->get_style();
+        $cb = $frame->get_containing_block();
 
-        $cellmap = $this->_frame->get_cellmap();
+        $height = $style->length_in_pt($style->height, $cb["h"]);
+
+        $cellmap = $frame->get_cellmap();
         $cellmap->assign_frame_heights();
         $rows = $cellmap->get_rows();
 
         // Determine our content height
-        $content_height = 0;
+        $content_height = 0.0;
         foreach ($rows as $r) {
             $content_height += $r["height"];
         }
 
-        $cb = $this->_frame->get_containing_block();
+        if ($height === "auto") {
+            $height = $content_height;
+        }
 
-        if (!($style->overflow === "visible" ||
-            ($style->overflow === "hidden" && $height === "auto"))
-        ) {
-            // Only handle min/max height if the height is independent of the frame's content
+        // Handle min/max height
+        $min_height = $style->min_height;
+        $max_height = $style->max_height;
 
-            $min_height = $style->min_height;
-            $max_height = $style->max_height;
-
-            if (isset($cb["h"])) {
-                $min_height = $style->length_in_pt($min_height, $cb["h"]);
-                $max_height = $style->length_in_pt($max_height, $cb["h"]);
-
-            } else if (isset($cb["w"])) {
-                if (mb_strpos($min_height, "%") !== false) {
-                    $min_height = 0;
-                } else {
-                    $min_height = $style->length_in_pt($min_height, $cb["w"]);
-                }
-                if (mb_strpos($max_height, "%") !== false) {
-                    $max_height = "none";
-                } else {
-                    $max_height = $style->length_in_pt($max_height, $cb["w"]);
-                }
-            }
-
-            if ($max_height !== "none" && $max_height !== "auto" && $height > (float)$max_height) {
-                $height = $max_height;
-            }
-
-            if ($height < (float)$min_height) {
-                $height = $min_height;
-            }
+        if (isset($cb["h"])) {
+            $min_height = $style->length_in_pt($min_height, $cb["h"]);
+            $max_height = $style->length_in_pt($max_height, $cb["h"]);
         } else {
-            // Use the content height or the height value, whichever is greater
-            if ($height !== "auto") {
-                $height = $style->length_in_pt($height, $cb["h"]);
+            $min_height = !Helpers::is_percent($min_height)
+                ? $style->length_in_pt($min_height, $cb["w"])
+                : "auto";
+            $max_height = !Helpers::is_percent($max_height)
+                ? $style->length_in_pt($max_height, $cb["w"])
+                : "none";
+        }
 
-                if ($height <= $content_height) {
-                    $height = $content_height;
-                } else {
-                    $cellmap->set_frame_heights($height, $content_height);
-                }
-            } else {
-                $height = $content_height;
-            }
+        if ($max_height !== "none" && $max_height !== "auto" && $height > $max_height) {
+            $height = $max_height;
+        }
+
+        if ($min_height !== "auto" && $min_height !== "none" && $height < $min_height) {
+            $height = $min_height;
+        }
+
+        // Use the content height or the height value, whichever is greater
+        if ($height <= $content_height) {
+            $height = $content_height;
+        } else {
+            // FIXME: Borders and row positions are not properly updated by this
+            // $cellmap->set_frame_heights($height, $content_height);
         }
 
         return $height;


### PR DESCRIPTION
No tangible benefits in practice, this is mostly making the code more consistent and easier to build upon in the future.

The initial value for `min-width/height` is now `auto`, per newest spec.

See https://www.w3.org/TR/css-sizing-3/#min-size-properties