### PR TITLE
Fix table and cell positions with asymmetrical collapsed borders

### DIFF
--- a/lib/res/html.css
+++ b/lib/res/html.css
@@ -148,16 +148,18 @@ table {
 }
 
 table[border] {
-  border-style: outset;
-  border-color: gray;
+  border: outset gray;
 }
 
-/* This won't work (???) */
-/*
 table[border] td,
 table[border] th {
-  border: 1pt solid grey;
-}*/
+  border: 1px inset gray;
+}
+
+table[border="0"] td,
+table[border="0"] th {
+  border-width: 0;
+}
 
 /* make sure backgrounds are inherited in tables  -- see bug 4510 */
 td, th, tr {

--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -574,7 +574,7 @@ class Cellmap
             $this->_frames[$key]["rows"] = range($start_row, max(0, $this->__row - 1));
             $this->_frames[$key]["frame"] = $frame;
 
-            if ($display !== "table-row" && $collapse) {
+            if ($collapse) {
                 $bp = $style->get_border_properties();
 
                 // Resolve vertical borders

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -400,19 +400,7 @@ class AttributeTranslator
      */
     protected static function _set_table_border(\DOMElement $node, $value)
     {
-        $cell_list = self::get_cell_list($node);
-
-        foreach ($cell_list as $cell) {
-            $style = rtrim($cell->getAttribute(self::$_style_attr));
-            $style .= "; border-width: " . ($value > 0 ? 1 : 0) . "pt; border-style: inset;";
-            $style = ltrim($style, ";");
-            $cell->setAttribute(self::$_style_attr, $style);
-        }
-
-        $style = rtrim($node->getAttribute(self::$_style_attr), ";");
-        $style .= "; border-width: $value" . "px; ";
-
-        return ltrim($style, "; ");
+        return "border-width: $value" . "px;";
     }
 
     /**

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1265,6 +1265,35 @@ class Style
     }
 
     /**
+     * Experimental fast setter for used values.
+     *
+     * If a shorthand property is specified, all of its sub-properties are set
+     * to the same value.
+     *
+     * @param string $prop
+     * @param mixed  $val
+     */
+    function set_used(string $prop, $val): void
+    {
+        // Legacy property aliases
+        if (isset(self::$_props_alias[$prop])) {
+            $prop = self::$_props_alias[$prop];
+        }
+
+        if (!isset(self::$_defaults[$prop])) {
+            throw new Exception("'$prop' is not a recognized CSS property.");
+        }
+
+        if (isset(self::$_props_shorthand[$prop])) {
+            foreach (self::$_props_shorthand[$prop] as $sub_prop) {
+                $this->set_used($sub_prop, $val);
+            }
+        } else {
+            $this->_prop_cache[$prop] = $val;
+        }
+    }
+
+    /**
      * @param string $prop The property to compute.
      * @param mixed  $val  The value to compute.
      *

--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -454,15 +454,7 @@ class Table extends AbstractFrameReflower
         // Assign heights to our cells:
         $style->height = $this->_calculate_height();
 
-        if ($style->border_collapse === "collapse") {
-            // Unset our borders because our cells are now using them
-            $style->border_color = "transparent";
-        }
-
         $page->table_reflow_end();
-
-        // Debugging:
-        //echo ($this->_frame->get_cellmap());
 
         if ($block && $frame->is_in_flow()) {
             $block->add_frame_to_line($frame);
@@ -480,12 +472,13 @@ class Table extends AbstractFrameReflower
         }
 
         $style = $this->_frame->get_style();
+        $cellmap = $this->_frame->get_cellmap();
 
         $this->_frame->normalise();
 
         // Add the cells to the cellmap (this will calculate column widths as
         // frames are added)
-        $this->_frame->get_cellmap()->add_frame($this->_frame);
+        $cellmap->add_frame($this->_frame);
 
         // Find the min/max width of the table and sort the columns into
         // absolute/percent/auto arrays
@@ -501,7 +494,7 @@ class Table extends AbstractFrameReflower
         $this->_state["percent"] = [];
         $this->_state["auto"] = [];
 
-        $columns =& $this->_frame->get_cellmap()->get_columns();
+        $columns =& $cellmap->get_columns();
         foreach (array_keys($columns) as $i) {
             $this->_state["min_width"] += $columns[$i]["min-width"];
             $this->_state["max_width"] += $columns[$i]["max-width"];

--- a/src/FrameReflower/TableRowGroup.php
+++ b/src/FrameReflower/TableRowGroup.php
@@ -67,10 +67,5 @@ class TableRowGroup extends AbstractFrameReflower
         $style->height = $cellmap->get_frame_height($frame);
 
         $frame->set_position($cellmap->get_frame_position($frame));
-
-        if ($table->get_style()->border_collapse === "collapse") {
-            // Unset our borders because our cells are now using them
-            $style->border_style = "none";
-        }
     }
 }


### PR DESCRIPTION
Resolved borders need to be applied after all cells have been added, so that the final values are known. Also resolve table-row borders when resolving collapsed table borders.

Adds an experimental `set_used_value` setter to the `Style` class and uses that to set resolved table borders. The values are already final used values, and need no computation. This has a noticeable positive impact on performance with large tables containing many cells.

Applies on top of #2722

Fixes #1675
Fixes #2291