### PR TITLE
Replace string-interpolation syntax deprecated with PHP 8.2

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2829,12 +2829,12 @@ class Style
 
         foreach ($components as $val) {
             if (in_array($val, self::$BORDER_STYLES, true)) {
-                $this->set_prop("border_${side}_style", $val, $important);
+                $this->set_prop("border_{$side}_style", $val, $important);
             } elseif ($this->is_color_value($val)) {
-                $this->set_prop("border_${side}_color", $val, $important);
+                $this->set_prop("border_{$side}_color", $val, $important);
             } else {
                 // Assume width
-                $this->set_prop("border_${side}_width", $val, $important);
+                $this->set_prop("border_{$side}_width", $val, $important);
             }
         }
     }

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -577,7 +577,7 @@ class Stylesheet
                     // class=".* $tok .*" and class=".* $tok"
 
                     // This doesn't work because libxml only supports XPath 1.0...
-                    //$query .= "[matches(@$attr,\"^${tok}\$|^${tok}[ ]+|[ ]+${tok}\$|[ ]+${tok}[ ]+\")]";
+                    //$query .= "[matches(@$attr,\"^{$tok}\$|^{$tok}[ ]+|[ ]+{$tok}\$|[ ]+{$tok}[ ]+\")]";
 
                     $query .= "[contains(concat(' ', normalize-space(@$attr), ' '), concat(' ', '$tok', ' '))]";
                     $tok = "";


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation