### PR TITLE
Drop PHP support older than 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
   - 7.4
   - 8.0
+  - 8.1
   - nightly
   - hhvm
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Follow us on [![Twitter](http://twitter-badges.s3.amazonaws.com/twitter-a.png)](
  
 ## Requirements
 
- * PHP version 7.1 or higher
+ * PHP version 7.4 or higher
  * DOM extension
  * MBString extension
  * php-font-lib

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*",
         "phenx/php-font-lib": "^0.5.4",


### PR DESCRIPTION
Because those are EOL, and this would solve the confusion expressed in  https://github.com/dompdf/php-svg-lib/pull/78#issuecomment-999455409