### PR TITLE
Fix extraneous line height when wrapping large inline sub-frame

### DIFF
--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -314,8 +314,18 @@ class Text extends AbstractFrameReflower
         }
 
         if ($split === 0) {
+            // Make sure to move text when floating frames leave no space to
+            // place anything onto the line
+            // TODO: Would probably be better to move just below the current
+            // floating frame instead of trying to place text in line-height
+            // increments
+            if ($current_line->h === 0.0) {
+                // Line height might be 0
+                $h = max($frame->get_margin_height(), 1.0);
+                $block->maximize_line_height($h, $frame);
+            }
+
             // Break line and repeat layout
-            $block->maximize_line_height($frame->get_margin_height(), $frame);
             $block->add_line();
 
             // Find the appropriate inline ancestor to split


### PR DESCRIPTION
Tweaks the logic that was originally added in commit 514c091e88c3c11fd98319cda4fba820a4582aa3. This should affect older versions, too, but the white-space-handling changes have made it more visible. The following test case is broken on master (works fine in 1.1.1, though I haven’t tried too hard to reproduce it there).

### Test case for the line-height issue

<details>
<summary>HTML</summary>

```html
<!DOCTYPE html>
<html>

<head>
<meta charset="UTF-8">
<style>
@page {
    size: 400pt 300pt;
    margin: 50pt;
}

body {
    font-size: 200%;
    border: solid thin;
}

span {
    font-size: 225%;
}
</style>
</head>

<body>
    Some text <span>wrapping</span> to several lines
</body>

</html>
```
</details>

[line-height-before.pdf](https://github.com/dompdf/dompdf/files/7836143/line-height-before.pdf)
[line-height-after.pdf](https://github.com/dompdf/dompdf/files/7836142/line-height-after.pdf)