### PR TITLE
Refactor handling of computed values

### DIFF
--- a/src/Css/Color.php
+++ b/src/Css/Color.php
@@ -189,7 +189,7 @@ class Color
             return $cache[$color];
         }
 
-        if (in_array($color, ["transparent", "inherit"])) {
+        if ($color === "transparent") {
             return $cache[$color] = $color;
         }
 
@@ -200,19 +200,19 @@ class Color
         $length = mb_strlen($color);
 
         // #rgb format
-        if ($length == 4 && $color[0] === "#") {
+        if ($length === 4 && $color[0] === "#") {
             return $cache[$color] = self::getArray($color[1] . $color[1] . $color[2] . $color[2] . $color[3] . $color[3]);
         } // #rgba format
-        else if ($length == 5 && $color[0] === "#") {
+        else if ($length === 5 && $color[0] === "#") {
             if (ctype_xdigit($color[4])) {
                 $alpha = round(hexdec($color[4] . $color[4])/255, 2);
             }
             return $cache[$color] = self::getArray($color[1] . $color[1] . $color[2] . $color[2] . $color[3] . $color[3], $alpha);
         } // #rrggbb format
-        else if ($length == 7 && $color[0] === "#") {
+        else if ($length === 7 && $color[0] === "#") {
             return $cache[$color] = self::getArray(mb_substr($color, 1, 6));
         } // #rrggbbaa format
-        else if ($length == 9 && $color[0] === "#") {
+        else if ($length === 9 && $color[0] === "#") {
             if (ctype_xdigit(mb_substr($color, 7, 2))) {
                 $alpha = round(hexdec(mb_substr($color, 7, 2))/255, 2);
             }
@@ -283,7 +283,8 @@ class Color
             return $cache[$color] = self::getArray($values);
         }
 
-        return self::getArray($color);
+        // Invalid or unsupported color format
+        return null;
     }
 
     /**

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -150,6 +150,19 @@ class Style
         "flex", "font", "list_style", "margin", "padding", "outline"];
 
     /**
+     * Maps legacy property names to actual property names.
+     *
+     * @var array
+     */
+    protected static $_props_alias = [
+        "word_wrap"                           => "overflow_wrap",
+        "_dompdf_background_image_resolution" => "background_image_resolution",
+        "_dompdf_image_resolution"            => "image_resolution",
+        "_webkit_transform"                   => "transform",
+        "_webkit_transform_origin"            => "transform_origin"
+    ];
+
+    /**
      * Default style values.
      *
      * @link http://www.w3.org/TR/CSS21/propidx.html
@@ -455,11 +468,7 @@ class Style
             $d["unicode_range"] = "";
 
             // vendor-prefixed properties
-            $d["_dompdf_background_image_resolution"] = &$d["background_image_resolution"];
-            $d["_dompdf_image_resolution"] = &$d["image_resolution"];
             $d["_dompdf_keep"] = "";
-            $d["_webkit_transform"] = &$d["transform"];
-            $d["_webkit_transform_origin"] = &$d["transform_origin"];
 
             // Properties that inherit by default
             self::$_inherited = [
@@ -915,8 +924,8 @@ class Style
         $prop = str_replace("-", "_", $prop);
 
         // Legacy property aliases
-        if ($prop === "word_wrap") {
-            $prop = "overflow_wrap";
+        if (isset(self::$_props_alias[$prop])) {
+            $prop = self::$_props_alias[$prop];
         }
 
         if (!isset(self::$_defaults[$prop])) {
@@ -978,8 +987,8 @@ class Style
     function __get($prop)
     {
         // Legacy property aliases
-        if ($prop === "word_wrap") {
-            $prop = "overflow_wrap";
+        if (isset(self::$_props_alias[$prop])) {
+            $prop = self::$_props_alias[$prop];
         }
 
         if (!isset(self::$_defaults[$prop])) {
@@ -1070,8 +1079,8 @@ class Style
     function get_prop($prop)
     {
         // Legacy property aliases
-        if ($prop === "word_wrap") {
-            $prop = "overflow_wrap";
+        if (isset(self::$_props_alias[$prop])) {
+            $prop = self::$_props_alias[$prop];
         }
 
         if (!isset(self::$_defaults[$prop])) {
@@ -3190,22 +3199,6 @@ class Style
     }
 
     /**
-     * @param $val
-     */
-    function set__webkit_transform($val)
-    {
-        $this->__set("transform", $val);
-    }
-
-    /**
-     * @param $val
-     */
-    function set__webkit_transform_origin($val)
-    {
-        $this->__set("transform_origin", $val);
-    }
-
-    /**
      * Sets the CSS3 transform-origin property
      *
      * @link http://www.w3.org/TR/css3-2d-transforms/#transform-origin
@@ -3306,22 +3299,6 @@ class Style
         $parsed = $this->parse_image_resolution($val);
 
         $this->_props_computed["image_resolution"] = $parsed;
-    }
-
-    /**
-     * @param $val
-     */
-    function set__dompdf_background_image_resolution($val)
-    {
-        $this->__set("background_image_resolution", $val);
-    }
-
-    /**
-     * @param $val
-     */
-    function set__dompdf_image_resolution($val)
-    {
-        $this->__set("image_resolution", $val);
     }
 
     /**

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1484,56 +1484,6 @@ class Style
         return $this->_get_border("left");
     }
 
-    private function _get_width($prop)
-    {
-        //TODO: should be handled in setter
-        if (strpos($this->_props_computed[$prop], "%") !== false) {
-            // calculate against width of containing block, needs to be done outside the style class
-            return $this->_props_computed[$prop];
-        }
-        return $this->length_in_pt($this->_props_computed[$prop], $this->__get("font_size"));
-    }
-
-    function get_margin_top()
-    {
-        return $this->_get_width("margin_top");
-    }
-
-    function get_margin_right()
-    {
-        return $this->_get_width("margin_right");
-    }
-
-    function get_margin_bottom()
-    {
-        return $this->_get_width("margin_bottom");
-    }
-
-    function get_margin_left()
-    {
-        return $this->_get_width("margin_left");
-    }
-
-    function get_padding_top()
-    {
-        return $this->_get_width("padding_top");
-    }
-
-    function get_padding_right()
-    {
-        return $this->_get_width("padding_right");
-    }
-
-    function get_padding_bottom()
-    {
-        return $this->_get_width("padding_bottom");
-    }
-
-    function get_padding_left()
-    {
-        return $this->_get_width("padding_left");
-    }
-
     /**
      * @deprecated
      * @param float $w
@@ -1658,16 +1608,6 @@ class Style
     function get_outline_color()
     {
         return $this->munge_color($this->_props_computed["outline_color"]);
-    }
-
-    /**#@+
-     * Returns the outline width, as it is currently stored
-     * @return float|string
-     */
-    function get_outline_width()
-    {
-        $style = $this->__get("outline_style");
-        return $style !== "none" && $style !== "hidden" ? $this->length_in_pt($this->_props_computed["outline_width"]) : 0;
     }
 
     /**#@+

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -670,12 +670,8 @@ class Style
             }
 
             if (($i = mb_stripos($l, "rem")) !== false) {
-                if ($this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style() === null) {
-                    // Interpreting it as "em", see https://github.com/dompdf/dompdf/issues/1406
-                    $ret += (float)mb_substr($l, 0, $i) * $this->__get("font_size");
-                } else {
-                    $ret += (float)mb_substr($l, 0, $i) * $this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style()->font_size;
-                }
+                $root_style = $this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style();
+                $ret += (float)mb_substr($l, 0, $i) * $root_style->font_size;
                 continue;
             }
 
@@ -2169,12 +2165,8 @@ class Style
 
         // length_in_pt uses the font size if units are em or ex (and, potentially, rem) so we'll calculate in the method
         if (($i = mb_strpos($fs, "rem")) !== false) {
-            if ($this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style() === null) {
-                // Interpreting it as "em", see https://github.com/dompdf/dompdf/issues/1406
-                $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
-            } else {
-                $fs = (float)mb_substr($fs, 0, $i) * $this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style()->font_size;
-            }
+            $root_style = $this->_stylesheet->get_dompdf()->getTree()->get_root()->get_style();
+            $fs = (float)mb_substr($fs, 0, $i) * $root_style->font_size;
         } elseif (($i = mb_strpos($fs, "em")) !== false) {
             $fs = (float)mb_substr($fs, 0, $i) * $this->_parent_font_size;
         } elseif (($i = mb_strpos($fs, "ex")) !== false) {

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -939,6 +939,10 @@ class Style
             $val = preg_replace("/([0-9]+) (pt|px|pc|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
         }
 
+        if ($val === "initial") {
+            $val = self::$_defaults[$prop];
+        }
+
         $this->_props[$prop] = $val;
         $this->_props_computed[$prop] = null;
         $this->_prop_cache[$prop] = null;

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1005,7 +1005,7 @@ class Style
         if (isset(self::$_props_shorthand[$prop])) {
             // Shorthand properties directly set their respective sub-properties
             // https://www.w3.org/TR/css-cascade-3/#shorthand
-            if ($val === "initial" || $val === "inherit") {
+            if ($val === "initial" || $val === "inherit" || $val === "unset") {
                 foreach (self::$_props_shorthand[$prop] as $sub_prop) {
                     $this->set_prop($sub_prop, $val, $important, $clear_dependencies);
                 }
@@ -1028,6 +1028,13 @@ class Style
 
             if ($important) {
                 $this->_important_props[$prop] = true;
+            }
+
+            // https://www.w3.org/TR/css-cascade-3/#inherit-initial
+            if ($val === "unset") {
+                $val = in_array($prop, self::$_inherited, true)
+                    ? "inherit"
+                    : "initial";
             }
 
             // https://www.w3.org/TR/css-cascade-3/#valdef-all-initial

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2242,7 +2242,7 @@ class Style
             $this->_set_style("background_image", "none", $important);
             $this->_set_style("background_color", "transparent", $important);
         } else {
-            $pos = [];
+            $pos_size = [];
             $tmp = preg_replace("/\s*\,\s*/", ",", $val); // when rgb() has spaces
             $tmp = preg_split("/\s+/", $tmp);
 
@@ -2256,12 +2256,22 @@ class Style
                 } elseif ($this->munge_color($attr) !== null) {
                     $this->_set_style("background_color", $attr, $important);
                 } else {
-                    $pos[] = $attr;
+                    $pos_size[] = $attr;
                 }
             }
 
-            if (count($pos)) {
-                $this->_set_style("background_position", implode(" ", $pos), $important);
+            if (count($pos_size)) {
+                $pos_size = preg_split("/\s*\/\s*/", implode(" ", $pos_size));
+                $pos = $pos_size[0] ?? "";
+                $size = $pos_size[1] ?? "";
+
+                if ($pos) {
+                    $this->_set_style("background_position", $pos, $important);
+                }
+
+                if ($size) {
+                    $this->_set_style("background_size", $size, $important);
+                }
             }
         }
     }

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1225,11 +1225,7 @@ class Stylesheet
                 print "]\n</pre>";
             }
 
