### PR TITLE
Add support for space-separated `rgb` color syntax

### DIFF
--- a/lib/res/html.css
+++ b/lib/res/html.css
@@ -163,12 +163,7 @@ table[border="0"] th {
 
 /* make sure backgrounds are inherited in tables  -- see bug 4510 */
 td, th, tr {
-  background-color: inherit;
-  background-image: inherit;
-  background-image-resolution: inherit;
-  background-position: inherit;
-  background-repeat: inherit;
-  background-size: inherit;
+  background: inherit;
 }
 
 /* caption inherits from table not table-outer */

--- a/lib/res/html.css
+++ b/lib/res/html.css
@@ -226,9 +226,6 @@ th {
 }
 
 /* inlines */
-q {
-  quotes: '"' '"' "'" "'"; /* FIXME only the first level is used */
-}
 
 q:before {
   content: open-quote;

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1054,7 +1054,7 @@ class Style
 
         if ($prop !== "content" && is_string($val) && strlen($val) > 5 && mb_strpos($val, "url") === false) {
             $val = mb_strtolower(trim(str_replace(["\n", "\t"], [" "], $val)));
-            $val = preg_replace("/([0-9]+) (pt|px|pc|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
+            $val = preg_replace("/([0-9]+) (pt|px|pc|rem|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
         }
 
         if (isset(self::$_props_shorthand[$prop])) {
@@ -2550,17 +2550,6 @@ class Style
      */
     function set_font($val, bool $important = false)
     {
-        // TODO: Remove custom `inherit` handling, already handled in `set_prop()`
-        if (strtolower($val) === "inherit") {
-            $this->set_prop("font_family", "inherit", $important);
-            $this->set_prop("font_size", "inherit", $important);
-            $this->set_prop("font_style", "inherit", $important);
-            $this->set_prop("font_variant", "inherit", $important);
-            $this->set_prop("font_weight", "inherit", $important);
-            $this->set_prop("line_height", "inherit", $important);
-            return;
-        }
-
         if (preg_match("/^(italic|oblique|normal)\s*(.*)$/i", $val, $match)) {
             $this->set_prop("font_style", $match[1], $important);
             $val = $match[2];
@@ -2573,16 +2562,16 @@ class Style
 
         //matching numeric value followed by unit -> this is indeed a subsequent font size. Skip!
         if (preg_match("/^(bold|bolder|lighter|100|200|300|400|500|600|700|800|900|normal)\s*(.*)$/i", $val, $match) &&
-            !preg_match("/^(?:pt|px|pc|em|ex|in|cm|mm|%)/", $match[2])
+            !preg_match("/^(?:pt|px|pc|rem|em|ex|in|cm|mm|%)/", $match[2])
         ) {
             $this->set_prop("font_weight", $match[1], $important);
             $val = $match[2];
         }
 
-        if (preg_match("/^(xx-small|x-small|small|medium|large|x-large|xx-large|smaller|larger|\d+\s*(?:pt|px|pc|em|ex|in|cm|mm|%))(?:\/|\s*)(.*)$/i", $val, $match)) {
+        if (preg_match("/^(xx-small|x-small|small|medium|large|x-large|xx-large|smaller|larger|\d+\s*(?:pt|px|pc|rem|em|ex|in|cm|mm|%))(?:\/|\s*)(.*)$/i", $val, $match)) {
             $this->set_prop("font_size", $match[1], $important);
             $val = $match[2];
-            if (preg_match("/^(?:\/|\s*)(\d+\s*(?:pt|px|pc|em|ex|in|cm|mm|%)?)\s*(.*)$/i", $val, $match)) {
+            if (preg_match("/^(?:\/|\s*)(\d+\s*(?:pt|px|pc|rem|em|ex|in|cm|mm|%)?)\s*(.*)$/i", $val, $match)) {
                 $this->set_prop("line_height", $match[1], $important);
                 $val = $match[2];
             }
@@ -3265,7 +3254,7 @@ class Style
     {
         $this->_prop_cache["size"] = null;
 
-        $length_re = "/(\d+\s*(?:pt|px|pc|em|ex|in|cm|mm|%))/";
+        $length_re = "/(\d+\s*(?:pt|px|pc|rem|em|ex|in|cm|mm|%))/";
 
         $val = mb_strtolower($val);
 

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1052,7 +1052,7 @@ class Style
             return;
         }
 
-        if ($prop !== "content" && is_string($val) && strlen($val) > 5 && mb_strpos($val, "url") === false) {
+        if ($prop !== "content" && is_string($val) && mb_strpos($val, "url") === false) {
             $val = mb_strtolower(trim(str_replace(["\n", "\t"], [" "], $val)));
             $val = preg_replace("/([0-9]+) (pt|px|pc|rem|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
         }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -211,13 +211,13 @@ class Helpers
     /**
      * Determines whether $value is a percentage or not
      *
-     * @param float $value
+     * @param string|float|int $value
      *
      * @return bool
      */
-    public static function is_percent($value)
+    public static function is_percent($value): bool
     {
-        return false !== mb_strpos($value, "%");
+        return is_string($value) && false !== mb_strpos($value, "%");
     }
 
     /**

--- a/tests/Css/ColorTest.php
+++ b/tests/Css/ColorTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace Dompdf\Tests\Css;
+
+use Dompdf\Css\Color;
+use Dompdf\Tests\TestCase;
+
+class ColorTest extends TestCase
+{
+    public function validColorProvider(): array
+    {
+        return [
+            // Color names
+            ["red", [1, 0, 0, 1.0]],
+            ["lime", [0, 1, 0, 1.0]],
+            ["blue", [0, 0, 1, 1.0]],
+
+            // Hex notation
+            ["#f00", [1, 0, 0, 1.0]],
+            ["#f003", [1, 0, 0, 0.2]],
+            ["#ff0000", [1, 0, 0, 1.0]],
+            ["#ff000033", [1, 0, 0, 0.2]],
+            ["#FFFFFF00", [1, 1, 1, 0.0]],
+
+            // Functional rgb syntax (space-separated)
+            ["rgb(255 0 0)", [1, 0, 0, 1.0]],
+            ["rgb(255 0 0/0.2)", [1, 0, 0, 0.2]],
+            ["rgb( 255 0 0 / 0.2 )", [1, 0, 0, 0.2]],
+            ["rgb(100% 0% 0% / 20%)", [1, 0, 0, 0.2]],
+            ["rgba(255 0 0)", [1, 0, 0, 1.0]],
+            ["rgba(255 0 0/0.2)", [1, 0, 0, 0.2]],
+
+            // Functional rgb syntax (comma-separated)
+            ["rgb(255, 0, 0)", [1, 0, 0, 1.0]],
+            ["rgb(255, 0, 0, 0.2)", [1, 0, 0, 0.2]],
+            ["rgb( 255,0,0,0.2 )", [1, 0, 0, 0.2]],
+            ["rgb(100%, 0%, 0%, 20%)", [1, 0, 0, 0.2]],
+            ["rgba(255, 0, 0)", [1, 0, 0, 1.0]],
+            ["rgba(255, 0, 0, 0.2)", [1, 0, 0, 0.2]],
+        ];
+    }
+
+    /**
+     * @dataProvider validColorProvider
+     */
+    public function testParseColor(string $value, array $expected): void
+    {
+        $color = Color::parse($value);
+
+        if (!is_array($color)) {
+            $this->fail("Failed to parse valid color declaration");
+        }
+
+        [$r, $g, $b] = $color;
+        $alpha = $color["alpha"];
+
+        $this->assertEquals($expected, [$r, $g, $b, $alpha]);
+    }
+}

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -1,0 +1,304 @@
+<?php
+namespace Dompdf\Tests\Css;
+
+use Dompdf\Dompdf;
+use Dompdf\Css\Style;
+use Dompdf\Css\Stylesheet;
+use Dompdf\Tests\TestCase;
+
+class ShorthandTest extends TestCase
+{
+    protected function style(): Style
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $sheet->set_base_path(__DIR__); // Treat stylesheet as being located in this directory
+
+        return new Style($sheet);
+    }
+
+    public function marginPaddingShorthandProvider(): array
+    {
+        return [
+            ["5pt", "5pt", "5pt", "5pt", "5pt"],
+            ["1rem 2rem", "1rem", "2rem", "1rem", "2rem"],
+            ["10% 5pt 25%", "10%", "5pt", "25%", "5pt"],
+            ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
+        ];
+    }
+
+    /**
+     * @dataProvider marginPaddingShorthandProvider
+     */
+    public function testMarginShorthand(
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $style = $this->style();
+        $style->set_prop("margin", $value);
+
+        $this->assertSame($top, $style->get_prop("margin_top"));
+        $this->assertSame($right, $style->get_prop("margin_right"));
+        $this->assertSame($bottom, $style->get_prop("margin_bottom"));
+        $this->assertSame($left, $style->get_prop("margin_left"));
+    }
+
+    /**
+     * @dataProvider marginPaddingShorthandProvider
+     */
+    public function testPaddingShorthand(
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $style = $this->style();
+        $style->set_prop("padding", $value);
+
+        $this->assertSame($top, $style->get_prop("padding_top"));
+        $this->assertSame($right, $style->get_prop("padding_right"));
+        $this->assertSame($bottom, $style->get_prop("padding_bottom"));
+        $this->assertSame($left, $style->get_prop("padding_left"));
+    }
+
+    protected function borderTypeShorthandTest(
+        string $type,
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $style = $this->style();
+        $style->set_prop("border_{$type}", $value);
+
+        $this->assertSame($top, $style->get_prop("border_top_{$type}"));
+        $this->assertSame($right, $style->get_prop("border_right_{$type}"));
+        $this->assertSame($bottom, $style->get_prop("border_bottom_{$type}"));
+        $this->assertSame($left, $style->get_prop("border_left_{$type}"));
+    }
+
+    public function borderWidthShorthandProvider(): array
+    {
+        return [
+            ["thin", "thin", "thin", "thin", "thin"],
+            ["medium 1.2rem", "medium", "1.2rem", "medium", "1.2rem"],
+            ["thick 5pt 12pc", "thick", "5pt", "12pc", "5pt"],
+            ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
+        ];
+    }
+
+    /**
+     * @dataProvider borderWidthShorthandProvider
+     */
+    public function testBorderWidthShorthand(
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $this->borderTypeShorthandTest("width", $value, $top, $right, $bottom, $left);
+    }
+
+    public function borderStyleShorthandProvider(): array
+    {
+        return [
+            ["solid", "solid", "solid", "solid", "solid"],
+            ["none double", "none", "double", "none", "double"],
+            ["inset outset groove", "inset", "outset", "groove", "outset"],
+            ["solid double none hidden", "solid", "double", "none", "hidden"],
+        ];
+    }
+
+    /**
+     * @dataProvider borderStyleShorthandProvider
+     */
+    public function testBorderStyleShorthand(
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $this->borderTypeShorthandTest("style", $value, $top, $right, $bottom, $left);
+    }
+
+    public function borderColorShorthandProvider(): array
+    {
+        return [
+            ["transparent", "transparent", "transparent", "transparent", "transparent"],
+            ["#000 #fff", "#000", "#fff", "#000", "#fff"],
+            ["red blue green", "red", "blue", "green", "blue"],
+            ["rgb(0 0 0) rgb(50%, 50%, 50%) currentcolor rgb(255 0 0 / 0.5)", "rgb(0 0 0)", "rgb(50%, 50%, 50%)", "currentcolor", "rgb(255 0 0 / 0.5)"],
+        ];
+    }
+
+    /**
+     * @dataProvider borderColorShorthandProvider
+     */
+    public function testBorderColorShorthand(
+        string $value,
+        string $top,
+        string $right,
+        string $bottom,
+        string $left
+    ): void {
+        $this->borderTypeShorthandTest("color", $value, $top, $right, $bottom, $left);
+    }
+
+    public function borderShorthandProvider(): array
+    {
+        return [
+            ["transparent", "medium", "none", "transparent"],
+            ["currentcolor 1pc", "1pc", "none", "currentcolor"],
+            ["thick inset", "thick", "inset", "currentcolor"],
+            ["solid 5pt", "5pt", "solid", "currentcolor"],
+            ["1pt solid red", "1pt", "solid", "red"],
+            ["rgb(0, 0, 0) double 1rem", "1rem", "double", "rgb(0, 0, 0)"],
+            ["thin rgb(0 255 0 / 0.2) solid", "thin", "solid", "rgb(0 255 0 / 0.2)"]
+        ];
+    }
+
+    /**
+     * @dataProvider borderShorthandProvider
+     */
+    public function testBorderShorthand(
+        string $value,
+        string $expectedWidth,
+        string $expectedStyle,
+        string $expectedColor
+    ): void {
+        $style = $this->style();
+        $style->set_prop("border", $value);
+
+        $sides = ["top", "right", "bottom", "left"];
+
+        foreach ($sides as $side) {
+            $this->assertSame($expectedWidth, $style->get_prop("border_{$side}_width"));
+            $this->assertSame($expectedStyle, $style->get_prop("border_{$side}_style"));
+            $this->assertSame($expectedColor, $style->get_prop("border_{$side}_color"));
+        }
+    }
+
+    /**
+     * @dataProvider borderShorthandProvider
+     */
+    public function testOutlineShorthand(
+        string $value,
+        string $expectedWidth,
+        string $expectedStyle,
+        string $expectedColor
+    ): void {
+        $style = $this->style();
+        $style->set_prop("outline", $value);
+
+        $this->assertSame($expectedWidth, $style->get_prop("outline_width"));
+        $this->assertSame($expectedStyle, $style->get_prop("outline_style"));
+        $this->assertSame($expectedColor, $style->get_prop("outline_color"));
+    }
+
+    public function borderRadiusShorthandProvider(): array
+    {
+        return [
+            ["5pt", "5pt", "5pt", "5pt", "5pt"],
+            ["1rem 2rem", "1rem", "2rem", "1rem", "2rem"],
+            ["10% 5pt 15%", "10%", "5pt", "15%", "5pt"],
+            ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
+        ];
+    }
+
+    /**
+     * @dataProvider borderRadiusShorthandProvider
+     */
+    public function testBorderRadiusShorthand(
+        string $value,
+        string $tl,
+        string $tr,
+        string $br,
+        string $bl
+    ): void {
+        $style = $this->style();
+        $style->set_prop("border_radius", $value);
+
+        $this->assertSame($tl, $style->get_prop("border_top_left_radius"));
+        $this->assertSame($tr, $style->get_prop("border_top_right_radius"));
+        $this->assertSame($br, $style->get_prop("border_bottom_right_radius"));
+        $this->assertSame($bl, $style->get_prop("border_bottom_left_radius"));
+    }
+
+    public function backgroundShorthandProvider(): array
+    {
+        $basePath = realpath(__DIR__ . "/..");
+        $imagePath = "$basePath/_files/jamaica.jpg";
+        $expectedPath = $basePath . DIRECTORY_SEPARATOR . "_files" . DIRECTORY_SEPARATOR . "jamaica.jpg";
+
+        return [
+            ["none", "none"],
+            ["url($imagePath)", $expectedPath],
+            ["url( \"$imagePath\" )", $expectedPath],
+            ["rgba( 5, 5, 5, 1 )", "none", "0% 0%", "auto auto", "repeat", "scroll", "rgba( 5, 5, 5, 1 )"],
+            ["url(non-existing.png) top center no-repeat red fixed", "none", "top center", "auto auto", "no-repeat", "fixed", "red"],
+            ["url($imagePath) left/200pt 30% rgb( 123 16 69/0.8 )no-repeat", $expectedPath, "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"]
+        ];
+    }
+
+    /**
+     * @dataProvider backgroundShorthandProvider
+     */
+    public function testBackgroundShorthand(
+        string $value,
+        string $image,
+        string $position = "0% 0%",
+        string $size = "auto auto",
+        string $repeat = "repeat",
+        string $attachment = "scroll",
+        string $color = "transparent"
+    ): void {
+        $style = $this->style();
+        $style->set_prop("background", $value);
+
+        $this->assertSame($image, $style->get_prop("background_image"));
+        $this->assertSame($position, $style->get_prop("background_position"));
+        $this->assertSame($size, $style->get_prop("background_size"));
+        $this->assertSame($repeat, $style->get_prop("background_repeat"));
+        $this->assertSame($attachment, $style->get_prop("background_attachment"));
+        $this->assertSame($color, $style->get_prop("background_color"));
+    }
+
+    public function listStyleShorthandProvider(): array
+    {
+        $basePath = realpath(__DIR__ . "/..");
+        $imagePath = "$basePath/_files/jamaica.jpg";
+        $expectedPath = $basePath . DIRECTORY_SEPARATOR . "_files" . DIRECTORY_SEPARATOR . "jamaica.jpg";
+
+        return [
+            ["none", "none", "none"],
+            ["url($imagePath)", "disc", $expectedPath],
+            ["url( '$imagePath' ) outside", "disc", $expectedPath, "outside"],
+            ["inside url($imagePath) square", "square", $expectedPath, "inside"],
+            ["inside decimal", "decimal", "none", "inside"]
+        ];
+    }
+
+    /**
+     * @dataProvider listStyleShorthandProvider
+     */
+    public function testListStyleShorthand(
+        string $value,
+        string $type,
+        string $image = "none",
+        string $position = "outside"
+    ): void {
+        $style = $this->style();
+        $style->set_prop("list_style", $value);
+
+        $this->assertSame($type, $style->get_prop("list_style_type"));
+        $this->assertSame($image, $style->get_prop("list_style_image"));
+        $this->assertSame($position, $style->get_prop("list_style_position"));
+    }
+}


### PR DESCRIPTION
With some improved shorthand-property parsing based on #2722, this was not a big deal anymore.

See https://www.w3.org/TR/css-color-4/#rgb-functions for reference.

Applies on top of #2722