### PR TITLE
Improve list-marker positioning

### DIFF
--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -351,7 +351,7 @@ class FontMetrics
     }
 
     /**
-     * Calculates font height
+     * Calculates font height, in points
      *
      * @param string $font
      * @param float $size
@@ -361,6 +361,19 @@ class FontMetrics
     public function getFontHeight($font, $size)
     {
         return $this->canvas->get_font_height($font, $size);
+    }
+
+    /**
+     * Calculates font baseline, in points
+     *
+     * @param string $font
+     * @param float $size
+     *
+     * @return float
+     */
+    public function getFontBaseline($font, $size)
+    {
+        return $this->canvas->get_font_baseline($font, $size);
     }
 
     /**

--- a/src/FrameDecorator/ListBullet.php
+++ b/src/FrameDecorator/ListBullet.php
@@ -18,13 +18,40 @@ use Dompdf\Frame;
  */
 class ListBullet extends AbstractFrameDecorator
 {
+    /**
+     * Bullet diameter as fraction of font size.
+     */
+    public const BULLET_SIZE = 0.35;
 
-    const BULLET_PADDING = 1; // Distance from bullet to text in pt
-    // As fraction of font size (including descent). See also DECO_THICKNESS.
-    const BULLET_THICKNESS = 0.04; // Thickness of bullet outline. Screen: 0.08, print: better less, e.g. 0.04
-    const BULLET_DESCENT = 0.3; //descent of font below baseline. Todo: Guessed for now.
-    const BULLET_SIZE = 0.35; // bullet diameter. For now 0.5 of font_size without descent.
+    /**
+     * Bullet offset from font baseline as fraction of font size.
+     */
+    public const BULLET_OFFSET = 0.1;
 
+    /**
+     * Thickness of bullet outline as fraction of font size.
+     * See also `DECO_THICKNESS`. Screen: 0.08, print: better less, e.g. 0.04.
+     */
+    public const BULLET_THICKNESS = 0.04;
+
+    /**
+     * Indentation from the start of the line as fraction of font size.
+     */
+    public const MARKER_INDENT = 0.52;
+
+    /**
+     * @deprecated
+     */
+    const BULLET_PADDING = 1;
+
+    /**
+     * @deprecated
+     */
+    const BULLET_DESCENT = 0.3;
+
+    /**
+     * @deprecated
+     */
     static $BULLET_TYPES = ["disc", "circle", "square"];
 
     /**
@@ -38,25 +65,11 @@ class ListBullet extends AbstractFrameDecorator
     }
 
     /**
-     * @return float
-     */
-    public function get_margin_width(): float
-    {
-        $style = $this->_frame->get_style();
-
-        if ($style->list_style_type === "none") {
-            return 0.0;
-        }
-
-        return $style->font_size * self::BULLET_SIZE + 2 * self::BULLET_PADDING;
-    }
-
-    /**
-     * hits only on "inset" lists items, to increase height of box
+     * Get the width of the bullet symbol.
      *
      * @return float
      */
-    public function get_margin_height(): float
+    public function get_width(): float
     {
         $style = $this->_frame->get_style();
 
@@ -64,24 +77,58 @@ class ListBullet extends AbstractFrameDecorator
             return 0.0;
         }
 
-        return $style->font_size * self::BULLET_SIZE + 2 * self::BULLET_PADDING;
+        return $style->font_size * self::BULLET_SIZE;
     }
 
     /**
-     * @return float|int
+     * Get the height of the bullet symbol.
+     *
+     * @return float
      */
-    function get_width()
+    public function get_height(): float
     {
-        return $this->get_margin_width();
+        $style = $this->_frame->get_style();
+
+        if ($style->list_style_type === "none") {
+            return 0.0;
+        }
+
+        return $style->font_size * self::BULLET_SIZE;
     }
 
     /**
-     * @return float|int
+     * Get the width of the bullet, including indentation.
      */
