### PR TITLE
Fixed frame inline reflower when the frame has no child.

### DIFF
--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -160,7 +160,8 @@ class Inline extends AbstractFrameReflower
         }
 
         // Assume the position of the first child
-        [$x, $y] = $frame->get_first_child()->get_position();
+        $firstChild = $frame->get_first_child();
+        [$x, $y] = $firstChild ? $firstChild->get_position() : [0, 0];
         $frame->set_position($x, $y);
 
         // Handle relative positioning


### PR DESCRIPTION
There is a bug when a frame has no child for inline reflower.
