### PR TITLE
file_get_contents use_include_path parameter set from null to false a…

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -871,9 +871,9 @@ class Helpers
                     $uri = Helpers::encodeURI($uri);
                 }
                 if (isset($maxlen)) {
-                    $result = file_get_contents($uri, null, $context, $offset, $maxlen);
+                    $result = file_get_contents($uri, false, $context, $offset, $maxlen);
                 } else {
-                    $result = file_get_contents($uri, null, $context, $offset);
+                    $result = file_get_contents($uri, false, $context, $offset);
                 }
                 if ($result !== false) {
                     $content = $result;


### PR DESCRIPTION
If I'm not mistaken, dompdf should set the second parameter of file_get_contents as false instead of null. Can't see why it was null in the first place but it's now deprecated and displays warnings.