### PR TITLE
CPDF lib: Fix imagick alpha channel check

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5722,7 +5722,7 @@ EOT;
             $imagick->setFormat('png');
 
             // Get opacity channel (negative of alpha channel)
-            if ($imagick->getImageAlphaChannel() !== 0) {
+            if ($imagick->getImageAlphaChannel()) {
                 $alpha_channel = $imagickClonable ? clone $imagick : $imagick->clone();
                 $alpha_channel->separateImageChannel(\Imagick::CHANNEL_ALPHA);
                 // Since ImageMagick7 negate invert transparency as default


### PR DESCRIPTION
As commented in the issue, this should cover both older version, where it returns `int`, and newer version, where it returns `bool` . 

I also tried generating the PDF again with this fix applied and it seemed to render the image correctly.

Fixes #2713