### PR TITLE
Small improvements to text and inline layout

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -140,7 +140,7 @@ class Frame
     /**
      * This frame's containing line box
      *
-     * @var LineBox
+     * @var LineBox|null
      */
     protected $_containing_line;
 
@@ -664,7 +664,7 @@ class Frame
     }
 
     /**
-     * @return LineBox
+     * @return LineBox|null
      */
     public function &get_containing_line()
     {

--- a/src/Frame/Factory.php
+++ b/src/Frame/Factory.php
@@ -116,13 +116,8 @@ class Factory
                     $decorator = "Text";
                     $reflower = "Text";
                 } else {
-                    if ($style->float !== "none") {
-                        $decorator = "Block";
-                        $reflower = "Block";
-                    } else {
-                        $decorator = "Inline";
-                        $reflower = "Inline";
-                    }
+                    $decorator = "Inline";
+                    $reflower = "Inline";
                 }
                 break;
 

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -704,7 +704,6 @@ abstract class AbstractFrameDecorator extends Frame
             $frame = $iter;
             $iter = $iter->get_next_sibling();
             $frame->reset();
-            $frame->_parent = $split;
             $split->append_child($frame);
 
             // recalculate the float offsets

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -114,27 +114,14 @@ class Block extends AbstractFrameDecorator
      * @param Frame $frame
      * @return LineBox|null
      */
