### PR TITLE
Clean up `page_script` handling

### DIFF
--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -721,7 +721,6 @@ class GD implements Canvas
      * @param int $w width (in pixels)
      * @param int $h height (in pixels)
      * @param string $resolution
-     * @return void
      *
      * @throws \Exception
      * @internal param string $img_type the type (e.g. extension) of the image
@@ -773,8 +772,6 @@ class GD implements Canvas
      * @param float $word_spacing word spacing adjustment
      * @param float $char_spacing
      * @param float $angle Text angle
-     *
-     * @return void
      */
     public function text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_spacing = 0.0, $char_spacing = 0.0, $angle = 0.0)
     {
@@ -985,7 +982,7 @@ class GD implements Canvas
         // N/A
     }
 
-    public function page_script($callback)
+    public function page_script($callback): void
     {
         // N/A
     }
@@ -995,7 +992,7 @@ class GD implements Canvas
         // N/A
     }
 
-    public function page_line()
+    public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = [])
     {
         // N/A
     }

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -131,21 +131,21 @@ interface Canvas
     function clipping_end();
 
     /**
-     * Processes a callback on every page
+     * Processes a callback on every page.
      *
-     * The callback function receives the four parameters `$pageNumber`,
-     * `$pageCount`, `$pdf`, and `$fontMetrics`, in that order.
+     * The callback function receives the four parameters `int $pageNumber`,
+     * `int $pageCount`, `Canvas $canvas`, and `FontMetrics $fontMetrics`, in
+     * that order.
      *
      * This function can be used to add page numbers to all pages after the
      * first one, for example.
      *
      * @param callable $callback The callback function to process on every page
-     * @todo Enable with next major release
      */
-    //public function page_script(callable $callback): void;
+    public function page_script($callback): void;
 
     /**
-     * Writes text at the specified x and y coordinates on every page
+     * Writes text at the specified x and y coordinates on every page.
      *
      * The strings '{PAGE_NUM}' and '{PAGE_COUNT}' are automatically replaced
      * with their current values.
@@ -165,7 +165,7 @@ interface Canvas
     public function page_text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0);
 
     /**
-     * Draw line at the specified coordinates on every page.
+     * Draws a line at the specified coordinates on every page.
      *
      * See {@link Style::munge_color()} for the format of the color array.
      *
@@ -176,9 +176,8 @@ interface Canvas
      * @param array $color
      * @param float $width
      * @param array $style optional
-     * @todo Enable with next major release
      */
-    //public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = []);
+    public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = []);
 
     /**
      * Save current state

--- a/tests/Canvas/CPDFTest.php
+++ b/tests/Canvas/CPDFTest.php
@@ -5,7 +5,6 @@ use Dompdf\Adapter\CPDF;
 use Dompdf\Canvas;
 use Dompdf\Dompdf;
 use Dompdf\FontMetrics;
-use Dompdf\Options;
 use Dompdf\Tests\TestCase;
 
 class CPDFTest extends TestCase
@@ -15,10 +14,7 @@ class CPDFTest extends TestCase
         global $called;
         $called = 0;
 
-        $options = new Options();
-        $options->setIsPhpEnabled(true);
-        $dompdf = new Dompdf($options);
-
+        $dompdf = new Dompdf();
         $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
         $canvas->new_page();
 


### PR DESCRIPTION
* Add the `page_script` and `page_line` methods to the `Canvas`interface
* Deprecate passing a script as string for the CPDF and PDFLib back ends
* Refactor handling of `page_script` and related methods. Use a simple list of callback methods to process on every page instead a custom format