### PR TITLE
Use containing block to resolve percentage image dimensions

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -634,22 +634,6 @@ class Cellmap
                 list($frame_min, $frame_max) = $frame->get_min_max_width();
             }
 
-            $min_width = $style->min_width;
-            $max_width = $style->max_width;
-
-            if ($min_width !== "auto" && !Helpers::is_percent($min_width)) {
-                $specified_min = (float) $style->length_in_pt($min_width);
-                $frame_min = max($frame_min, $specified_min);
-                $frame_max = max($frame_max, $frame_min);
-            }
-
-            if ($max_width !== "none" && !Helpers::is_percent($max_width)) {
-                // `min-width` takes precedence over `max-width` here
-                $specified_max = (float) $style->length_in_pt($max_width);
-                $frame_max = max(min($frame_max, $specified_max), $specified_min ?? 0);
-                $frame_min = min($frame_min, $frame_max);
-            }
-
             $width = $style->width;
 
             $val = null;
@@ -658,7 +642,7 @@ class Cellmap
                 $val = (float)rtrim($width, "% ");
             } else if ($width !== "auto" && $colspan === 1) {
                 $var = "absolute";
-                $val = $style->length_in_pt($frame_min);
+                $val = $frame_min;
             }
 
             $min = 0;

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -45,9 +45,9 @@ class AttributeTranslator
                 'right' => 'margin-left: auto; margin-right: 0;'
             ],
             'bgcolor' => 'background-color: %s;',
-            'border' => '!set_table_border',
-            'cellpadding' => '!set_table_cellpadding', //'border-spacing: %0.2F; border-collapse: separate;',
-            'cellspacing' => '!set_table_cellspacing',
+            'border' => '_set_table_border',
+            'cellpadding' => '_set_table_cellpadding', //'border-spacing: %0.2F; border-collapse: separate;',
+            'cellspacing' => '_set_table_cellspacing',
             'frame' => [
                 'void' => 'border-style: none;',
                 'above' => 'border-top-style: solid;',
@@ -59,13 +59,13 @@ class AttributeTranslator
                 'box' => 'border-style: solid;',
                 'border' => 'border-style: solid;'
             ],
