### PR TITLE
Extend percentage-width case for determining image min/max width

### DIFF
--- a/src/FrameReflower/Image.php
+++ b/src/FrameReflower/Image.php
@@ -69,7 +69,9 @@ class Image extends AbstractFrameReflower
         [$width] = $this->calculate_size(null, null);
         $min_width = $this->resolve_min_width(null);
         $percent_width = Helpers::is_percent($style->width)
-            || Helpers::is_percent($style->max_width);
+            || Helpers::is_percent($style->max_width)
+            || ($style->width === "auto"
+                && (Helpers::is_percent($style->height) || Helpers::is_percent($style->max_height)));
 
         // Use the specified min width as minimum when width or max width depend
         // on the containing block and cannot be resolved yet. This mimics


### PR DESCRIPTION
An `auto` width with percentage height results in the image width depending on the containing block as well.

Improves #2846 slightly