### PR TITLE
Clearer property name for split-off frames

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -162,13 +162,6 @@ class Frame
     public $_float_next_line = false;
 
     /**
-     * Whether the frame is a split-off frame
-     *
-     * @var bool
-     */
-    public $_splitted;
-
-    /**
      * @var int
      */
     public static $_ws_state = self::WS_SPACE;

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -108,6 +108,13 @@ abstract class AbstractFrameDecorator extends Frame
     public $is_split = false;
 
     /**
+     * Whether the frame is a split-off frame
+     *
+     * @var bool
+     */
+    public $is_split_off = false;
+
+    /**
      * Class constructor
      *
      * @param Frame $frame   The decoration target
@@ -700,7 +707,7 @@ abstract class AbstractFrameDecorator extends Frame
 
         $split->set_style(clone $split_style);
         $this->is_split = true;
-        $split->_splitted = true;
+        $split->is_split_off = true;
         $split->_already_pushed = true;
 
         $this->get_parent()->insert_child_after($split, $this);

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -139,7 +139,7 @@ class ListBullet extends AbstractRenderer
         $this->_set_opacity($frame->get_opacity($style->opacity));
 
         // Don't render bullets twice if the list item was split
-        if ($li->_splitted) {
+        if ($li->is_split_off) {
             return;
         }
 


### PR DESCRIPTION
Followup to #2569, where the renaming was omitted due to backwards compatibility.