-            /*DEBUGCSS print: see below different print debugging method
-            Helpers::pre_r($frame->get_node()->nodeName . ":");
-            echo "<pre>";
-            echo $style;
-            echo "</pre>";*/
+            $style->clear_important();
             $frame->set_style($style);
 
             if (!$root_flg && $this->_page_styles["base"]) {
@@ -1627,18 +1623,10 @@ class Stylesheet
 
             $prop_name = rtrim(mb_strtolower(mb_substr($prop, 0, $i)));
             $value = ltrim(mb_substr($prop, $i + 1));
-            if ($DEBUGCSS) print $prop_name . ':=' . $value . ($important ? '!IMPORTANT' : '') . ')';
-            //New style, anyway empty
-            //if ($important || !$style->important_get($prop_name) ) {
-            //$style->$prop_name = array($value,$important);
-            //assignment might be replaced by overloading through __set,
-            //and overloaded functions might check _important_props,
-            //therefore set _important_props first.
-            if ($important) {
-                $style->important_set($prop_name);
-            }
 
-            $style->set_prop($prop_name, $value, false);
+            if ($DEBUGCSS) print $prop_name . ':=' . $value . ($important ? '!IMPORTANT' : '') . ')';
+
+            $style->set_prop($prop_name, $value, $important, false);
         }
         if ($DEBUGCSS) print '_parse_properties]';
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1637,8 +1637,8 @@ class Stylesheet
             if ($important) {
                 $style->important_set($prop_name);
             }