-    function get_height()
+    public function get_margin_width(): float
     {
-        return $this->get_margin_height();
+        $style = $this->get_style();
+
+        if ($style->list_style_type === "none") {
+            return 0.0;
+        }
+
+        return $style->font_size * (self::BULLET_SIZE + self::MARKER_INDENT);
     }
 
-    //........................................................................
+    /**
+     * Get the line height for the bullet.
+     *
+     * This increases the height of the corresponding line box when necessary.
+     */
+    public function get_margin_height(): float
+    {
+        $style = $this->get_style();
+
+        if ($style->list_style_type === "none") {
+            return 0.0;
+        }
+
+        // TODO: This is a copy of `FrameDecorator\Text::get_margin_height()`
+        // Would be nice to properly refactor that at some point
+        $font = $style->font_family;
+        $size = $style->font_size;
+        $fontHeight = $this->_dompdf->getFontMetrics()->getFontHeight($font, $size);
+
+        return ($style->line_height / ($size > 0 ? $size : 1)) * $fontHeight;
+    }
 }

--- a/src/FrameDecorator/ListBulletImage.php
+++ b/src/FrameDecorator/ListBulletImage.php
@@ -18,7 +18,7 @@ use Dompdf\Image\Cache;
  *
  * @package dompdf
  */
