### PR TITLE
Use `HTML5` to save HTML instead of `DOMDocument`

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -508,7 +508,7 @@ class Dompdf
             // see Masterminds/html5-php#166
             $doc = new DOMDocument("1.0", $encoding);
             $doc->preserveWhiteSpace = true;
-            $doc->loadHtml($dom->saveHtml(), LIBXML_NOWARNING | LIBXML_NOERROR);
+            $doc->loadHTML($html5->saveHTML($dom), LIBXML_NOWARNING | LIBXML_NOERROR);
 
             $this->loadDOM($doc, $quirksmode);
         } finally {


### PR DESCRIPTION
`DOMDocument::saveHTML()` aggressively encodes entities and paths. It also incorrectly encodes characters in embedded CSS.

See https://github.com/dompdf/dompdf/pull/2859#issuecomment-1129120544