-            //For easier debugging, don't use overloading of assignments with __set
-            $style->$prop_name = $value;
+
+            $style->set_prop($prop_name, $value, false);
         }
         if ($DEBUGCSS) print '_parse_properties]';
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -261,61 +261,43 @@ class Stylesheet
     }
 
     /**
+     * Create a new Style object associated with this stylesheet
+     *
+     * @return Style
+     */
+    function create_style(): Style
+    {
+        return new Style($this, $this->_current_origin);
+    }
+
+    /**
      * Add a new Style object to the stylesheet
-     * add_style() adds a new Style object to the current stylesheet, or
-     * merges a new Style with an existing one.
+     *
+     * The style's origin is changed to the current origin of the stylesheet.
      *
      * @param string $key the Style's selector
      * @param Style $style the Style to be added
-     *
-     * @throws \Dompdf\Exception
      */
-    function add_style($key, Style $style)
+    function add_style(string $key, Style $style): void
     {
-        if (!is_string($key)) {
-            throw new Exception("CSS rule must be keyed by a string.");
-        }
-
         if (!isset($this->_styles[$key])) {
             $this->_styles[$key] = [];
         }
-        $new_style = clone $style;
-        $new_style->set_origin($this->_current_origin);
-        $this->_styles[$key][] = $new_style;
+
+        $style->set_origin($this->_current_origin);
+        $this->_styles[$key][] = $style;
     }
 
     /**
-     * lookup a specific Style collection
+     * Lookup a specific Style collection
      *
-     * lookup() returns the Style collection specified by $key, or null if the Style is
-     * not found.
+     * @param string $key the selector of the requested Style collection
      *
-     * @param string $key the selector of the requested Style
-     * @return Style
-     *
-     * @Fixme _styles is a two dimensional array. It should produce wrong results
+     * @return Style[]
      */
