### PR TITLE
Small fixes for generated content

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -422,7 +422,7 @@ class Style
             $d["pitch"] = "medium";
             $d["play_during"] = "auto";
             $d["position"] = "static";
-            $d["quotes"] = "";
+            $d["quotes"] = "auto";
             $d["richness"] = "50";
             $d["right"] = "auto";
             $d["size"] = "auto"; // @page

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1025,7 +1025,16 @@ class Stylesheet
                             continue;
                         }
 
-                        if (($src = $this->resolve_url($style->get_prop('content'))) !== "none") {
+                        $content = $style->get_prop("content");
+
+                        // Do not create non-displayed before/after pseudo elements
+                        // https://www.w3.org/TR/CSS21/generate.html#content
+                        // https://www.w3.org/TR/CSS21/generate.html#undisplayed-counters
+                        if ($content === "normal" || $content === "none") {
+                            continue;
+                        }
+
+                        if (($src = $this->resolve_url($content)) !== "none") {
                             $new_node = $node->ownerDocument->createElement("img_generated");
                             $new_node->setAttribute("src", $src);
                         } else {

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -223,8 +223,6 @@ abstract class AbstractFrameDecorator extends Frame
     {
         if ($this->content_set
             && $this->get_node()->nodeName === "dompdf_generated"
-            && $this->get_style()->content !== "normal"
-            && $this->get_style()->content !== "none"
         ) {
             foreach ($this->get_children() as $child) {
                 $this->remove_child($child);

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -450,10 +450,18 @@ abstract class AbstractFrameReflower
     /**
      * Parses the CSS "content" property
      *
+     * https://www.w3.org/TR/CSS21/generate.html#content
+     *
      * @return string The resulting string
      */
-    protected function _parse_content()
+    protected function _parse_content(): string
     {
+        $content = $this->_frame->get_style()->content;
+
+        if ($content === "normal" || $content === "none") {
+            return "";
+        }
+
         // Matches generated content
         $re = "/\n" .
             "\s(counters?\\([^)]*\\))|\n" .
@@ -463,8 +471,6 @@ abstract class AbstractFrameReflower
             "\s([^\s\"']+)|\n" .
             "\A([^\s\"']+)\n" .
             "/xi";
-
-        $content = $this->_frame->get_style()->content;
 
         $quotes = $this->_parse_quotes();
 
@@ -601,7 +607,7 @@ abstract class AbstractFrameReflower
             $frame->increment_counters($increment);
         }
 
-        if ($style->content && $frame->get_node()->nodeName === "dompdf_generated") {
+        if ($frame->get_node()->nodeName === "dompdf_generated") {
             $content = $this->_parse_content();
 
             if ($content !== "") {


### PR DESCRIPTION
* Do not create non-displayed before/after pseudo elements. This significantly improves performance with general rules that apply to all before/after pseudo elements, e.g. when using Bootstrap
* Avoid errors when using `open-quote` or `close-quote` and not specifying `quotes`

For reference:
* https://www.w3.org/TR/CSS21/generate.html#content
* https://www.w3.org/TR/CSS21/generate.html#undisplayed-counters
* https://www.w3.org/TR/css-content-3/#quotes