### PR TITLE
CPDF: Fixes for metadata handling with encryption

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1792,14 +1792,14 @@ EOT;
 
                     // dates must be outputted as-is, without Unicode transformations
                     if ($k !== 'CreationDate' && $k !== 'ModDate') {
-                        $v = $this->filterText($v, true, false);
+                        $v = $this->utf8toUtf16BE($v);
                     }
 
                     if ($encrypted) {
                         $v = $this->ARC4($v);
                     }
 
-                    $res .= $v;
+                    $res .= $this->filterText($v, false, false);
                     $res .= ")\n";
                 }
 

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -2919,15 +2919,17 @@ EOT;
                 break;
             case 'out':
                 $info = &$this->objects[$id]['info'];
+                $filename = $this->utf8toUtf16BE($info['filename']);
+                $description = $this->utf8toUtf16BE($info['description']);
 
                 if ($this->encrypted) {
                     $this->encryptInit($id);
-                    $filename = $this->ARC4($info['filename']);
-                    $description = $this->ARC4($info['description']);
-                } else {
-                    $filename = $info['filename'];
-                    $description = $info['description'];
+                    $filename = $this->ARC4($filename);
+                    $description = $this->ARC4($description);
                 }
+
+                $filename = $this->filterText($filename, false, false);
+                $description = $this->filterText($description, false, false);
 
                 $res = "\n$id 0 obj <</Type /Filespec /EF";
                 $res .= " <</F " . $info['embedded_reference'] . " 0 R >>";


### PR DESCRIPTION
* Fix PDF metadata with encryption enabled
The fix is is similar to the one suggested in https://github.com/dompdf/dompdf/issues/1541#issuecomment-700951464, but instead of escaping metadata fields two times when encryption is enabled, we apply Unicode transformations first, then encryption, and finally escape the string. I think that is the proper way to handle it; `filterText` just calls `utf8toUtf16BE` in the beginning when the second parameter is `true` and the third `false`.
* Handle Unicode in filenames and descriptions when embedding files
By applying the same logic as above when adding embedded files.

Fixes #1541
Fixes #2281
