### PR TITLE
Make `httpContext` available from options

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -156,14 +156,6 @@ class Dompdf
     private $protocol = "";
 
     /**
-     * HTTP context created with stream_context_create()
-     * Will be used for file_get_contents
-     *
-     * @var resource
-     */
-    private $httpContext;
-
-    /**
      * The system's locale
      *
      * @var string
@@ -400,7 +392,7 @@ class Dompdf
             $uri = $realfile;
         }
 
-        [$contents, $http_response_header] = Helpers::getFileContent($uri, $this->httpContext);
+        [$contents, $http_response_header] = Helpers::getFileContent($uri, $this->options->getHttpContext());
         if ($contents === null) {
             throw new Exception("File '$file' not found.");
         }
@@ -1244,12 +1236,12 @@ class Dompdf
     /**
      * Sets the HTTP context
      *
-     * @param resource $httpContext
+     * @param resource|array $httpContext
      * @return $this
      */
     public function setHttpContext($httpContext)
     {
-        $this->httpContext = $httpContext;
+        $this->options->setHttpContext($httpContext);
         return $this;
     }
 
@@ -1269,7 +1261,7 @@ class Dompdf
      */
     public function getHttpContext()
     {
-        return $this->httpContext;
+        return $this->options->getHttpContext();
     }
 
     /**
@@ -1363,6 +1355,11 @@ class Dompdf
      */
     public function setOptions(Options $options)
     {
+        // For backwards compatibility
+        if ($this->options && $this->options->getHttpContext() && !$options->getHttpContext()) {
+            $options->setHttpContext($this->options->getHttpContext());
+        }
+
         $this->options = $options;
         $fontMetrics = $this->getFontMetrics();
         if (isset($fontMetrics)) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -276,6 +276,16 @@ class Options
     private $pdflibLicense = "";
 
     /**
+     * HTTP context created with stream_context_create()
+     * Will be used for file_get_contents
+     *
+     * @link https://www.php.net/manual/context.php
+     *
+     * @var resource
+     */
+    private $httpContext;
+
+    /**
      * @param array $attributes
      */
     public function __construct(array $attributes = null)
@@ -356,6 +366,8 @@ class Options
                 $this->setPdfBackend($value);
             } elseif ($key === 'pdflibLicense' || $key === 'pdflib_license') {
                 $this->setPdflibLicense($value);
+            } elseif ($key === 'httpContext' || $key === 'http_context') {
+                $this->setHttpContext($value);
             }
         }
         return $this;
@@ -419,6 +431,8 @@ class Options
             return $this->getPdfBackend();
         } elseif ($key === 'pdflibLicense' || $key === 'pdflib_license') {
             return $this->getPdflibLicense();
+        } elseif ($key === 'httpContext' || $key === 'http_context') {
+            return $this->getHttpContext();
         }
         return null;
     }
@@ -955,5 +969,27 @@ class Options
     public function getRootDir()
     {
         return $this->rootDir;
+    }
+
+    /**
+     * Sets the HTTP context
+     *
+     * @param resource|array $httpContext
+     * @return $this
+     */
+    public function setHttpContext($httpContext)
+    {
+        $this->httpContext = is_array($httpContext) ? stream_context_create($httpContext) : $httpContext;
+        return $this;
+    }
+
+    /**
+     * Returns the HTTP context
+     *
+     * @return resource
+     */
+    public function getHttpContext()
+    {
+        return $this->httpContext;
     }
 }

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -49,6 +49,10 @@ class DompdfTest extends TestCase
         $this->assertInstanceOf(Options::class, $dompdf->getOptions());
         $this->assertEquals('test3', $dompdf->getProtocol());
         $this->assertInstanceOf(FrameTree::class, $dompdf->getTree());
+
+        $dompdf = new Dompdf();
+        $dompdf->setHttpContext(['ssl' => ['verify_peer' => false]]);
+        $this->assertIsResource($dompdf->getHttpContext());
     }
 
     public function testLoadHtml()

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -64,7 +64,8 @@ class OptionsTest extends TestCase
             'debugLayoutLines' => false,
             'debugLayoutBlocks' => false,
             'debugLayoutInline' => false,
-            'debugLayoutPaddingBox' => false
+            'debugLayoutPaddingBox' => false,
+            'httpContext' => ['ssl' => ['verify_peer' => false]],
         ]);
         $this->assertEquals('test1', $option->getTempDir());
         $this->assertEquals('test2', $option->getFontDir());
@@ -89,6 +90,7 @@ class OptionsTest extends TestCase
         $this->assertFalse($option->getDebugLayoutBlocks());
         $this->assertFalse($option->getDebugLayoutInline());
         $this->assertFalse($option->getDebugLayoutPaddingBox());
+        $this->assertIsResource($option->getHttpContext());
 
         $option->setChroot(['test11']);
         $this->assertEquals(['test11'], $option->getChroot());


### PR DESCRIPTION
- Move `httpContext` from `Dompdf.php` to `Options.php` with the same functionality
- Support `array` on `setHttpContext()`(useful in laravel when using cache and arrays need to be serialized)

Now is posible to do:
```php
$options = new Options(['http_context' =>['ssl' => ['verify_peer'=>false]]]);
// or
$options = new Options();
$option->setHttpContext(['ssl' => ['verify_peer'=>false]]);
// or
$dompdf = new Dompdf();
$dompdf->setHttpContext(['ssl' => ['verify_peer'=>false]]);
```
Closes #2682

----
**Links:**
- https://www.php.net/manual/en/function.stream-context-create.php
- https://www.php.net/manual/en/context.php
- https://www.php.net/manual/en/context.ssl.php