### PR TITLE
Take `min/max-height` into account in `get_min_max_width` for images

### DIFF
--- a/src/FrameReflower/Table.php
+++ b/src/FrameReflower/Table.php
@@ -75,7 +75,7 @@ class Table extends AbstractFrameReflower
         $columns =& $this->_frame->get_cellmap()->get_columns();
 
         $width = $style->width;
-        $min_table_width = (float) $style->length_in_pt($style->min_width, $cb["w"]) - $delta;
+        $min_table_width = $this->resolve_min_width($cb["w"]) - $delta;
 
         if ($width !== "auto") {
             $preferred_width = (float) $style->length_in_pt($width, $cb["w"]) - $delta;
@@ -278,28 +278,10 @@ class Table extends AbstractFrameReflower
         }
 
         // Handle min/max height
-        $min_height = $style->min_height;
-        $max_height = $style->max_height;
-
-        if (isset($cb["h"])) {
-            $min_height = $style->length_in_pt($min_height, $cb["h"]);
-            $max_height = $style->length_in_pt($max_height, $cb["h"]);
-        } else {
-            $min_height = !Helpers::is_percent($min_height)
-                ? $style->length_in_pt($min_height, $cb["w"])
-                : "auto";
-            $max_height = !Helpers::is_percent($max_height)
-                ? $style->length_in_pt($max_height, $cb["w"])
-                : "none";
-        }
-
-        if ($max_height !== "none" && $max_height !== "auto" && $height > $max_height) {
-            $height = $max_height;
-        }
-
-        if ($min_height !== "auto" && $min_height !== "none" && $height < $min_height) {
-            $height = $min_height;
-        }
+        // https://www.w3.org/TR/CSS21/visudet.html#min-max-heights
+        $min_height = $this->resolve_min_height($cb["h"]);
+        $max_height = $this->resolve_max_height($cb["h"]);
+        $height = Helpers::clamp($height, $min_height, $max_height);
 
         // Use the content height or the height value, whichever is greater
         if ($height <= $content_height) {

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -130,8 +130,8 @@ class TableCell extends Block
 
     public function get_min_max_content_width(): array
     {
-        // Ignore percentage values for a specified width here, as the
-        // containing block is not defined yet
+        // Ignore percentage values for a specified width here, as they are
+        // relative to the table width, which is not determined yet
         $style = $this->_frame->get_style();
         $width = $style->width;
         $fixed_width = $width !== "auto" && !Helpers::is_percent($width);
@@ -147,6 +147,11 @@ class TableCell extends Block
         }
 
         // Handle min/max width style properties
-        return $this->restrict_min_max_width($min, $max);
+        $min_width = $this->resolve_min_width(null);
+        $max_width = $this->resolve_max_width(null);
+        $min = Helpers::clamp($min, $min_width, $max_width);
+        $max = Helpers::clamp($max, $min_width, $max_width);
+
+        return [$min, $max];
     }
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -209,6 +209,22 @@ class Helpers
     }
 
     /**
+     * Restrict a length to the given range.
+     *
+     * If min > max, the result is min.
+     *
+     * @param float $length
+     * @param float $min
+     * @param float $max
+     *
+     * @return float
+     */
+    public static function clamp(float $length, float $min, float $max): float
+    {
+        return max($min, min($length, $max));
+    }
+
+    /**
      * Determines whether $value is a percentage or not
      *
      * @param string|float|int $value

--- a/tests/LayoutTest/ImageTest.php
+++ b/tests/LayoutTest/ImageTest.php
@@ -49,7 +49,7 @@ HTML
                 100.0,
                 200.0
             ],
-            "min-max" => [
+            "min-max 1" => [
                 <<<HTML
 <img src="$filepath" style="
     width: 100px;
@@ -63,6 +63,58 @@ HTML
 ,
                 400 * $dpiFactor,
                 500 * $dpiFactor
+            ],
+            "min-max 2" => [
+                <<<HTML
+<img src="$filepath" style="
+    width: auto;
+    height: 100px;
+    max-width: 200px;
+    min-height: 200px;
+    ">
+HTML
+,
+                200 * $dpiFactor,
+                200 * $dpiFactor
+            ],
+            "min-max 3" => [
+                <<<HTML
+<img src="$filepath" style="
+    width: 100px;
+    height: auto;
+    min-width: 200px;
+    max-height: 200px;
+    ">
+HTML
+,
+                200 * $dpiFactor,
+                150 * $dpiFactor
+            ],
+            "min-max 4" => [
+                <<<HTML
+<img src="$filepath" style="
+    width: auto;
+    height: auto;
+    max-width: 100px;
+    max-height: 200px;
+    ">
+HTML
+,
+                100 * $dpiFactor,
+                75 * $dpiFactor
+            ],
+            "min-max 5" => [
+                <<<HTML
+<img src="$filepath" style="
+    width: auto;
+    height: auto;
+    max-width: 100px;
+    max-height: 50px;
+    ">
+HTML
+,
+                50 * (4 / 3) * $dpiFactor,
+                50 * $dpiFactor
             ],
             "page size" => [
                 <<<HTML


### PR DESCRIPTION
This includes a rework of the size calculations for images, so that min/max constraints are always honored. Previously, constraints were ignored in some cases to maintain aspect ratio. See the last part of the section on min/max widths in https://www.w3.org/TR/CSS21/visudet.html#min-max-widths for the spec on the matter.

The first commit is a small change to enable rendering of zero-sized image frames. This ensures that outlines are drawn and that the image is still available as link target.

Fixes #2738