### PR TITLE
Fix generated inline frames involving line breaks

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -246,8 +246,12 @@ abstract class AbstractFrameDecorator extends Frame
         if ($this->content_set
             && $this->get_node()->nodeName === "dompdf_generated"
         ) {
-            foreach ($this->get_children() as $child) {
-                $this->remove_child($child);
+            $content = $this->get_style()->content;
+
+            if ($content !== "normal" && $content !== "none") {
+                foreach ($this->get_children() as $child) {
+                    $this->remove_child($child);
+                }
             }
         }
     }

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -89,10 +89,10 @@ class Inline extends AbstractFrameDecorator
         }
 
         //On continuation of inline element on next line,
-        //don't repeat non-vertically repeatable background images
+        //don't repeat non-horizontally repeatable background images
         //See e.g. in testcase image_variants, long descriptions
         if (($url = $split->get_style()->background_image) && $url !== "none"
-            && ($repeat = $split->get_style()->background_repeat) && $repeat !== "repeat" && $repeat !== "repeat-y"
+            && ($repeat = $split->get_style()->background_repeat) && $repeat !== "repeat" && $repeat !== "repeat-x"
         ) {
             $split_style->background_image = "none";
         }

--- a/src/FrameDecorator/Inline.php
+++ b/src/FrameDecorator/Inline.php
@@ -68,33 +68,38 @@ class Inline extends AbstractFrameDecorator
         $this->revert_counter_increment();
         $node = $this->_frame->get_node();
         $split = $this->copy($node->cloneNode());
-        // if this is a generated node don't propagate the content style
-        if ($split->get_node()->nodeName == "dompdf_generated") {
-            $split->get_style()->content = "normal";
-        }
-        $this->get_parent()->insert_child_after($split, $this);
+
+        $style = $this->_frame->get_style();
+        $split_style = $split->get_original_style();
 
         // Unset the current node's right style properties
-        $style = $this->_frame->get_style();
         $style->margin_right = 0;
         $style->padding_right = 0;
         $style->border_right_width = 0;
 
         // Unset the split node's left style properties since we don't want them
         // to propagate
-        $style = $split->get_style();
-        $style->margin_left = 0;
-        $style->padding_left = 0;
-        $style->border_left_width = 0;
+        $split_style->margin_left = 0;
+        $split_style->padding_left = 0;
+        $split_style->border_left_width = 0;
+
+        // If this is a generated node don't propagate the content style
+        if ($split->get_node()->nodeName == "dompdf_generated") {
+            $split_style->content = "normal";
+        }
 
         //On continuation of inline element on next line,
         //don't repeat non-vertically repeatable background images
         //See e.g. in testcase image_variants, long descriptions
-        if (($url = $style->background_image) && $url !== "none"
-            && ($repeat = $style->background_repeat) && $repeat !== "repeat" && $repeat !== "repeat-y"
+        if (($url = $split->get_style()->background_image) && $url !== "none"
+            && ($repeat = $split->get_style()->background_repeat) && $repeat !== "repeat" && $repeat !== "repeat-y"
         ) {
-            $style->background_image = "none";
+            $split_style->background_image = "none";
         }
+
+        $split->set_style(clone $split_style);
+
+        $this->get_parent()->insert_child_after($split, $this);
 
         // Add $child and all following siblings to the new split node
         $iter = $child;


### PR DESCRIPTION
Ensure that the changes to the split style are not immediately reset when the parent frame is split.

Fixes #2794