### PR TITLE
Be more lenient when parsing `width` and `height` attributes for images

### DIFF
--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -351,12 +351,14 @@ class AttributeTranslator
 
     protected static function _set_px_width(\DOMElement $node, string $value): string
     {
-        if (Helpers::is_percent($value)) {
-            return sprintf("width: %s;", $value);
+        $v = trim($value);
+
+        if (Helpers::is_percent($v)) {
+            return sprintf("width: %s;", $v);
         }
 
-        if (is_numeric($value)) {
-            return sprintf("width: %spx;", $value);
+        if (is_numeric(mb_substr($v, 0, 1))) {
+            return sprintf("width: %spx;", (float) $v);
         }
 
         return "";
@@ -364,12 +366,14 @@ class AttributeTranslator
 
     protected static function _set_px_height(\DOMElement $node, string $value): string
     {
-        if (Helpers::is_percent($value)) {
-            return sprintf("height: %s;", $value);
+        $v = trim($value);
+
+        if (Helpers::is_percent($v)) {
+            return sprintf("height: %s;", $v);
         }
 
-        if (is_numeric($value)) {
-            return sprintf("height: %spx;", $value);
+        if (is_numeric(mb_substr($v, 0, 1))) {
+            return sprintf("height: %spx;", (float) $v);
         }
 
         return "";


### PR DESCRIPTION
Accept any value starting with a number as `px` value, not just a unit-less one, restoring previous behavior.

Quick fix for the sample from https://github.com/dompdf/dompdf/issues/2781#issuecomment-1063395313