### PR TITLE
Added support for jpeg data uri in $canvas->image()

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -6230,15 +6230,21 @@ EOT;
         // attempt to add a jpeg image straight from a file, using no GD commands
         // note that this function is unable to operate on a remote file.
 
-        if (!file_exists($img)) {
-            return;
+        if(substr($img, 0, 5) == 'data:') {
+            $filename = 'data-'.hash('md4',$img);
+        }
+        else {
+            if (!file_exists($img)) {
+                return;
+            }
+            $filename = $img;
         }
 
-        if ($this->image_iscached($img)) {
+        if ($this->image_iscached($filename)) {
             $data = null;
-            $imageWidth = $this->imagelist[$img]['w'];
-            $imageHeight = $this->imagelist[$img]['h'];
-            $channels = $this->imagelist[$img]['c'];
+            $imageWidth = $this->imagelist[$filename]['w'];
+            $imageHeight = $this->imagelist[$filename]['h'];
+            $channels = $this->imagelist[$filename]['c'];
         } else {
             $tmp = getimagesize($img);
             $imageWidth = $tmp[0];
@@ -6265,7 +6271,7 @@ EOT;
             $h = $w * $imageHeight / $imageWidth;
         }
 
-        $this->addJpegImage_common($data, $img, $imageWidth, $imageHeight, $x, $y, $w, $h, $channels);
+        $this->addJpegImage_common($data, $filename, $imageWidth, $imageHeight, $x, $y, $w, $h, $channels);
     }
 
     /**


### PR DESCRIPTION
Other image formats already work with data uri's, but jpeg's don't as cpdf->addJpegFromFile uses file_exists.
This change adds support for data uri's to addJpegFromFile.