### PR TITLE
Image caching improvements

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -606,52 +606,6 @@ class CPDF implements Canvas
     }
 
     /**
-     * Convert image to a PNG image
-     *
-     * @param string $image_url
-     * @param int $type
-     *
-     * @throws Exception
-     * @return string The url of the newly converted image
-     */
-    protected function _convert_to_png($image_url, $type)
-    {
-        $func_name = "imagecreatefrom$type";
-
-        if (!function_exists($func_name)) {
-            if (!method_exists(Helpers::class, $func_name)) {
-                throw new Exception("Function $func_name() not found.  Cannot convert $type image: $image_url.  Please install the image PHP extension.");
-            }
-            $func_name = "\\Dompdf\\Helpers::" . $func_name;
-        }
-
-        set_error_handler([Helpers::class, 'record_warnings']);
-
-        try {
-            $im = call_user_func($func_name, $image_url);
-
-            if ($im) {
-                imageinterlace($im, false);
-
-                $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
-                $tmp_name = @tempnam($tmp_dir, "{$type}dompdf_img_");
-                @unlink($tmp_name);
-                $filename = "$tmp_name.png";
-                $this->_image_cache[] = $filename;
-
-                imagepng($im, $filename);
-                imagedestroy($im);
-            } else {
-                $filename = Cache::$broken_image;
-            }
-        } finally {
-            restore_error_handler();
-        }
-
-        return $filename;
-    }
-
-    /**
      * @param float $x1
      * @param float $y1
      * @param float $w
@@ -831,6 +785,52 @@ class CPDF implements Canvas
 
         $this->_set_fill_transparency("Normal", $this->_current_opacity);
         $this->_set_line_transparency("Normal", $this->_current_opacity);
+    }
+
+    /**
+     * Convert image to a PNG image
+     *
+     * @param string $image_url
+     * @param int $type
+     *
+     * @throws Exception
+     * @return string The url of the newly converted image
+     */
+    protected function _convert_to_png($image_url, $type)
+    {
+        $func_name = "imagecreatefrom$type";
+
+        if (!function_exists($func_name)) {
+            if (!method_exists(Helpers::class, $func_name)) {
+                throw new Exception("Function $func_name() not found.  Cannot convert $type image: $image_url.  Please install the image PHP extension.");
+            }
+            $func_name = "\\Dompdf\\Helpers::" . $func_name;
+        }
+
+        set_error_handler([Helpers::class, 'record_warnings']);
+
+        try {
+            $im = call_user_func($func_name, $image_url);
+
+            if ($im) {
+                imageinterlace($im, false);
+
+                $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
+                $tmp_name = @tempnam($tmp_dir, "{$type}dompdf_img_");
+                @unlink($tmp_name);
+                $filename = "$tmp_name.png";
+                $this->_image_cache[] = $filename;
+
+                imagepng($im, $filename);
+                imagedestroy($im);
+            } else {
+                $filename = Cache::$broken_image;
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        return $filename;
     }
 
     /**

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -735,10 +735,10 @@ class GD implements Canvas
 
         $func_name = "imagecreatefrom$img_type";
         if (!function_exists($func_name)) {
-            if (!method_exists("Dompdf\Helpers", $func_name)) {
+            if (!method_exists(Helpers::class, $func_name)) {
                 throw new \Exception("Function $func_name() not found.  Cannot convert $img_type image: $img_url.  Please install the image PHP extension.");
             }
-            $func_name = "\\Dompdf\\Helpers::" . $func_name;
+            $func_name = [Helpers::class, $func_name];
         }
         $src = @call_user_func($func_name, $img_url);
 

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -837,7 +837,9 @@ class Dompdf
         $root->reflow();
 
         // Clean up cached images
-        Cache::clear();
+        if (!$this->options->getDebugKeepTemp()) {
+            Cache::clear($this->options->getDebugPng());
+        }
 
         global $_dompdf_warnings, $_dompdf_show_warnings;
         if ($_dompdf_show_warnings && isset($_dompdf_warnings)) {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -246,28 +246,36 @@ abstract class AbstractRenderer
             $repeat = "no-repeat";
         }
 
-        //Use filename as indicator only
-        //different names for different variants to have different copies in the pdf
-        //This is not dependent of background color of box! .'_'.(is_array($bg_color) ? $bg_color["hex"] : $bg_color)
-        //Note: Here, bg_* are the start values, not end values after going through the tile loops!
+        // Avoid rendering identical background-image variants multiple times
+        // This is not dependent of background color of box! .'_'.(is_array($bg_color) ? $bg_color["hex"] : $bg_color)
+        // Note: Here, bg_* are the start values, not end values after going through the tile loops!
 
-        $filedummy = $img;
+        $key = implode("_", [$bg_width, $bg_height, $img_w, $img_h, $bg_x, $bg_y, $repeat]);
+        // FIXME: This will fail when a file with that exact name exists in the
+        // same directory, included in the document as regular image
+        $cpdfKey = $img . "_" . $key;
+        $tmpFile = Cache::getTempImage($img, $key);
+        $cached = ($this->_canvas instanceof CPDF && $this->_canvas->get_cpdf()->image_iscached($cpdfKey))
+            || ($tmpFile !== null && file_exists($tmpFile));
 
-        $is_png = false;
-        $filedummy .= '_' . $bg_width . '_' . $bg_height . '_' . $bg_x . '_' . $bg_y . '_' . $repeat;
+        if (!$cached) {
+            // img: image url string
+            // img_w, img_h: original image size in px
+            // width, height: box size in pt
+            // bg_width, bg_height: box size in px
+            // x, y: left/top edge of box on page in pt
+            // start_x, start_y: placement of image relative to pattern
+            // $repeat: repeat mode
+            // $bg: GD object of result image
+            // $src: GD object of original image
 
-        //Optimization to avoid multiple times rendering the same image.
-        //If check functions are existing and identical image already cached,
-        //then skip creation of duplicate, because it is not needed by addImagePng
-        if ($this->_canvas instanceof CPDF && $this->_canvas->get_cpdf()->image_iscached($filedummy)) {
-            $bg = null;
-        } else {
             // Create a new image to fit over the background rectangle
             $bg = imagecreatetruecolor($bg_width, $bg_height);
+            $cpdfFromGd = true;
 
             switch (strtolower($type)) {
                 case "png":
-                    $is_png = true;
+                    $cpdfFromGd = false;
                     imagesavealpha($bg, true);
                     imagealphablending($bg, false);
                     $src = imagecreatefrompng($img);
@@ -408,47 +416,41 @@ abstract class AbstractRenderer
 
             imagedestroy($src);
 
-        } /* End optimize away creation of duplicates */
+            if ($cpdfFromGd && $this->_canvas instanceof CPDF) {
+                // Skip writing temp file as the GD object is added directly
+            } else {
+                $tmpDir = $this->_dompdf->getOptions()->getTempDir();
+                $tmpName = @tempnam($tmpDir, "bg_dompdf_img_");
+                @unlink($tmpName);
+                $tmpFile = "$tmpName.png";
+
+                imagepng($bg, $tmpFile);
+                imagedestroy($bg);
+
+                Cache::addTempImage($img, $tmpFile, $key);
+            }
+        } else {
+            $bg = null;
+            $cpdfFromGd = $tmpFile === null;
+        }
+
+        if ($this->_dompdf->getOptions()->getDebugPng()) {
+            print '[_background_image ' . $tmpFile . ']';
+        }
 
         $this->_canvas->clipping_rectangle($x, $y, $box_width, $box_height);
 
-        //img: image url string
-        //img_w, img_h: original image size in px
-        //width, height: box size in pt
-        //bg_width, bg_height: box size in px
-        //x, y: left/top edge of box on page in pt
-        //start_x, start_y: placement of image relative to pattern
-        //$repeat: repeat mode
-        //$bg: GD object of result image
-        //$src: GD object of original image
-        //When using cpdf and optimization to direct png creation from gd object is available,
-        //don't create temp file, but place gd object directly into the pdf
-        if (!$is_png && $this->_canvas instanceof CPDF) {
+        // When using cpdf and optimization to direct png creation from gd object is available,
+        // don't create temp file, but place gd object directly into the pdf
+        if ($cpdfFromGd && $this->_canvas instanceof CPDF) {
             // Note: CPDF_Adapter image converts y position
-            $this->_canvas->get_cpdf()->addImagePng($bg, $filedummy, $x, $this->_canvas->get_height() - $y - $height, $width, $height);
+            $this->_canvas->get_cpdf()->addImagePng($bg, $cpdfKey, $x, $this->_canvas->get_height() - $y - $height, $width, $height);
+
+            if (isset($bg)) {
+                imagedestroy($bg);
+            }
         } else {
-            $tmp_dir = $this->_dompdf->getOptions()->getTempDir();
-            $tmp_name = @tempnam($tmp_dir, "bg_dompdf_img_");
-            @unlink($tmp_name);
-            $tmp_file = "$tmp_name.png";
-
-            //debugpng
-            if ($this->_dompdf->getOptions()->getDebugPng()) {
-                print '[_background_image ' . $tmp_file . ']';
-            }
-
-            imagepng($bg, $tmp_file);
-            $this->_canvas->image($tmp_file, $x, $y, $width, $height);
-            imagedestroy($bg);
-
-            //debugpng
-            if ($this->_dompdf->getOptions()->getDebugPng()) {
-                print '[_background_image unlink ' . $tmp_file . ']';
-            }
-
-            if (!$this->_dompdf->getOptions()->getDebugKeepTemp()) {
-                unlink($tmp_file);
-            }
+            $this->_canvas->image($tmpFile, $x, $y, $width, $height);
         }
 
         $this->_canvas->clipping_end();


### PR DESCRIPTION
* Cache temporary background-image files, improving performance and file size when background images with identical parameters are used multiple times
* Fix caching of transparent PNG images when using the CPDF back end
* Cache converted images when using the CPDF back end

Fixes #1768