### PR TITLE
Fix crash in inline reflower when child reflow moves all children

### DIFF
--- a/src/FrameReflower/Inline.php
+++ b/src/FrameReflower/Inline.php
@@ -165,6 +165,10 @@ class Inline extends AbstractFrameReflower
             }
         }
 
+        if (!$frame->get_first_child()) {
+            return;
+        }
+
         // Assume the position of the first child
         [$x, $y] = $frame->get_first_child()->get_position();
         $frame->set_position($x, $y);


### PR DESCRIPTION
The fix in #2822 catered for cases where the frame itself is moved and reset. When a page break occurs before the first child, which can happen when an inline frame contains a block frame, the frame is left empty after child reflow. Make sure to not crash in that case.

The frame is left without position, but as empty inline frames are not drawn currently, this should be fine for now.

Fixes #2763