-    function lookup($key)
+    function lookup(string $key): array
     {
-        if (!isset($this->_styles[$key])) {
-            return null;
-        }
-
-        return $this->_styles[$key];
-    }
-
-    /**
-     * create a new Style object associated with this stylesheet
-     *
-     * @param Style $parent The style of this style's parent in the DOM tree
-     * @return Style
-     */
-    function create_style(Style $parent = null)
-    {
-        if ($parent == null) {
-            $parent = $this;
-        }
-        return new Style($parent, $this->_current_origin);
+        return $this->_styles[$key] ?? [];
     }
 
     /**
@@ -331,7 +313,6 @@ class Stylesheet
         }
         $this->_parse_css($css);
     }
-
 
     /**
      * load and parse a CSS file
@@ -1105,14 +1086,14 @@ class Stylesheet
             // Find nearest DOMElement parent
             $p = $frame;
             while ($p = $p->get_parent()) {
-                if ($p->get_node()->nodeType == XML_ELEMENT_NODE) {
+                if ($p->get_node()->nodeType === XML_ELEMENT_NODE) {
                     break;
                 }
             }
 
             // Styles can only be applied directly to DOMElements; anonymous
             // frames inherit from their parent
-            if ($frame->get_node()->nodeType != XML_ELEMENT_NODE) {
+            if ($frame->get_node()->nodeType !== XML_ELEMENT_NODE) {
                 if ($p) {
                     $style->inherit($p->get_style());
                 }

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -865,9 +865,7 @@ class Frame
             return $this->_is_cache["absolute"];
         }
 
-        $position = $this->get_style()->position;
-
-        return $this->_is_cache["absolute"] = ($position === "absolute" || $position === "fixed");
+        return $this->_is_cache["absolute"] = $this->get_style()->is_absolute();
     }
 
     /**
@@ -917,6 +915,7 @@ class Frame
     }
 
     /**
+     * @deprecated
      * @return bool
      */
     public function is_inline_block()
@@ -937,7 +936,7 @@ class Frame
             return $this->_is_cache["in_flow"];
         }
 
-        return $this->_is_cache["in_flow"] = !($this->get_style()->float !== "none" || $this->is_absolute());
+        return $this->_is_cache["in_flow"] = $this->get_style()->is_in_flow();
     }
 
     /**

--- a/src/Frame/Factory.php
+++ b/src/Frame/Factory.php
@@ -7,7 +7,6 @@
  */
 namespace Dompdf\Frame;
 
-use Dompdf\Css\Style;
 use Dompdf\Dompdf;
 use Dompdf\Exception;
 use Dompdf\Frame;
@@ -71,39 +70,14 @@ class Factory
         $style = $frame->get_style();
         $display = $style->display;
 