-    function add_frame_to_line(Frame $frame)
+    public function add_frame_to_line(Frame $frame)
     {
         $current_line = $this->_line_boxes[$this->_cl];
         $frame->set_containing_line($current_line);
 
-        // Handle inline frames (which are effectively wrappers)
+        // Inline frames are currently treated as wrappers, and are not actually
+        // added to the line
         if ($frame instanceof Inline) {
-            // Handle line breaks
-            if ($frame->get_node()->nodeName === "br") {
-                $style = $frame->get_style();
-                $this->maximize_line_height($style->line_height, $frame);
-                $this->add_line(true);
-
-                $next = $frame->get_next_sibling();
-                $p = $frame->get_parent();
-
-                if ($next && $p instanceof Inline) {
-                    $p->split($next);
-                }
-            }
-
             return null;
         }
 

--- a/src/FrameDecorator/Block.php
+++ b/src/FrameDecorator/Block.php
@@ -10,7 +10,6 @@ namespace Dompdf\FrameDecorator;
 use Dompdf\Dompdf;
 use Dompdf\Frame;
 use Dompdf\LineBox;
-use Dompdf\FrameReflower\Text as TextFrameReflower;
 
 /**
  * Decorates frames for block layout
@@ -240,19 +239,6 @@ class Block extends AbstractFrameDecorator
     function add_line(bool $br = false)
     {
         $line = $this->_line_boxes[$this->_cl];
-        $frames = $line->get_frames();
-
-        if (count($frames) > 0) {
-            $last_frame = $frames[count($frames) - 1];
-            $reflower = $last_frame->get_reflower();
-
-            if ($reflower instanceof TextFrameReflower
-                && !$last_frame->is_pre()
-            ) {
-                $reflower->trim_trailing_ws();
-                $line->recalculate_width();
-            }
-        }
 
         $line->br = $br;
         $y = $line->y + $line->h;

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -403,11 +403,17 @@ class Page extends AbstractFrameDecorator
                 // Rule C
                 $block_parent = $frame->find_block_parent();
                 $parent_style = $block_parent->get_style();
+                $line = $block_parent->get_current_line_box();
+                $line_count = count($block_parent->get_line_boxes());
+                $line_number = $frame->get_containing_line() && empty($line->get_frames())
+                    ? $line_count - 1
+                    : $line_count;
+
                 // The line number of the frame can be less than the current
                 // number of line boxes, in case we are backtracking. As long as
                 // we are not checking for widows yet, just checking against the
                 // number of line boxes is sufficient in most cases, though.
-                if (count($block_parent->get_line_boxes()) <= $parent_style->orphans) {
+                if ($line_number <= $parent_style->orphans) {
                     Helpers::dompdf_debug("page-break", "orphans");
 
                     return false;

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -130,7 +130,7 @@ class Text extends AbstractFrameDecorator
     }
 
     /**
-     *  Recalculate the text width
+     * Recalculate the text width
      *
      * @return float
      */

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -452,12 +452,16 @@ class Block extends AbstractFrameReflower
             default:
             case "left":
                 foreach ($this->_frame->get_line_boxes() as $line) {
-                    if (!$line->inline || !$line->left) {
+                    if (!$line->inline) {
                         continue;
                     }
 
-                    foreach ($line->frames_to_align() as $frame) {
-                        $frame->move($line->left, 0);
+                    $line->trim_trailing_ws();
+
+                    if ($line->left) {
+                        foreach ($line->frames_to_align() as $frame) {
+                            $frame->move($line->left, 0);
+                        }
                     }
                 }
                 break;
@@ -467,6 +471,8 @@ class Block extends AbstractFrameReflower
                     if (!$line->inline) {
                         continue;
                     }
+
+                    $line->trim_trailing_ws();
 
                     $indent = $i === 0 ? $text_indent : 0;
                     $dx = $width - $line->w - $line->right - $indent;
@@ -488,6 +494,8 @@ class Block extends AbstractFrameReflower
                     if (!$line->inline) {
                         continue;
                     }
+
+                    $line->trim_trailing_ws();
 
                     if ($line->left) {
                         foreach ($line->frames_to_align() as $frame) {
@@ -544,6 +552,8 @@ class Block extends AbstractFrameReflower
                     if (!$line->inline) {
                         continue;
                     }
+
+                    $line->trim_trailing_ws();
 
                     $indent = $i === 0 ? $text_indent : 0;
                     $dx = ($width + $line->left - $line->w - $line->right - $indent) / 2;

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -593,10 +593,26 @@ class Block extends AbstractFrameReflower
 
                 //FIXME: The 0.8 ratio applied to the height is arbitrary (used to accommodate descenders?)
                 if ($isInlineBlock) {
-                    $frames = $line->get_frames();
-                    if (count($frames) === 1) {
+                    // Workaround: Skip vertical alignment if the frame is the
+                    // only one one the line, excluding empty text frames, which
+                    // may be the result of trailing white space
+                    // FIXME: This special case should be removed once vertical
+                    // alignment is properly fixed
+                    $skip = true;
+
+                    foreach ($line->get_frames() as $other) {
+                        if ($other !== $frame
+                            && !($other->is_text_node() && $other->get_node()->nodeValue === "")
+                         ) {
+                            $skip = false;
+                            break;
+                        }
+                    }
+
+                    if ($skip) {
                         continue;
                     }
+
                     $marginHeight = $frame->get_margin_height();
                     $imageHeightDiff = $height * 0.8 - $marginHeight;
 

--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -82,6 +82,12 @@ class Inline extends AbstractFrameReflower
 
         $frame->position();
 
+        // If positioning necessitates a parent split, then the position is not
+        // set. The frame will have a new reflow via the new split parent
+        if ($frame->get_position("x") === null) {
+            return;
+        }
+
         $cb = $frame->get_containing_block();
 
         if ($block) {

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -333,30 +333,13 @@ class Text extends AbstractFrameReflower
                 $t = $frame->get_text();
                 $shyPosition = mb_strpos($t, self::SOFT_HYPHEN);
                 if (false !== $shyPosition && $shyPosition < mb_strlen($t) - 1) {
-                    $t = str_replace(self::SOFT_HYPHEN, '', mb_substr($t, 0, -1)) . mb_substr($t, -1);
+                    $t = str_replace(self::SOFT_HYPHEN, "", mb_substr($t, 0, -1)) . mb_substr($t, -1);
                     $frame->set_text($t);
                 }
             }
         } elseif ($text !== "") {
-            $t = $text;
-
-            // Trim trailing white space if this is the last text frame on the
-            // last line
-            if (!$frame->is_pre()) {
-                $last = $frame->get_next_sibling() === null;
-                $p = $frame->get_parent();
-                while ($last && $p instanceof InlineFrameDecorator) {
-                    $last = $last && $p->get_next_sibling() === null;
-                    $p = $p->get_parent();
-                }
-
-                if ($last) {
-                    $t = rtrim($t);
-                }
-            }
-
             // Remove soft hyphens
-            $t = str_replace(self::SOFT_HYPHEN, '', $t);
+            $t = str_replace(self::SOFT_HYPHEN, "", $text);
             $frame->set_text($t);
         }
 

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -28,17 +28,21 @@ class Text extends AbstractFrameReflower
 
     /**
      * The regex splits on everything that's a separator (^\S double negative),
-     * excluding nbsp (\xa0).
-     * This currently excludes the "narrow nbsp" character.
+     * excluding the following non-breaking space characters:
+     * * nbsp (\xA0)
+     * * narrow nbsp (\x{202F})
+     * * figure space (\x{2007})
      */
-    public static $_whitespace_pattern = '/([^\S\xA0]+)/u';
+    public static $_whitespace_pattern = '/([^\S\xA0\x{202F}\x{2007}]+)/u';
 
     /**
-     * The regex splits on everything that's a separator (^\S double negative),
-     * excluding nbsp (\xa0), plus dashes.
-     * This currently excludes the "narrow nbsp" character.
+     * The regex splits on everything that's a separator (^\S double negative)
+     * plus dashes, excluding the following non-breaking space characters:
+     * * nbsp (\xA0)
+     * * narrow nbsp (\x{202F})
+     * * figure space (\x{2007})
      */
-    public static $_wordbreak_pattern = '/([^\S\xA0]+|\-+|\xAD+)/u';
+    public static $_wordbreak_pattern = '/([^\S\xA0\x{202F}\x{2007}]+|\-+|\xAD+)/u';
 
     /**
      * @var BlockFrameDecorator

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -914,7 +914,12 @@ class Helpers
         return [$content, $headers];
     }
 
-    public static function mb_ucwords($str) {
+    /**
+     * @param string $str
+     * @return string
+     */
+    public static function mb_ucwords(string $str): string
+    {
         $max_len = mb_strlen($str);
         if ($max_len === 1) {
             return mb_strtoupper($str);

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -11,6 +11,7 @@ use Dompdf\FrameDecorator\AbstractFrameDecorator;
 use Dompdf\FrameDecorator\Block;
 use Dompdf\FrameDecorator\ListBullet;
 use Dompdf\FrameDecorator\Page;
+use Dompdf\FrameReflower\Text as TextFrameReflower;
 use Dompdf\Positioner\Inline as InlinePositioner;
 
 /**
@@ -348,6 +349,26 @@ class LineBox
             if ($frame->get_positioner() instanceof InlinePositioner) {
                 yield $frame;
             }
+        }
+    }
+
+    /**
+     * Trim trailing whitespace from the line.
+     */
+    public function trim_trailing_ws(): void
+    {
+        $lastIndex = count($this->_frames) - 1;
+
+        if ($lastIndex < 0) {
+            return;
+        }
+
+        $lastFrame = $this->_frames[$lastIndex];
+        $reflower = $lastFrame->get_reflower();
+
+        if ($reflower instanceof TextFrameReflower && !$lastFrame->is_pre()) {
+            $reflower->trim_trailing_ws();
+            $this->recalculate_width();
         }
     }
 

--- a/src/Positioner/Inline.php
+++ b/src/Positioner/Inline.php
@@ -9,6 +9,7 @@
 namespace Dompdf\Positioner;
 
 use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\FrameDecorator\Inline as InlineFrameDecorator;
 use Dompdf\FrameReflower\Inline as InlineFrameReflower;
 use Dompdf\Exception;
 
@@ -57,6 +58,16 @@ class Inline extends AbstractPositioner
             // If no parts of the inline frame fit in the current line, it
             // should break to a new line
             if ($min > ($cb["w"] - $line->left - $line->w - $line->right)) {
+                $prev = $frame->get_prev_sibling();
+                $parent = $frame->get_parent();
+
+                if ($prev && $parent instanceof InlineFrameDecorator) {
+                    // Split parent and don't set position, so current reflow
+                    // can be stopped
+                    $parent->split($frame);
+                    return;
+                }
+
                 $p->add_line();
                 $line = $p->get_current_line_box();
             }


### PR DESCRIPTION
* Trim trailing white space after all line boxes have been laid out, so that it is handled consistently
* Allow trailing white space to overflow
* Respect narrow non-breaking space and figure space when collapsing white space
* Fix `break-word` logic so that cases where the first character overflows are handled correctly
* Simpler and more consistent inline-positioning logic
* Improve min/max-width determination

Fixes the last sample from https://github.com/dompdf/dompdf/issues/2631#issuecomment-996897945
Fixes #2702