### PR TITLE
Make dompdf setters available as options

### DIFF
--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -35,9 +35,9 @@ class DompdfTest extends TestCase
         $dompdf->setCss(new Stylesheet($dompdf));
         $dompdf->setDom(new DOMDocument());
         $dompdf->setHttpContext(fopen(__DIR__ . "/_files/jamaica.jpg", 'r'));
-        $dompdf->setOptions(new Options());
         $dompdf->setProtocol('test3');
         $dompdf->setTree(new FrameTree($dompdf->getDom()));
+        $dompdf->setOptions(new Options());
 
         $this->assertEquals('test1', $dompdf->getBaseHost());
         $this->assertEquals('test2', $dompdf->getBasePath());
@@ -46,6 +46,31 @@ class DompdfTest extends TestCase
         $this->assertInstanceOf('DOMDocument', $dompdf->getDom());
         $this->assertIsResource($dompdf->getHttpContext());
         $this->assertInstanceOf('Dompdf\Options', $dompdf->getOptions());
+        $this->assertEquals('test3', $dompdf->getProtocol());
+        $this->assertInstanceOf('Dompdf\Frame\FrameTree', $dompdf->getTree());
+    }
+
+    public function testSettersAsOptions()
+    {
+        $options = new Options([
+            'http_context' => fopen(__DIR__ . "/_files/jamaica.jpg", 'r'),
+            'base_host' => 'test1',
+            'base_path' => 'test2',
+            'callbacks' => [['event' => 'test', 'f' => function() {}]],
+            'css' => new Stylesheet(new Dompdf()),
+            'dom' => new DOMDocument(),
+            'protocol' => 'test3',
+            'tree' => new FrameTree(new DOMDocument()),
+        ]);
+        $dompdf = new Dompdf($options);
+        $dompdf->setOptions(new Options());
+
+        $this->assertEquals('test1', $dompdf->getBaseHost());
+        $this->assertEquals('test2', $dompdf->getBasePath());
+        $this->assertCount(1, $dompdf->getCallbacks());
+        $this->assertInstanceOf('Dompdf\Css\Stylesheet', $dompdf->getCss());
+        $this->assertInstanceOf('DOMDocument', $dompdf->getDom());
+        $this->assertIsResource($dompdf->getHttpContext());
         $this->assertEquals('test3', $dompdf->getProtocol());
         $this->assertInstanceOf('Dompdf\Frame\FrameTree', $dompdf->getTree());
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,8 +1,12 @@
 <?php
 namespace Dompdf\Tests;
 
+use Dompdf\Frame\FrameTree;
 use Dompdf\Options;
 use Dompdf\Tests\TestCase;
+use Dompdf\Dompdf;
+use Dompdf\Css\Stylesheet;
+use DOMDocument;
 
 class OptionsTest extends TestCase
 {
@@ -64,7 +68,15 @@ class OptionsTest extends TestCase
             'debugLayoutLines' => false,
             'debugLayoutBlocks' => false,
             'debugLayoutInline' => false,
-            'debugLayoutPaddingBox' => false
+            'debugLayoutPaddingBox' => false,
+            'http_context' => fopen(__DIR__ . "/_files/jamaica.jpg", 'r'),
+            'base_host' => 'test1',
+            'base_path' => 'test2',
+            'callbacks' => [['event' => 'test', 'f' => function() {}]],
+            'css' => new Stylesheet(new Dompdf()),
+            'dom' => new DOMDocument(),
+            'protocol' => 'test3',
+            'tree' => new FrameTree(new DOMDocument()),
         ]);
         $this->assertEquals('test1', $option->getTempDir());
         $this->assertEquals('test2', $option->getFontDir());
@@ -92,5 +104,14 @@ class OptionsTest extends TestCase
 
         $option->setChroot(['test11']);
         $this->assertEquals(['test11'], $option->getChroot());
+
+        $this->assertEquals('test1', $option->getBaseHost());
+        $this->assertEquals('test2', $option->getBasePath());
+        $this->assertCount(1, $option->getCallbacks());
+        $this->assertInstanceOf('Dompdf\Css\Stylesheet', $option->getCss());
+        $this->assertInstanceOf('DOMDocument', $option->getDom());
+        $this->assertIsResource($option->getHttpContext());
+        $this->assertEquals('test3', $option->getProtocol());
+        $this->assertInstanceOf('Dompdf\Frame\FrameTree', $option->getTree());
     }
 }


### PR DESCRIPTION
Closes #2682
Setters moved to  [Dompdf\Options](https://github.com/dompdf/dompdf/blob/master/src/Options.php), and prevent overwriting setter value on `setOptions` when new options brings empty values(BC)

```batch
/var/www/github/dompdf# ./vendor/bin/phpunit
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

...................................................               51 / 51 (100%)

Time: 00:00.305, Memory: 12.00 MB

OK ( 51 tests, 209 assertions)
```