### PR TITLE
CPDF: Avoid duplicate temporary file names when using font subsetting

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1192,8 +1192,7 @@ class Cpdf
                 $font_obj->reduce();
 
                 // Write new font
-                $tmp_name = $this->tmp . "/" . basename($fbfile) . ".tmp." . uniqid();
-                touch($tmp_name);
+                $tmp_name = @tempnam($this->tmp, "cpdf_subset_");
                 $font_obj->open($tmp_name, BinaryStream::modeReadWrite);
                 $font_obj->encode(["OS/2"]);
                 $font_obj->close();


### PR DESCRIPTION
As discussed in #2674, this should fix the issue.