-class ListBulletImage extends AbstractFrameDecorator
+class ListBulletImage extends ListBullet
 {
 
     /**
@@ -31,22 +31,21 @@ class ListBulletImage extends AbstractFrameDecorator
     /**
      * The image's width in pixels
      *
-     * @var int
+     * @var float
      */
     protected $_width;
 
     /**
      * The image's height in pixels
      *
-     * @var int
+     * @var float
      */
     protected $_height;
 
     /**
-     * Class constructor
-     *
-     * @param Frame $frame   the bullet frame to decorate
-     * @param Dompdf $dompdf the document's dompdf object
+     * ListBulletImage constructor.
+     * @param Frame $frame
+     * @param Dompdf $dompdf
      */
     function __construct(Frame $frame, Dompdf $dompdf)
     {
@@ -56,106 +55,54 @@ class ListBulletImage extends AbstractFrameDecorator
         $this->_img = new Image($frame, $dompdf);
         parent::__construct($this->_img, $dompdf);
 
-        if (Cache::is_broken($this->_img->get_image_url())) {
-            $width = 0;
-            $height = 0;
+        $url = $this->_img->get_image_url();
+
+        if (Cache::is_broken($url)) {
+            $this->_width = parent::get_width();
+            $this->_height = parent::get_height();
         } else {
-            list($width, $height) = Helpers::dompdf_getimagesize($this->_img->get_image_url(), $dompdf->getHttpContext());
-        }
+            [$width, $height] = Helpers::dompdf_getimagesize($url, $dompdf->getHttpContext());
 
-        // Resample the bullet image to be consistent with 'auto' sized images
-        // See also Image::get_min_max_width
-        // Tested php ver: value measured in px, suffix "px" not in value: rtrim unnecessary.
-        $dpi = $this->_dompdf->getOptions()->getDpi();
-        $this->_width = ((float)rtrim($width, "px") * 72) / $dpi;
-        $this->_height = ((float)rtrim($height, "px") * 72) / $dpi;
-
-        //If an image is taller as the containing block/box, the box should be extended.
-        //Neighbour elements are overwriting the overlapping image areas.
-        //Todo: Where can the box size be extended?
-        //Code below has no effect.
-        //See block_frame_reflower _calculate_restricted_height
-        //See generated_frame_reflower, Dompdf:render() "list-item", "-dompdf-list-bullet"S.
-        //Leave for now
-        //if ($style->min_height < $this->_height ) {
-        //  $style->min_height = $this->_height;
-        //}
-        //$style->height = "auto";
-    }
-
-    /**
-     * Return the bullet's width
-     *
-     * @return int
-     */
-    function get_width()
-    {
-        //ignore image width, use same width as on predefined bullet ListBullet
-        //for proper alignment of bullet image and text. Allow image to not fitting on left border.
-        //This controls the distance between bullet image and text
-        //return $this->_width;
-        return $this->_frame->get_style()->font_size * ListBullet::BULLET_SIZE +
-        2 * ListBullet::BULLET_PADDING;
-    }
-
-    /**
-     * Return the bullet's height
-     *
-     * @return int
-     */
-    function get_height()
-    {
-        //based on image height
-        if ($this->_height == 0) {
-            $style = $this->_frame->get_style();
-
-            if ($style->list_style_type === "none") {
-                return 0;
-            }
-    
-            return $style->font_size * ListBullet::BULLET_SIZE + 2 * ListBullet::BULLET_PADDING;
-        } else {
-            return $this->_height;
+            // Resample the bullet image to be consistent with 'auto' sized images
+            // See also Image::get_min_max_width
+            $dpi = $this->_dompdf->getOptions()->getDpi();
+            $this->_width = ((float) $width * 72) / $dpi;
+            $this->_height = ((float) $height * 72) / $dpi;
         }
     }
 
-    /**
-     * Override get_margin_width
-     *
-     * @return int
-     */
+    public function get_width(): float
+    {
+        return $this->_width;
+    }
+
+    public function get_height(): float
+    {
+        return $this->_height;
+    }
+
     public function get_margin_width(): float
     {
-        //ignore image width, use same width as on predefined bullet ListBullet
-        //for proper alignment of bullet image and text. Allow image to not fitting on left border.
-        //This controls the extra indentation of text to make room for the bullet image.
-        //Here use actual image size, not predefined bullet size
-        //return $this->_frame->get_style()->font_size*ListBullet::BULLET_SIZE +
-        //  2 * ListBullet::BULLET_PADDING;
-
-        // Small hack to prevent indenting of list text
-        // Image might not exist, then position like on list_bullet_frame_decorator fallback to none.
-        if ($this->_frame->get_style()->list_style_position === "outside" || $this->_width == 0) {
-            return 0.0;
-        }
-        //This aligns the "inside" image position with the text.
-        //The text starts to the right of the image.
-        //Between the image and the text there is an added margin of image width.
-        //Where this comes from is unknown.
-        //The corresponding ListBullet sets a smaller margin. bullet size?
-        return $this->_width + 2 * ListBullet::BULLET_PADDING;
+        $style = $this->get_style();
+        return $this->_width + $style->font_size * self::MARKER_INDENT;
     }
 
-    /**
-     * Override get_margin_height()
-     *
-     * @return float
-     */
     public function get_margin_height(): float
     {
-        //Hits only on "inset" lists items, to increase height of box
-        //based on image height
-        return $this->_height + 2 * ListBullet::BULLET_PADDING;
+        $fontMetrics = $this->_dompdf->getFontMetrics();
+        $style = $this->get_style();
+        $font = $style->font_family;
+        $size = $style->font_size;
+        $fontHeight = $fontMetrics->getFontHeight($font, $size);
+        $baseline = $fontMetrics->getFontBaseline($font, $size);
+
+        // This is the same factor as used in
+        // `FrameDecorator\Text::get_margin_height()`
+        $f = $style->line_height / ($size > 0 ? $size : 1);
+
+        // FIXME: Tries to approximate replacing the space above the font
+        // baseline with the image
+        return $f * ($fontHeight - $baseline) + $this->_height;
     }
 
     /**
@@ -167,5 +114,4 @@ class ListBulletImage extends AbstractFrameDecorator
     {
         return $this->_img->get_image_url();
     }
-
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -587,8 +587,8 @@ class Block extends AbstractFrameReflower
                     if (count($frames) === 1) {
                         continue;
                     }
-                    $frameBox = $frame->get_border_box();
-                    $imageHeightDiff = $height * 0.8 - $frameBox["h"];
+                    $marginHeight = $frame->get_margin_height();
+                    $imageHeightDiff = $height * 0.8 - $marginHeight;
 
                     $align = $frame->get_style()->vertical_align;
                     if (in_array($align, Style::$vertical_align_keywords, true)) {
@@ -623,7 +623,7 @@ class Block extends AbstractFrameReflower
                                 break;
                         }
                     } else {
-                        $y_offset = $baseline - (float)$style->length_in_pt($align, $style->font_size) - $frameBox["h"];
+                        $y_offset = $baseline - (float)$style->length_in_pt($align, $style->font_size) - $marginHeight;
                     }
                 } else {
                     $parent = $frame->get_parent();

--- a/src/FrameReflower/ListBullet.php
+++ b/src/FrameReflower/ListBullet.php
@@ -8,7 +8,7 @@
 namespace Dompdf\FrameReflower;
 
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
-use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\FrameDecorator\ListBullet as ListBulletFrameDecorator;
 
 /**
  * Reflows list bullets
@@ -20,9 +20,9 @@ class ListBullet extends AbstractFrameReflower
 
     /**
      * ListBullet constructor.
-     * @param AbstractFrameDecorator $frame
+     * @param ListBulletFrameDecorator $frame
      */
-    function __construct(AbstractFrameDecorator $frame)
+    function __construct(ListBulletFrameDecorator $frame)
     {
         parent::__construct($frame);
     }
@@ -32,6 +32,7 @@ class ListBullet extends AbstractFrameReflower
      */
     function reflow(BlockFrameDecorator $block = null)
     {
+        /** @var ListBulletFrameDecorator */
         $frame = $this->_frame;
         $style = $frame->get_style();
 
@@ -39,8 +40,9 @@ class ListBullet extends AbstractFrameReflower
         $frame->position();
 
         if ($style->list_style_position === "inside") {
-            $p = $frame->find_block_parent();
-            $p->add_frame_to_line($frame);
+            $block->add_frame_to_line($frame);
+        } else {
+            $block->add_dangling_marker($frame);
         }
     }
 }

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -335,6 +335,23 @@ class LineBox
     }
 
     /**
+     * An iterator of all list markers and inline positioned frames of the line
+     * box.
+     *
+     * @return \Iterator<AbstractFrameDecorator>
+     */
+    public function frames_to_align(): \Iterator
+    {
+        yield from $this->list_markers;
+
+        foreach ($this->_frames as $frame) {
+            if ($frame->get_positioner() instanceof InlinePositioner) {
+                yield $frame;
+            }
+        }
+    }
+
+    /**
      * Recalculate LineBox width based on the contained frames total width.
      *
      * @return float

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -9,6 +9,7 @@ namespace Dompdf;
 
 use Dompdf\FrameDecorator\AbstractFrameDecorator;
 use Dompdf\FrameDecorator\Block;
+use Dompdf\FrameDecorator\ListBullet;
 use Dompdf\FrameDecorator\Page;
 use Dompdf\Positioner\Inline as InlinePositioner;
 
@@ -32,6 +33,11 @@ class LineBox
      * @var AbstractFrameDecorator[]
      */
     protected $_frames = [];