-            'rules' => '!set_table_rules',
+            'rules' => '_set_table_rules',
             'width' => 'width: %s;',
         ],
         'hr' => [
-            'align' => '!set_hr_align', // Need to grab width to set 'left' & 'right' correctly
+            'align' => '_set_hr_align', // Need to grab width to set 'left' & 'right' correctly
             'noshade' => 'border-style: solid;',
-            'size' => '!set_hr_size', //'border-width: %0.2F px;',
+            'size' => '_set_hr_size', //'border-width: %0.2F px;',
             'width' => 'width: %s;',
         ],
         'div' => [
@@ -91,7 +91,7 @@ class AttributeTranslator
         ],
         //TODO: translate more form element attributes
         'input' => [
-            'size' => '!set_input_width'
+            'size' => '_set_input_width'
         ],
         'p' => [
             'align' => 'text-align: %s;',
@@ -105,56 +105,56 @@ class AttributeTranslator
 //      'valign' => '',
 //    ),
         'tbody' => [
-            'align' => '!set_table_row_align',
-            'valign' => '!set_table_row_valign',
+            'align' => '_set_table_row_align',
+            'valign' => '_set_table_row_valign',
         ],
         'td' => [
             'align' => 'text-align: %s;',
-            'bgcolor' => '!set_background_color',
+            'bgcolor' => '_set_background_color',
             'height' => 'height: %s;',
             'nowrap' => 'white-space: nowrap;',
             'valign' => 'vertical-align: %s;',
             'width' => 'width: %s;',
         ],
         'tfoot' => [
-            'align' => '!set_table_row_align',
-            'valign' => '!set_table_row_valign',
+            'align' => '_set_table_row_align',
+            'valign' => '_set_table_row_valign',
         ],
         'th' => [
             'align' => 'text-align: %s;',
-            'bgcolor' => '!set_background_color',
+            'bgcolor' => '_set_background_color',
             'height' => 'height: %s;',
             'nowrap' => 'white-space: nowrap;',
             'valign' => 'vertical-align: %s;',
             'width' => 'width: %s;',
         ],
         'thead' => [
-            'align' => '!set_table_row_align',
-            'valign' => '!set_table_row_valign',
+            'align' => '_set_table_row_align',
+            'valign' => '_set_table_row_valign',
         ],
         'tr' => [
-            'align' => '!set_table_row_align',
-            'bgcolor' => '!set_table_row_bgcolor',
-            'valign' => '!set_table_row_valign',
+            'align' => '_set_table_row_align',
+            'bgcolor' => '_set_table_row_bgcolor',
+            'valign' => '_set_table_row_valign',
         ],
         'body' => [
             'background' => 'background-image: url(%s);',
-            'bgcolor' => '!set_background_color',
-            'link' => '!set_body_link',
-            'text' => '!set_color',
+            'bgcolor' => '_set_background_color',
+            'link' => '_set_body_link',
+            'text' => '_set_color',
         ],
         'br' => [
             'clear' => 'clear: %s;',
         ],
         'basefont' => [
-            'color' => '!set_color',
+            'color' => '_set_color',
             'face' => 'font-family: %s;',
-            'size' => '!set_basefont_size',
+            'size' => '_set_basefont_size',
         ],
         'font' => [
-            'color' => '!set_color',
+            'color' => '_set_color',
             'face' => 'font-family: %s;',
-            'size' => '!set_font_size',
+            'size' => '_set_font_size',
         ],
         'dir' => [
             'compact' => 'margin: 0.5em 0;',
@@ -260,11 +260,8 @@ class AttributeTranslator
      */
     protected static function _resolve_target(\DOMNode $node, $target, $value)
     {
-        if ($target[0] === "!") {
-            // Function call
-            $func = "_" . mb_substr($target, 1);
-
-            return self::$func($node, $value);
+        if ($target[0] === "_") {
+            return self::$target($node, $value);
         }
 
         return $value ? sprintf($target, $value) : "";

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -9,6 +9,7 @@
 namespace Dompdf\Css;
 
 use Dompdf\Frame;
+use Dompdf\Helpers;
 
 /**
  * Translates HTML 4.0 attributes into CSS rules
@@ -33,10 +34,10 @@ class AttributeTranslator
                 'right' => 'float: right;'
             ],
             'border' => 'border: %0.2Fpx solid;',
-            'height' => 'height: %spx;',
+            'height' => '_set_px_height',
             'hspace' => 'padding-left: %1$0.2Fpx; padding-right: %1$0.2Fpx;',
             'vspace' => 'padding-top: %1$0.2Fpx; padding-bottom: %1$0.2Fpx;',
-            'width' => 'width: %spx;',
+            'width' => '_set_px_width',
         ],
         'table' => [
             'align' => [
@@ -346,6 +347,32 @@ class AttributeTranslator
         $value = self::_get_valid_color($value);
 
         return "background-color: $value;";
+    }
+
+    protected static function _set_px_width(\DOMElement $node, string $value): string
+    {
+        if (Helpers::is_percent($value)) {
+            return sprintf("width: %s;", $value);
+        }
+
+        if (is_numeric($value)) {
+            return sprintf("width: %spx;", $value);
+        }
+
+        return "";
+    }
+
+    protected static function _set_px_height(\DOMElement $node, string $value): string
+    {
+        if (Helpers::is_percent($value)) {
+            return sprintf("height: %s;", $value);
+        }
+
+        if (is_numeric($value)) {
+            return sprintf("height: %spx;", $value);
+        }
+
+        return "";
     }
 
     /**

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -72,7 +72,7 @@ class Stylesheet
         self::ORIG_AUTHOR => 0x30000000, // author normal declarations
     ];
 
-    /*
+    /**
      * Non-CSS presentational hints (i.e. HTML 4 attributes) are handled as if added
      * to the beginning of an author stylesheet, i.e. anything in author stylesheets
      * should override them.

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -865,7 +865,7 @@ abstract class AbstractFrameDecorator extends Frame
     /**
      * @return array
      */
-    final function get_min_max_width(): array
+    final public function get_min_max_width(): array
     {
         return $this->_reflower->get_min_max_width();
     }

--- a/src/FrameDecorator/Image.php
+++ b/src/FrameDecorator/Image.php
@@ -10,6 +10,7 @@ namespace Dompdf\FrameDecorator;
 
 use Dompdf\Dompdf;
 use Dompdf\Frame;
+use Dompdf\Helpers;
 use Dompdf\Image\Cache;
 
 /**
@@ -66,6 +67,30 @@ class Image extends AbstractFrameDecorator
             $style->width = (4 / 3) * $dompdf->getFontMetrics()->getTextWidth($alt, $style->font_family, $style->font_size, $style->word_spacing);
             $style->height = $dompdf->getFontMetrics()->getFontHeight($style->font_family, $style->font_size);
         }
+    }
+
+    /**
+     * Get the intrinsic pixel dimensions of the image.
+     *
+     * @return array Width and height as `float|int`.
+     */
+    public function get_intrinsic_dimensions(): array
+    {
+        [$width, $height] = Helpers::dompdf_getimagesize($this->_image_url, $this->_dompdf->getHttpContext());
+
+        return [$width, $height];
+    }
+
+    /**
+     * Resample the given pixel length according to dpi.
+     *
+     * @param float|int $length
+     * @return float
+     */
+    public function resample($length): float
+    {
+        $dpi = $this->_dompdf->getOptions()->getDpi();
+        return ($length * 72) / $dpi;
     }
 
     /**

--- a/src/FrameDecorator/ListBulletImage.php
+++ b/src/FrameDecorator/ListBulletImage.php
@@ -61,13 +61,10 @@ class ListBulletImage extends ListBullet
             $this->_width = parent::get_width();
             $this->_height = parent::get_height();
         } else {
-            [$width, $height] = Helpers::dompdf_getimagesize($url, $dompdf->getHttpContext());
-
             // Resample the bullet image to be consistent with 'auto' sized images
-            // See also Image::get_min_max_width
-            $dpi = $this->_dompdf->getOptions()->getDpi();
-            $this->_width = ((float) $width * 72) / $dpi;
-            $this->_height = ((float) $height * 72) / $dpi;
+            [$width, $height] = $this->_img->get_intrinsic_dimensions();
+            $this->_width = $this->_img->resample($width);
+            $this->_height = $this->_img->resample($height);
         }
     }
 

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -395,38 +395,7 @@ abstract class AbstractFrameReflower
      */
     public function get_min_max_content_width(): array
     {
-        // Ignore percentage values for a specified width here, as the
-        // containing block is not defined yet
-        $style = $this->_frame->get_style();
-        $display = $style->display;
-        $width = $style->width;
-        $fixed_width = $width !== "auto" && !Helpers::is_percent($width);
-        $is_inline = $display === "inline" || $display === "-dompdf-br";
-
-        if ($fixed_width && !$is_inline && $display !== "table-cell") {
-            // If the frame has a specified width, then we don't need to check
-            // its children. Table cells are handled slightly differently below
-            $min = (float) $style->length_in_pt($width, 0);
-            $max = $min;
-        } else {
-            // Calculate min/max width requested by the children of the frame
-            [$min, $max] = $this->get_min_max_child_width();
-
-            // For table cells: Use specified width if it is greater than the
-            // minimum defined by the content
-            if ($fixed_width && $display === "table-cell") {
-                $width = (float) $style->length_in_pt($width, 0);
-                $min = max($width, $min);
-                $max = $min;
-            }
-        }
-
-        // Handle min/max width style properties
-        if (!$is_inline) {
-            [$min, $max] = $this->restrict_min_max_width($min, $max);
-        }
-
-        return [$min, $max];
+        return $this->get_min_max_child_width();
     }
 
     /**

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -104,19 +104,19 @@ class Block extends AbstractFrameReflower
                     // rule 3, per instruction preceding rule set
                     // shrink-to-fit width
                     $left = $inflow_x;
-                    [$min, $max] = $this->get_min_max_content_width();
+                    [$min, $max] = $this->get_min_max_child_width();
                     $width = min(max($min, $diff - $left), $max);
                     $right = $diff - $left - $width;
                 } elseif ($width === "auto" && $left === "auto") {
                     // rule 1
                     // shrink-to-fit width
-                    [$min, $max] = $this->get_min_max_content_width();
+                    [$min, $max] = $this->get_min_max_child_width();
                     $width = min(max($min, $diff), $max);
                     $left = $diff - $width;
                 } elseif ($width === "auto" && $right === "auto") {
                     // rule 3
                     // shrink-to-fit width
-                    [$min, $max] = $this->get_min_max_content_width();
+                    [$min, $max] = $this->get_min_max_child_width();
                     $width = min(max($min, $diff), $max);
                     $right = $diff - $width;
                 } elseif ($left === "auto" && $right === "auto") {
@@ -162,7 +162,7 @@ class Block extends AbstractFrameReflower
             // https://www.w3.org/TR/CSS21/visudet.html#inlineblock-width
 
             if ($width === "auto") {
-                [$min, $max] = $this->get_min_max_content_width();
+                [$min, $max] = $this->get_min_max_child_width();
                 $width = min(max($min, $diff), $max);
             }
             if ($lm === "auto") {

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -932,4 +932,25 @@ class Block extends AbstractFrameReflower
             }
         }
     }
+
+    public function get_min_max_content_width(): array
+    {
+        // Ignore percentage values for a specified width here, as the
+        // containing block is not defined yet
+        $style = $this->_frame->get_style();
+        $width = $style->width;
+        $fixed_width = $width !== "auto" && !Helpers::is_percent($width);
+
+        // If the frame has a specified width, then we don't need to check
+        // its children
+        if ($fixed_width) {
+            $min = (float) $style->length_in_pt($width, 0);
+            $max = $min;
+        } else {
+            [$min, $max] = $this->get_min_max_child_width();
+        }
+
+        // Handle min/max width style properties
+        return $this->restrict_min_max_width($min, $max);
+    }
 }

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -50,7 +50,6 @@ class Table extends AbstractFrameReflower
     {
         parent::reset();
         $this->_state = null;
-        $this->_min_max_cache = null;
     }
 
     protected function _assign_widths()
@@ -474,7 +473,7 @@ class Table extends AbstractFrameReflower
         }
     }
 
-    function get_min_max_width(): array
+    public function get_min_max_width(): array
     {
         if (!is_null($this->_min_max_cache)) {
             return $this->_min_max_cache;

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -9,6 +9,7 @@ namespace Dompdf\FrameReflower;
 
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Table as TableFrameDecorator;
+use Dompdf\Helpers;
 
 /**
  * Reflows table cells
@@ -122,5 +123,27 @@ class TableCell extends Block
         foreach ($this->_frame->get_children() as $child) {
             $this->position_relative($child);
         }
+    }
+
+    public function get_min_max_content_width(): array
+    {
+        // Ignore percentage values for a specified width here, as the
+        // containing block is not defined yet
+        $style = $this->_frame->get_style();
+        $width = $style->width;
+        $fixed_width = $width !== "auto" && !Helpers::is_percent($width);
+
+        [$min, $max] = $this->get_min_max_child_width();
+
+        // For table cells: Use specified width if it is greater than the
+        // minimum defined by the content
+        if ($fixed_width) {
+            $width = (float) $style->length_in_pt($width, 0);
+            $min = max($width, $min);
+            $max = $min;
+        }
+
+        // Handle min/max width style properties
+        return $this->restrict_min_max_width($min, $max);
     }
 }

--- a/src/FrameReflower/TableRow.php
+++ b/src/FrameReflower/TableRow.php
@@ -73,7 +73,7 @@ class TableRow extends AbstractFrameReflower
     /**
      * @throws Exception
      */
-    function get_min_max_width(): array
+    public function get_min_max_width(): array
     {
         throw new Exception("Min/max width is undefined for table rows");
     }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -444,7 +444,7 @@ class Text extends AbstractFrameReflower
 
     //........................................................................
 
-    function get_min_max_width(): array
+    public function get_min_max_width(): array
     {
         $frame = $this->_frame;
         $style = $frame->get_style();

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -558,15 +558,18 @@ class Text extends AbstractFrameReflower
                 break;
         }
 
-        // The containing block is not defined yet, treat percentages as 0
-        $delta = (float) $style->length_in_pt([
-            $style->margin_left,
-            $style->border_left_width,
+        // Account for margins, borders, and padding
+        $dims = [
             $style->padding_left,
             $style->padding_right,
+            $style->border_left_width,
             $style->border_right_width,
+            $style->margin_left,
             $style->margin_right
-        ], 0);
+        ];
+
+        // The containing block is not defined yet, treat percentages as 0
+        $delta = (float) $style->length_in_pt($dims, 0);
         $min += $delta;
         $max += $delta;
 

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -619,7 +619,8 @@ class Helpers
      *
      * @param string $filename
      * @param resource $context
-     * @return array The same format as getimagesize($filename)
+     * @return array An array of three elements: width and height as
+     *         `float|int`, and image type as `string|null`.
      */
     public static function dompdf_getimagesize($filename, $context = null)
     {
@@ -640,30 +641,30 @@ class Helpers
             IMAGETYPE_WEBP => "webp",
         ];
 
-        $type = isset($types[$type]) ? $types[$type] : null;
+        $type = $types[$type] ?? null;
 
         if ($width == null || $height == null) {
-            [$data, $headers] = Helpers::getFileContent($filename, $context);
+            [$data] = Helpers::getFileContent($filename, $context);
 
             if ($data !== null) {
                 if (substr($data, 0, 2) === "BM") {
-                    $meta = unpack('vtype/Vfilesize/Vreserved/Voffset/Vheadersize/Vwidth/Vheight', $data);
-                    $width = (int)$meta['width'];
-                    $height = (int)$meta['height'];
+                    $meta = unpack("vtype/Vfilesize/Vreserved/Voffset/Vheadersize/Vwidth/Vheight", $data);
+                    $width = (int) $meta["width"];
+                    $height = (int) $meta["height"];
                     $type = "bmp";
-                } else {
-                    if (strpos($data, "<svg") !== false) {
-                        $doc = new \Svg\Document();
-                        $doc->loadFile($filename);
+                } elseif (strpos($data, "<svg") !== false) {
+                    $doc = new \Svg\Document();
+                    $doc->loadFile($filename);
 
-                        [$width, $height] = $doc->getDimensions();
-                        $type = "svg";
-                    }
+                    [$width, $height] = $doc->getDimensions();
+                    $width = (float) $width;
+                    $height = (float) $height;
+                    $type = "svg";
                 }
             }
         }
 
-        return $cache[$filename] = [$width, $height, $type];
+        return $cache[$filename] = [$width ?? 0, $height ?? 0, $type];
     }
 
     /**

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -164,7 +164,7 @@ class Cache
                 list($width, $height, $type) = Helpers::dompdf_getimagesize($resolved_url, $dompdf->getHttpContext());
 
                 // Known image type
-                if ($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg","webp"])) {
+                if ($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg","webp"], true)) {
                     //Don't put replacement image into cache - otherwise it will be deleted on cache cleanup.
                     //Only execute on successful caching of remote image.
                     if ($enable_remote && $remote || $data_uri) {

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -112,7 +112,7 @@ abstract class AbstractRenderer
         //$img_w = imagesx($src); $img_h = imagesy($src);
 
         list($img_w, $img_h) = Helpers::dompdf_getimagesize($img, $this->_dompdf->getHttpContext());
-        if (!isset($img_w) || $img_w == 0 || !isset($img_h) || $img_h == 0) {
+        if ($img_w == 0 || $img_h == 0) {
             return;
         }
 

--- a/tests/FrameReflower/ImageTestReflower.php
+++ b/tests/FrameReflower/ImageTestReflower.php
@@ -1,0 +1,12 @@
+<?php
+namespace Dompdf\Tests\FrameReflower;
+
+use Dompdf\FrameReflower\Image;
+
+class ImageTestReflower extends Image
+{
+    public function resolve_dimensions(): void
+    {
+        parent::resolve_dimensions();
+    }
+}

--- a/tests/LayoutTest/ImageTest.php
+++ b/tests/LayoutTest/ImageTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace Dompdf\Tests\LayoutTest;
+
+use Dompdf\Dompdf;
+use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\Options;
+use Dompdf\Tests\TestCase;
+
+class ImageTest extends TestCase
+{
+    public function imageDimensionsProvider(): array
+    {
+        $filepath = "../_files/jamaica.jpg";
+        $dpiFactor = 72 / 96;
+        $intrinsicWidth = 2048 * $dpiFactor;
+        $intrinsicHeight = 1536 * $dpiFactor;
+
+        return [
+            // TODO: Heredocs can be nicely indented starting with PHP 7.3
+            "zero" => [
+                <<<HTML
+<img src="$filepath" style="width: 0; height: 0;">
+HTML
+,
+                0.0,
+                0.0
+            ],
+            "auto" => [
+                <<<HTML
+<img src="$filepath">
+HTML
+,
+                $intrinsicWidth,
+                $intrinsicHeight
+            ],
+            "fixed px" => [
+                <<<HTML
+<img src="$filepath" width="100" height="200">
+HTML
+,
+                100 * $dpiFactor,
+                200 * $dpiFactor
+            ],
+            "fixed pt" => [
+                <<<HTML
+<img src="$filepath" style="width: 100pt; height: 200pt;">
+HTML
+,
+                100.0,
+                200.0
+            ],
+            "min-max" => [
+                <<<HTML
+<img src="$filepath" style="
+    width: 100px;
+    height: 1200px;
+    min-width: 400px;
+    max-width: 800px;
+    min-height: 300px;
+    max-height: 500px;
+    ">
+HTML
+,
+                400 * $dpiFactor,
+                500 * $dpiFactor
+            ],
+            "page size" => [
+                <<<HTML
+<img src="$filepath" style="width: 100%; height: 100%;">
+HTML
+,
+                400.0,
+                300.0
+            ],
+            "percentage chain" => [
+                <<<HTML
+<div style="width: 400px; height: 800px;">
+    <div style="width: 50%; height: 75%;">
+        <img src="$filepath" style="width: 50%; height: 75%;">
+    </div>
+</div>
+HTML
+,
+                100 * $dpiFactor,
+                450 * $dpiFactor
+            ],
+            "in table" => [
+                <<<HTML
+<table style="width: 20%; border-collapse: collapse;">
+    <tr>
+        <td style="padding: 0;">
+            <img src="$filepath">
+        </td>
+    </tr>
+</div>
+HTML
+,
+                $intrinsicWidth,
+                $intrinsicHeight
+            ],
+            "in table max-width" => [
+                <<<HTML
+<table style="width: 20%; border-collapse: collapse;">
+    <tr>
+        <td style="padding: 0;">
+            <img src="$filepath" style="max-width: 100%; height: auto;">
+        </td>
+    </tr>
+</div>
+HTML
+,
+                80.0,
+                60.0
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider imageDimensionsProvider
+     */
+    public function testImageDimensions(
+        string $body,
+        float $expectedWidth,
+        float $expectedHeight
+    ): void {
+        $width = null;
+        $height = null;
+
+        $options = new Options();
+        $options->setLogOutputFile("");
+
+        // Use callback to inspect frame tree
+        $dompdf = new Dompdf($options);
+        $dompdf->setBasePath(__DIR__);
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function ($info) use (&$width, &$height) {
+                    /** @var AbstractFrameDecorator */
+                    $frame = $info["frame"];
+
+                    if ($frame->get_node()->nodeName === "img") {
+                        [, , $width, $height] = $frame->get_content_box();
+                    }
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml(<<<HTML
+    <!DOCTYPE html>
+    <head>
+    <meta charset="UTF-8">
+    <style>
+        @page {
+            size: 400pt 300pt;
+            margin: 0;
+        }
+    </style>
+    </head>
+    <html>
+    <body>$body</body>
+    </html>
+HTML
+        );
+        $dompdf->render();
+
+        $this->assertSame($expectedWidth, $width);
+        $this->assertSame($expectedHeight, $height);
+    }
+}


### PR DESCRIPTION
Also improve parsing `width`/`height` attributes on `img` elements to not fail on `auto`.

Fixes #2240
Fixes #1448
Fixes #2631