-        // Floating (and more generally out-of-flow) elements are blocks
-        // https://www.w3.org/TR/CSS21/visuren.html#dis-pos-flo
-        if (!$frame->is_in_flow()
-            && in_array($display, Style::INLINE_LEVEL_TYPES, true)
-        ) {
-            switch ($display) {
-                case "inline-flex":
-                    $display = "flex";
-                    break;
-                case "inline-table":
-                    $display = "table";
-                    break;
-                default:
-                    $display = "block";
-            }
-
-            // The original style needs to be modified, too, here, as the style
-            // gets reset to the original style after a page break
-            $frame->get_original_style()->display = $display;
-            $style->display = $display;
-        }
-
         switch ($display) {
 
-            case "flex": //FIXME: display type not yet supported
-            case "table-caption": //FIXME: display type not yet supported
             case "block":
                 $positioner = "Block";
                 $decorator = "Block";
                 $reflower = "Block";
                 break;
 
-            case "inline-flex": //FIXME: display type not yet supported
             case "inline-block":
                 $positioner = "Inline";
                 $decorator = "Block";
@@ -188,7 +162,6 @@ class Factory
                 break;
 
             default:
-                // FIXME: should throw some sort of warning or something?
             case "none":
                 if ($style->_dompdf_keep !== "yes") {
                     // Remove the node and the frame

--- a/src/FrameDecorator/Table.php
+++ b/src/FrameDecorator/Table.php
@@ -9,6 +9,7 @@ namespace Dompdf\FrameDecorator;
 
 use Dompdf\Cellmap;
 use DOMNode;
+use Dompdf\Css\Style;
 use Dompdf\Dompdf;
 use Dompdf\Frame;
 use Dompdf\Frame\Factory;
@@ -20,16 +21,7 @@ use Dompdf\Frame\Factory;
  */
 class Table extends AbstractFrameDecorator
 {
-    public static $VALID_CHILDREN = [
-        "table-row-group",
-        "table-row",
-        "table-header-group",
-        "table-footer-group",
-        "table-column",
-        "table-column-group",
-        "table-caption",
-        "table-cell"
-    ];
+    public static $VALID_CHILDREN = Style::TABLE_INTERNAL_TYPES;
 
     public static $ROW_GROUPS = [
         "table-row-group",

--- a/src/FrameDecorator/Table.php
+++ b/src/FrameDecorator/Table.php
@@ -298,10 +298,10 @@ class Table extends AbstractFrameDecorator
                     // Lookup styles for tbody tags.  If the user wants styles to work
                     // better, they should make the tbody explicit... I'm not going to
                     // try to guess what they intended.
-                    if ($tbody_style = $css->lookup("tbody")) {
+                    foreach ($css->lookup("tbody") as $tbody_style) {
                         $style->merge($tbody_style);
                     }
-                    $style->display = 'table-row-group';
+                    $style->display = "table-row-group";
 
                     // Okay, I have absolutely no idea why I need this clone here, but
                     // if it's omitted, php (as of 2004-07-28) segfaults.
@@ -319,10 +319,10 @@ class Table extends AbstractFrameDecorator
                     // Lookup styles for tr tags.  If the user wants styles to work
                     // better, they should make the tr explicit... I'm not going to
                     // try to guess what they intended.
-                    if ($tr_style = $css->lookup("tr")) {
+                    foreach ($css->lookup("tr") as $tr_style) {
                         $style->merge($tr_style);
                     }
-                    $style->display = 'table-row';
+                    $style->display = "table-row";
 
                     // Okay, I have absolutely no idea why I need this clone here, but
                     // if it's omitted, php (as of 2004-07-28) segfaults.

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -456,7 +456,7 @@ class Table extends AbstractFrameReflower
 
         if ($style->border_collapse === "collapse") {
             // Unset our borders because our cells are now using them
-            $style->border_style = "none";
+            $style->border_color = "transparent";
         }
 
         $page->table_reflow_end();


### PR DESCRIPTION
* Improve performance due to more efficient handling of computed values and shorthand properties
* Fix incorrectly calculated `rem` lengths in some cases, due to the root style not being available at the time of computation
* Fix incorrectly calculated `em` and `ex` lengths in some cases, due to incorrect caching in `length_in_pt`
* Fix several bugs related to `!important` handling, e.g. important declarations were incorrectly considered during inheritance
* Start dropping invalid declarations. This can be improved upon by extending the existing property setters or implementing missing ones
* Move `display` value computation to the `Style` class, which makes borders and backgrounds work on `table-caption` and `flex` elements, as they are fully treated as `block` elements now
* Add support for the `initial` and `unset` keywords
* Add support for the `currentcolor` color keyword
* Support `background-size` in `background` shorthand

This changes the `Style` class to only compute values when actually needed, instead of immediately on set. Previously, values were computed immediately while parsing style blocks, which meant unnecessary computation of values from unused styles and unnecessary invalidations later because of property dependencies. It also makes sure that the the root style is available when computing lengths, as values are now never computed before style merge and inheritance, at which point the root style is defined already. This fixes some cases of incorrectly computed `rem` lengths. Additionally, the handling of shorthand properties and `!important` declarations is cleaned up.

Together, these changes result in quite a noticeable performance improvement in the range of about 15–35% of the total render time, judging from some rudimentary testing with different documents.

Fixes #612
Fixes #1515