### PR TITLE
Improve declaration of `add_info` method

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5471,12 +5471,12 @@ EOT;
     }
 
     /**
-     * add content to the documents info object
+     * Add content to the documents info object
      *
-     * @param $label
-     * @param int $value
+     * @param string|array $label
+     * @param string       $value
      */
-    function addInfo($label, $value = 0)
+    public function addInfo($label, string $value = ""): void
     {
         // this will only work if the label is one of the valid ones.
         // modify this so that arrays can be passed as well.
@@ -5484,7 +5484,7 @@ EOT;
         // else assume that they are both scalar, anything else will probably error
         if (is_array($label)) {
             foreach ($label as $l => $v) {
-                $this->o_info($this->infoObject, $l, $v);
+                $this->o_info($this->infoObject, $l, (string) $v);
             }
         } else {
             $this->o_info($this->infoObject, $label, $value);

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -232,13 +232,7 @@ class CPDF implements Canvas
         return $this->_pdf;
     }
 
-    /**
-     * Add meta information to the PDF
-     *
-     * @param string $label label of the value (Creator, Producer, etc.)
-     * @param string $value the text to set
-     */
-    public function add_info($label, $value)
+    public function add_info(string $label, string $value): void
     {
         $this->_pdf->addInfo($label, $value);
     }

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -826,13 +826,7 @@ class GD implements Canvas
         // Not implemented
     }
 
-    /**
-     * Add meta information to the PDF
-     *
-     * @param string $label label of the value (Creator, Producer, etc.)
-     * @param string $value the text to set
-     */
-    public function add_info($label, $value)
+    public function add_info(string $label, string $value): void
     {
         // N/A
     }

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -314,13 +314,7 @@ class PDFLib implements Canvas
         return $this->_pdf;
     }
 
-    /**
-     * Add meta information to the PDF
-     *
-     * @param string $label label of the value (Creator, Producter, etc.)
-     * @param string $value the text to set
-     */
-    public function add_info($label, $value)
+    public function add_info(string $label, string $value): void
     {
         $this->_pdf->set_info($label, $value);
     }

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -348,12 +348,12 @@ interface Canvas
     function add_link($url, $x, $y, $width, $height);
 
     /**
-     * Add meta information to the pdf
+     * Add meta information to the PDF.
      *
-     * @param string $name Label of the value (Creator, Producer, etc.)
+     * @param string $label Label of the value (Creator, Producer, etc.)
      * @param string $value The text to set
      */
-    function add_info($name, $value);
+    public function add_info(string $label, string $value): void;
 
     /**
      * Calculates text size, in points

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -821,17 +821,6 @@ class Dompdf
     }
 
     /**
-     * Add meta information to the PDF after rendering
-     */
-    public function add_info($label, $value)
-    {
-        $canvas = $this->getCanvas();
-        if (!is_null($canvas)) {
-            $canvas->add_info($label, $value);
-        }
-    }
-
-    /**
      * Writes the output buffer in the log file
      *
      * @param string $logOutputFile
@@ -855,6 +844,30 @@ class Dompdf
         ob_clean();
 
         file_put_contents($logOutputFile, $out);
+    }
+
+    /**
+     * Add meta information to the PDF after rendering.
+     *
+     * @deprecated
+     */
+    public function add_info($label, $value)
+    {
+        $this->addInfo($label, $value);
+    }
+
+    /**
+     * Add meta information to the PDF after rendering.
+     *
+     * @param string $label Label of the value (Creator, Producer, etc.)
+     * @param string $value The text to set
+     */
+    public function addInfo(string $label, string $value): void
+    {
+        $canvas = $this->getCanvas();
+        if (!is_null($canvas)) {
+            $canvas->add_info($label, $value);
+        }
     }
 
     /**


### PR DESCRIPTION
* Make sure the passed value is string, so that `Cpdf` does not error.
* Add a camel-cased version of the method to the `Dompdf` class and deprecate the existing one.

Fixes #2057