### PR TITLE
Suggestions for callback handling

### DIFF
--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -184,13 +184,6 @@ class PDFLib implements Canvas
     protected $_page_count;
 
     /**
-     * Callbacks to process on every page after rendering is complete
-     *
-     * @var callable[]
-     */
-    protected $pageCallbacks;
-
-    /**
      * Array of pages for accessing after rendering is initially complete
      *
      * @var array
@@ -264,7 +257,6 @@ class PDFLib implements Canvas
         $this->_pdf->begin_page_ext($this->_width, $this->_height, "");
 
         $this->_page_number = $this->_page_count = 1;
-        $this->pageCallbacks = [];
 
         $this->_imgs = [];
         $this->_fonts = [];
@@ -1214,37 +1206,37 @@ class PDFLib implements Canvas
     public function page_script($callback): void
     {
         if (is_string($callback)) {
-            $this->pageCallbacks[] = function (
+            $this->processPageScript(function (
                 int $PAGE_NUM,
                 int $PAGE_COUNT,
                 self $pdf,
                 FontMetrics $fontMetrics
             ) use ($callback) {
                 eval($callback);
-            };
+            });
             return;
         }
 
-        $this->pageCallbacks[] = $callback;
+        $this->processPageScript($callback);
     }
 
     public function page_text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0)
     {
-        $this->pageCallbacks[] = function (int $pageNumber, int $pageCount) use ($x, $y, $text, $font, $size, $color, $word_space, $char_space, $angle) {
+        $this->processPageScript(function (int $pageNumber, int $pageCount) use ($x, $y, $text, $font, $size, $color, $word_space, $char_space, $angle) {
             $text = str_replace(
                 ["{PAGE_NUM}", "{PAGE_COUNT}"],
                 [$pageNumber, $pageCount],
                 $text
             );
             $this->text($x, $y, $text, $font, $size, $color, $word_space, $char_space, $angle);
-        };
+        });
     }
 
     public function page_line($x1, $y1, $x2, $y2, $color, $width, $style = [])
     {
-        $this->pageCallbacks[] = function () use ($x1, $y1, $x2, $y2, $color, $width, $style) {
+        $this->processPageScript(function () use ($x1, $y1, $x2, $y2, $color, $width, $style) {
             $this->line($x1, $y1, $x2, $y2, $color, $width, $style);
-        };
+        });
     }
 
     public function new_page()
@@ -1257,21 +1249,15 @@ class PDFLib implements Canvas
         $this->_page_number = ++$this->_page_count;
     }
 
-    protected function processPageCallbacks(): void
+    protected function processPageScript(callable $callback): void
     {
-        if (empty($this->pageCallbacks)) {
-            return;
-        }
-
         $this->_pdf->suspend_page("");
 
         for ($p = 1; $p <= $this->_page_count; $p++) {
             $this->_pdf->resume_page("pagenumber=$p");
 
-            foreach ($this->pageCallbacks as $callback) {
-                $fontMetrics = $this->_dompdf->getFontMetrics();
-                $callback($p, $this->_page_count, $this, $fontMetrics);
-            }
+            $fontMetrics = $this->_dompdf->getFontMetrics();
+            $callback($p, $this->_page_count, $this, $fontMetrics);
 
             $this->_pdf->suspend_page("");
         }
@@ -1294,8 +1280,6 @@ class PDFLib implements Canvas
         if (!isset($options["Attachment"])) {
             $options["Attachment"] = true;
         }
-
-        $this->processPageCallbacks();
 
         if ($options["compress"]) {
             $this->setPDFLibValue("compress", 6);
@@ -1356,8 +1340,6 @@ class PDFLib implements Canvas
         if (!isset($options["compress"])) {
             $options["compress"] = true;
         }
-
-        $this->processPageCallbacks();
 
         if ($options["compress"]) {
             $this->setPDFLibValue("compress", 6);

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -1390,11 +1390,10 @@ class Dompdf
      * * `end_page_render`: called after page rendering is complete
      * * `end_document`: called for every page after rendering is complete
      *
-     * The function `f` receives an array as argument, which contains info
-     * about the event (`[0 => Canvas, 1 => Frame, "canvas" => Canvas,
-     * "frame" => Frame]`). For the `end_document` event, the function receives
-     * four arguments `int $pageNumber`, `int $pageCount`, `Canvas $canvas`, and
-     * `FontMetrics $fontMetrics` instead.
+     * The function `f` receives three arguments `Frame $frame`, `Canvas $canvas`,
+     * and `FontMetrics $fontMetrics` for all events but `end_document`. For
+     * `end_document`, the function receives four arguments `int $pageNumber`,
+     * `int $pageCount`, `Canvas $canvas`, and `FontMetrics $fontMetrics` instead.
      *
      * @param array $callbacks The set of callbacks to set.
      * @return $this

--- a/src/FrameReflower/Page.php
+++ b/src/FrameReflower/Page.php
@@ -181,20 +181,18 @@ class Page extends AbstractFrameReflower
     protected function _check_callbacks(string $event, Frame $frame): void
     {
         if (!isset($this->_callbacks)) {
-            $dompdf = $this->_frame->get_dompdf();
+            $dompdf = $this->get_dompdf();
             $this->_callbacks = $dompdf->getCallbacks();
             $this->_canvas = $dompdf->getCanvas();
         }
 
         if (isset($this->_callbacks[$event])) {
             $fs = $this->_callbacks[$event];
-            $info = [
-                0 => $this->_canvas, "canvas" => $this->_canvas,
-                1 => $frame,         "frame"  => $frame,
-            ];
+            $canvas = $this->_canvas;
+            $fontMetrics = $this->get_dompdf()->getFontMetrics();
 
             foreach ($fs as $f) {
-                $f($info);
+                $f($frame, $canvas, $fontMetrics);
             }
         }
     }

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -225,13 +225,11 @@ class Renderer extends AbstractRenderer
 
         if (isset($this->_callbacks[$event])) {
             $fs = $this->_callbacks[$event];
-            $info = [
-                0 => $this->_canvas, "canvas" => $this->_canvas,
-                1 => $frame,         "frame"  => $frame
-            ];
+            $canvas = $this->_canvas;
+            $fontMetrics = $this->_dompdf->getFontMetrics();
 
             foreach ($fs as $f) {
-                $f($info);
+                $f($frame, $canvas, $fontMetrics);
             }
         }
     }

--- a/tests/Canvas/CPDFTest.php
+++ b/tests/Canvas/CPDFTest.php
@@ -36,13 +36,34 @@ class CPDFTest extends TestCase
             $pdf->text(20, 0, "Page $PAGE_NUM of $PAGE_COUNT", $font, 12);
         ');
 
-        $font = $dompdf->getFontMetrics()->getFont("Helvetica");
-        $canvas->page_text(60, 40, "Page {PAGE_NUM} of {PAGE_COUNT}", $font, 12);
-        $canvas->page_line(0, 0, 200, 200, [0, 0, 0], 1);
-
         $output = $canvas->output();
 
         $this->assertNotSame("", $output);
         $this->assertSame(4, $called);
+    }
+
+    public function testPageText(): void
+    {
+        $dompdf = new Dompdf();
+        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas->new_page();
+
+        $font = $dompdf->getFontMetrics()->getFont("Helvetica");
+        $canvas->page_text(60, 40, "Page {PAGE_NUM} of {PAGE_COUNT}", $font, 12);
+
+        $output = $canvas->output();
+        $this->assertNotSame("", $output);
+    }
+
+    public function testPageLine(): void
+    {
+        $dompdf = new Dompdf();
+        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas->new_page();
+
+        $canvas->page_line(0, 0, 200, 200, [0, 0, 0], 1);
+
+        $output = $canvas->output();
+        $this->assertNotSame("", $output);
     }
 }

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -110,6 +110,30 @@ class DompdfTest extends TestCase
         $this->assertSame($numCalls, $called);
     }
 
+    public function testEndDocumentCallback(): void
+    {
+        $called = 0;
+
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "end_document",
+                "f" => function ($pageNumber, $pageCount, $canvas, $fontMetrics) use (&$called) {
+                    $called++;
+                    $this->assertSame($called, $pageNumber);
+                    $this->assertSame(2, $pageCount);
+                    $this->assertInstanceOf(Canvas::class, $canvas);
+                    $this->assertInstanceOf(FontMetrics::class, $fontMetrics);
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml("<html><body><p>Page 1</p><p style='page-break-before: always;'>Page 2</p></body></html>");
+        $dompdf->render();
+
+        $this->assertSame(2, $called);
+    }
+
     public function customCanvasProvider(): array
     {
         return [

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -3,8 +3,11 @@ namespace Dompdf\Tests;
 
 use DOMDocument;
 use Dompdf\Adapter\CPDF;
+use Dompdf\Canvas;
 use Dompdf\Css\Stylesheet;
 use Dompdf\Dompdf;
+use Dompdf\FontMetrics;
+use Dompdf\Frame;
 use Dompdf\Frame\FrameTree;
 use Dompdf\Options;
 use Dompdf\Tests\TestCase;
@@ -96,9 +99,10 @@ class DompdfTest extends TestCase
         $dompdf->setCallbacks([
             [
                 "event" => $event,
-                "f" => function ($infos) use (&$called) {
-                    $this->assertIsArray($infos);
-                    $this->assertCount(4, $infos);
+                "f" => function ($frame, $canvas, $fontMetrics) use (&$called) {
+                    $this->assertInstanceOf(Frame::class, $frame);
+                    $this->assertInstanceOf(Canvas::class, $canvas);
+                    $this->assertInstanceOf(FontMetrics::class, $fontMetrics);
                     $called++;
                 }
             ]
@@ -184,8 +188,7 @@ class DompdfTest extends TestCase
         // will dispose of it before dompdf->render finishes
         $dompdf->setCallbacks(['test' => [
             'event' => 'end_page_render',
-            'f' => function($params) use (&$text_frame_contents) {
-                $frame = $params["frame"];
+            'f' => function (Frame $frame) use (&$text_frame_contents) {
                 foreach ($frame->get_children() as $child) {
                     foreach ($child->get_children() as $grandchild) {
                         $text_frame_contents[] = $grandchild->get_text();

--- a/tests/LayoutTest/ImageTest.php
+++ b/tests/LayoutTest/ImageTest.php
@@ -187,10 +187,7 @@ HTML
         $dompdf->setCallbacks([
             [
                 "event" => "begin_frame",
-                "f" => function ($info) use (&$width, &$height) {
-                    /** @var AbstractFrameDecorator */
-                    $frame = $info["frame"];
-
+                "f" => function (AbstractFrameDecorator $frame) use (&$width, &$height) {
                     if ($frame->get_node()->nodeName === "img") {
                         [, , $width, $height] = $frame->get_content_box();
                     }

--- a/tests/LayoutTest/PageTest.php
+++ b/tests/LayoutTest/PageTest.php
@@ -96,11 +96,7 @@ HTML
         $dompdf->setCallbacks([
             [
                 "event" => "begin_frame",
-                "f" => function ($info) use ($expectedPages, &$elementPages) {
-                    /** @var Canvas */
-                    $canvas = $info["canvas"];
-                    /** @var AbstractFrameDecorator */
-                    $frame = $info["frame"];
+                "f" => function (AbstractFrameDecorator $frame, Canvas $canvas) use ($expectedPages, &$elementPages) {
                     $node = $frame->get_node();
 
                     if (!($node instanceof DOMElement)) {


### PR DESCRIPTION
Here are 3 suggestions for improving callback handling. As number 1 and 3 would be breaking changes, the 2.0 release might be a good time to do these. Though I am not really sure whether number 3 is worth the break, as it is purely for convenience and consistency; see the adapted test cases for how it would look in practice.

### 1. Make `page_script` take effect immediately
Existing issues this aims to resolve:
* Calling `output` multiple times after render will stack up additional invocations of all `page_*` method calls.
* Calling the canvas `page_*` methods before render does not work when the canvas is replaced on render start. This happens when the default paper size and orientation do not match the document.

I think that this behavior is also easier to understand. The `page_*` methods now need to be called after render or, if used in embedded PHP code, at the end of the document.

### 2. Add an `end_document` callback event

As replacement for the old `page_script` method behavior. This allows the page script to be set up before render, while making sure that it is actually called after render (and not on output).

This should allow pretty much every basic use case to be handled with dompdf callbacks only.

### 3. Modify dompdf callback signature

Make the callbacks receive three parameters `$frame`, `$canvas`, and `$fontMetrics` instead of an info array; for ease of use and to be consistent with the `end_document` callback and `page_script`.