### PR TITLE
Keep list-style-type's single character case

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1055,7 +1055,7 @@ class Style
             return;
         }
 
-        if ($prop !== "content" && is_string($val) && mb_strpos($val, "url") === false) {
+        if ($prop !== "content" && is_string($val) && mb_strpos($val, "url") === false && !($prop == 'list_style_type' && strlen($val) == 1)) {
             $val = mb_strtolower(trim(str_replace(["\n", "\t"], [" "], $val)));
             $val = preg_replace("/([0-9]+) (pt|px|pc|rem|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
         }

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1055,7 +1055,7 @@ class Style
             return;
         }
 
-        if ($prop !== "content" && is_string($val) && mb_strpos($val, "url") === false && !($prop == 'list_style_type' && strlen($val) == 1)) {
+        if ($prop !== "content" && is_string($val) && mb_strpos($val, "url") === false && strlen($val) > 1) {
             $val = mb_strtolower(trim(str_replace(["\n", "\t"], [" "], $val)));
             $val = preg_replace("/([0-9]+) (pt|px|pc|rem|em|ex|in|cm|mm|%)/S", "\\1\\2", $val);
         }

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -160,4 +160,25 @@ class StyleTest extends TestCase
         $style->set_prop("content", $value);
         $this->assertSame($expected, $style->content);
     }
+
+    public function valueCaseProvider(): array
+    {
+        return [
+            ["width", "Auto",           "width", "auto"],
+            ["list-style-type", "A",    "list_style_type", "A"],
+        ];
+    }
+
+    /**
+     * @dataProvider valueCaseProvider
+     */
+    public function testValueCase(string $cssProp, string $inputValue, string $phpProp, string $expectValue): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop($cssProp, $inputValue);
+        $this->assertSame($expectValue, $style->$phpProp);
+    }
 }


### PR DESCRIPTION
Currently `<ol type="A">` will be saved with `list_style_type` = `a` instead of `A`, because of the `mb_strtolower` in `set_prop`.

The workaround is very easy: use `upper-alpha` instead of `A`. But still. `type="A"` is valid HTML.