### PR TITLE
Avoid using `inherit` as computed value

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1313,12 +1313,14 @@ class Style
             self::$_methods_cache[$method] = method_exists($this, $method);
         }
 
-        // During style merge, let `inherit` compute to `inherit`, because the
-        // parent style is not available yet. The keyword is resolved during
-        // inheritance
+        // During style merge, the parent style is not available yet, so
+        // temporarily use the initial value for `inherit` properties. The
+        // keyword is properly resolved during inheritance
         if ($val === "inherit") {
-            $this->_props_computed[$prop] = $val;
-        } elseif (self::$_methods_cache[$method]) {
+            $val = self::$_defaults[$prop];
+        }
+
+        if (self::$_methods_cache[$method]) {
             $this->$method($val);
         } elseif ($val !== "") {
             $this->_props_computed[$prop] = $val;


### PR DESCRIPTION
Use the initial value as fallback until inheritance is done.

Fixes #2818
Alternative to #2814