+
+    /**
+     * @var ListBullet[]
+     */
+    protected $list_markers = [];
 
     /**
      * @var int
@@ -304,6 +310,28 @@ class LineBox
         }
 
         $this->h = $h;
+    }
+
+    /**
+     * Get the `outside` positioned list markers to be vertically aligned with
+     * the line box.
+     *
+     * @return ListBullet[]
+     */
+    public function get_list_markers(): array
+    {
+        return $this->list_markers;
+    }
+
+    /**
+     * Add a list marker to the line box.
+     *
+     * The list marker is only added for the purpose of vertical alignment, it
+     * is not actually added to the list of frames of the line box.
+     */
+    public function add_list_marker(ListBullet $marker): void
+    {
+        $this->list_markers[] = $marker;
     }
 
     /**

--- a/src/Positioner/ListBullet.php
+++ b/src/Positioner/ListBullet.php
@@ -10,6 +10,7 @@
 namespace Dompdf\Positioner;
 
 use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\FrameDecorator\ListBullet as ListBulletFrameDecorator;
 
 /**
  * Positions list bullets
@@ -18,61 +19,27 @@ use Dompdf\FrameDecorator\AbstractFrameDecorator;
  */
 class ListBullet extends AbstractPositioner
 {
-
     /**
-     * @param AbstractFrameDecorator $frame
+     * @param ListBulletFrameDecorator $frame
      */
     function position(AbstractFrameDecorator $frame)
     {
+        // List markers are positioned to the left of the border edge of their
+        // parent element (FIXME: right for RTL)
+        $parent = $frame->get_parent();
+        $style = $parent->get_style();
+        $cbw = $parent->get_containing_block("w");
+        $margin_left = (float) $style->length_in_pt($style->margin_left, $cbw);
+        $border_edge = $parent->get_position("x") + $margin_left;
 
-        // Bullets & friends are positioned an absolute distance to the left of
-        // the content edge of their parent element
-        $cb = $frame->get_containing_block();
+        // This includes the marker indentation
+        $x = $border_edge - $frame->get_margin_width();
 
-        // Note: this differs from most frames in that we must position
-        // ourselves after determining our width
-        $x = $cb["x"] - $frame->get_width();
-
+        // The marker is later vertically aligned with the corresponding line
+        // box and its vertical position is fine-tuned in the renderer
         $p = $frame->find_block_parent();
-
         $y = $p->get_current_line_box()->y;
 
-        // This is a bit of a hack...
-        $n = $frame->get_next_sibling();
-        if ($n) {
-            $style = $n->get_style();
-            $line_height = $style->line_height;
-            // TODO: should offset take into account the line height of the next sibling (per previous logic)?
-            // $offset = (float)$style->length_in_pt($line_height, $n->get_containing_block("h")) - $frame->get_height();
-            $offset = $line_height - $frame->get_height();
-            $y += $offset / 2;
-        }
-
-        // Now the position is the left top of the block which should be marked with the bullet.
-        // We tried to find out the y of the start of the first text character within the block.
-        // But the top margin/padding does not fit, neither from this nor from the next sibling
-        // The "bit of a hack" above does not work also.
-
-        // Instead let's position the bullet vertically centered to the block which should be marked.
-        // But for get_next_sibling() the get_containing_block is all zero, and for find_block_parent()
-        // the get_containing_block is paper width and the entire list as height.
-
-        // if ($p) {
-        //   //$cb = $n->get_containing_block();
-        //   $cb = $p->get_containing_block();
-        //   $y += $cb["h"]/2;
-        // print 'cb:'.$cb["x"].':'.$cb["y"].':'.$cb["w"].':'.$cb["h"].':';
-        // }
-
-        // Todo:
-        // For now give up on the above. Use Guesswork with font y-pos in the middle of the line spacing
-
-        /*$style = $p->get_style();
-        $font_size = $style->font_size;
-        $line_height = (float)$style->length_in_pt($style->line_height, $font_size);
-        $y += ($line_height - $font_size) / 2;    */
-
-        //Position is x-end y-top of character position of the bullet.
         $frame->set_position($x, $y);
     }
 }


### PR DESCRIPTION
* Fix horizontal position to be outside the border box of the parent instead of outside the content box
* Align bullet markers with the font baseline so that the vertical position adapts better to different fonts and sizes
* Handle vertical alignment of `outside` list markers to adapt their position for larger line heights. They now also affect the height of the corresponding line box
* Apply text alignment to list markers. This also ensures they are affected by floats
* Apply word and letter spacing for text markers

The following issue is still unresolved:

* Inside positioned text markers do not properly take the space they need. This is due to the fact that the exact marker text is only resolved in the renderer. To fix this, the marker text would need to be resolved in the reflow process, similar to counters (actually, most of the logic could be shared).

Fixes #478
Fixes #708
Fixes #1801
Fixes #1902
Fixes #2451