### PR TITLE
Add support for deprecated `word-break` property value `break-word`

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -581,6 +581,7 @@ class Style
             $d["white_space"] = "normal";
             $d["widows"] = "2";
             $d["width"] = "auto";
+            $d["word_break"] = "normal";
             $d["word_spacing"] = "normal";
             $d["z_index"] = "auto";
 
@@ -642,6 +643,7 @@ class Style
                 "volume",
                 "white_space",
                 "widows",
+                "word_break",
                 "word_spacing",
             ];
 
@@ -1079,6 +1081,13 @@ class Style
                 }
             }
         } else {
+            // Legacy support for `word-break: break-word`
+            // https://www.w3.org/TR/css-text-3/#valdef-word-break-break-word
+            if ($prop === "word_break" && $val === "break-word") {
+                $val = "normal";
+                $this->set_prop("overflow_wrap", "anywhere", $important, $clear_dependencies);
+            }
+
             // `!important` declarations take precedence over normal ones
             if (!$important && isset($this->_important_props[$prop])) {
                 return;

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -181,4 +181,17 @@ class StyleTest extends TestCase
         $style->set_prop($cssProp, $inputValue);
         $this->assertSame($expectValue, $style->$phpProp);
     }
+
+    public function testWordBreakBreakWord(): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop("overflow_wrap", "break-word");
+        $style->set_prop("word_break", "break-word");
+        
+        $this->assertSame("normal", $style->word_break);
+        $this->assertSame("anywhere", $style->overflow_wrap);
+    }
 }


### PR DESCRIPTION
For compatibility with legacy content, treat

```css
word-break: break-word;
```

as

```css
word-break: normal;
overflow-wrap: anywhere;
```

Note that the regular `word-break` property is not supported.

https://www.w3.org/TR/css-text-3/#valdef-word-break-break-word