### PR TITLE
Add support for passing a callback to `page_script` method

### DIFF
--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -179,7 +179,6 @@ class GD implements Canvas
         $this->_actual_height = $this->_upscale($this->_height);
 
         $this->_page_number = $this->_page_count = 0;
-        $this->_page_text = [];
 
         if (is_null($bg_color) || !is_array($bg_color)) {
             // Pure white bg
@@ -986,24 +985,11 @@ class GD implements Canvas
         // N/A
     }
 
-    /**
-     * Writes text at the specified x and y coordinates on every page
-     *
-     * The strings '{PAGE_NUM}' and '{PAGE_COUNT}' are automatically replaced
-     * with their current values.
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     *
-     * @param float  $x
-     * @param float  $y
-     * @param string $text       the text to write
-     * @param string $font       the font file to use
-     * @param float  $size       the font size, in points
-     * @param array  $color
-     * @param float  $word_space word spacing adjustment
-     * @param float  $char_space char spacing adjustment
-     * @param float  $angle      angle to write the text at, measured CW starting from the x-axis
-     */
+    public function page_script($callback)
+    {
+        // N/A
+    }
+
     public function page_text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0)
     {
         // N/A

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1400,20 +1400,29 @@ class PDFLib implements Canvas
     //........................................................................
 
     /**
-     * Processes a script on every page
+     * Processes a callback or script on every page
      *
-     * The variables $pdf, $PAGE_NUM, and $PAGE_COUNT are available.
+     * The callback function receives the four parameters `$pageNumber`,
+     * `$pageCount`, `$pdf`, and `$fontMetrics`, in that order. If a script is
+     * passed as string, the variables `$PAGE_NUM`, `$PAGE_COUNT`, `$pdf`, and
+     * `$fontMetrics` are available instead.
      *
-     * This function can be used to add page numbers to all pages
-     * after the first one, for example.
+     * This function can be used to add page numbers to all pages after the
+     * first one, for example.
      *
-     * @param string $code the script code
-     * @param string $type the language type for script
+     * @param callable|string $code The callback function or PHP script to process on every page
      */
-    public function page_script($code, $type = "text/php")
+    public function page_script($code)
     {
-        $_t = "script";
-        $this->_page_text[] = compact("_t", "code", "type");
+        if (is_callable($code)) {
+            $this->_page_text[] = [
+                "_t"       => "callback",
+                "callback" => $code
+            ];
+        } else {
+            $_t = "script";
+            $this->_page_text[] = compact("_t", "code");
+        }
     }
 
     /**
@@ -1454,14 +1463,19 @@ class PDFLib implements Canvas
                         $this->text($x, $y, $text, $font, $size, $color, $word_space, $char_space, $angle);
                         break;
 
+                    case "callback":
+                        $fontMetrics = $this->get_dompdf()->getFontMetrics();
+                        $callback($p, $this->_page_count, $this, $fontMetrics);
+                        break;
+
                     case "script":
                         if (!$eval) {
                             $eval = new PHPEvaluator($this);
                         }
-                        $eval->evaluate($code, ['PAGE_NUM' => $p, 'PAGE_COUNT' => $this->_page_count]);
+                        $eval->evaluate($code, ["PAGE_NUM" => $p, "PAGE_COUNT" => $this->_page_count]);
                         break;
 
-                    case 'line':
+                    case "line":
                         $this->line($x1, $y1, $x2, $y2, $color, $width, $style);
                         break;
 

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -131,6 +131,20 @@ interface Canvas
     function clipping_end();
 
     /**
+     * Processes a callback on every page
+     *
+     * The callback function receives the four parameters `$pageNumber`,
+     * `$pageCount`, `$pdf`, and `$fontMetrics`, in that order.
+     *
+     * This function can be used to add page numbers to all pages after the
+     * first one, for example.
+     *
+     * @param callable $callback The callback function to process on every page
+     * @todo Enable with next major release
+     */
+    //public function page_script(callable $callback): void;
+
+    /**
      * Writes text at the specified x and y coordinates on every page
      *
      * The strings '{PAGE_NUM}' and '{PAGE_COUNT}' are automatically replaced
@@ -149,6 +163,22 @@ interface Canvas
      * @param float  $angle      angle to write the text at, measured CW starting from the x-axis
      */
     public function page_text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0);
+
+    /**
+     * Draw line at the specified coordinates on every page.
+     *
+     * See {@link Style::munge_color()} for the format of the color array.
+     *
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param array $color
+     * @param float $width
+     * @param array $style optional
+     * @todo Enable with next major release
+     */
+    //public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = []);
 
     /**
      * Save current state

--- a/tests/Canvas/CPDFTest.php
+++ b/tests/Canvas/CPDFTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace Dompdf\Tests\Canvas;
+
+use Dompdf\Adapter\CPDF;
+use Dompdf\Canvas;
+use Dompdf\Dompdf;
+use Dompdf\FontMetrics;
+use Dompdf\Options;
+use Dompdf\Tests\TestCase;
+
+class CPDFTest extends TestCase
+{
+    public function testPageScript(): void
+    {
+        global $called;
+        $called = 0;
+
+        $options = new Options();
+        $options->setIsPhpEnabled(true);
+        $dompdf = new Dompdf($options);
+
+        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas->new_page();
+
+        $canvas->page_script(function (
+            int $pageNumber,
+            int $pageCount,
+            Canvas $canvas,
+            FontMetrics $fontMetrics
+        ) use (&$called) {
+            $called++;
+            $font = $fontMetrics->getFont("Helvetica");
+            $canvas->text(40, 20, "Page $pageNumber of $pageCount", $font, 12);
+            $canvas->line(200, 0, 0, 200, [0, 0, 0], 1);
+        });
+        $canvas->page_script('
+            global $called;
+            $called++;
+            $font = $fontMetrics->getFont("Helvetica");
+            $pdf->text(20, 0, "Page $PAGE_NUM of $PAGE_COUNT", $font, 12);
+        ');
+
+        $font = $dompdf->getFontMetrics()->getFont("Helvetica");
+        $canvas->page_text(60, 40, "Page {PAGE_NUM} of {PAGE_COUNT}", $font, 12);
+        $canvas->page_line(0, 0, 200, 200, [0, 0, 0], 1);
+
+        $output = $canvas->output();
+
+        $this->assertNotSame("", $output);
+        $this->assertSame(4, $called);
+    }
+}


### PR DESCRIPTION
Implementation notes:
* The `$type` parameter is unused, and since calling user-defined functions with extra parameters is not an error, I simply removed the parameter.
* Added commented `page_script` and `page_line` signatures to the `Canvas` interface, to be enabled with the next major release, as to not break existing custom implementations.
* Didn’t add the string option to the (commented) interface declaration, as it feels like a legacy feature. Didn’t realize this before, but the code string is also only evaluated with the `$isPhpEnabled` option set (though that would be easy to resolve).

Fixes #1838