### PR TITLE
Various doc block cleanups for `Canvas` and `Cpdf`

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3871,11 +3871,11 @@ EOT;
     /**
      * draw a line from one set of coordinates to another
      *
-     * @param $x1
-     * @param $y1
-     * @param $x2
-     * @param $y2
-     * @param bool $stroke
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param bool  $stroke
      */
     function line($x1, $y1, $x2, $y2, $stroke = true)
     {
@@ -3889,14 +3889,14 @@ EOT;
     /**
      * draw a bezier curve based on 4 control points
      *
-     * @param $x0
-     * @param $y0
-     * @param $x1
-     * @param $y1
-     * @param $x2
-     * @param $y2
-     * @param $x3
-     * @param $y3
+     * @param float $x0
+     * @param float $y0
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param float $x3
+     * @param float $y3
      */
     function curve($x0, $y0, $x1, $y1, $x2, $y2, $x3, $y3)
     {
@@ -3910,13 +3910,13 @@ EOT;
     /**
      * draw a part of an ellipse
      *
-     * @param $x0
-     * @param $y0
-     * @param $astart
-     * @param $afinish
-     * @param $r1
-     * @param int $r2
-     * @param int $angle
+     * @param float $x0
+     * @param float $y0
+     * @param float $astart
+     * @param float $afinish
+     * @param float $r1
+     * @param float $r2
+     * @param float $angle
      * @param int $nSeg
      */
     function partEllipse($x0, $y0, $astart, $afinish, $r1, $r2 = 0, $angle = 0, $nSeg = 8)
@@ -3927,14 +3927,14 @@ EOT;
     /**
      * draw a filled ellipse
      *
-     * @param $x0
-     * @param $y0
-     * @param $r1
-     * @param int $r2
-     * @param int $angle
+     * @param float $x0
+     * @param float $y0
+     * @param float $r1
+     * @param float $r2
+     * @param float $angle
      * @param int $nSeg
-     * @param int $astart
-     * @param int $afinish
+     * @param float $astart
+     * @param float $afinish
      */
     function filledEllipse($x0, $y0, $r1, $r2 = 0, $angle = 0, $nSeg = 8, $astart = 0, $afinish = 360)
     {
@@ -3942,8 +3942,8 @@ EOT;
     }
 
     /**
-     * @param $x
-     * @param $y
+     * @param float $x
+     * @param float $y
      */
     function lineTo($x, $y)
     {
@@ -3951,8 +3951,8 @@ EOT;
     }
 
     /**
-     * @param $x
-     * @param $y
+     * @param float $x
+     * @param float $y
      */
     function moveTo($x, $y)
     {
@@ -3962,12 +3962,12 @@ EOT;
     /**
      * draw a bezier curve based on 4 control points
      *
-     * @param $x1
-     * @param $y1
-     * @param $x2
-     * @param $y2
-     * @param $x3
-     * @param $y3
+     * @param float $x1
+     * @param float $y1
+     * @param float $x2
+     * @param float $y2
+     * @param float $x3
+     * @param float $y3
      */
     function curveTo($x1, $y1, $x2, $y2, $x3, $y3)
     {
@@ -3976,6 +3976,11 @@ EOT;
 
     /**
      * draw a bezier curve based on 4 control points
+     *
+     * @param float $cpx
+     * @param float $cpy
+     * @param float $x
+     * @param float $y
      */
     function quadTo($cpx, $cpy, $x, $y)
     {
@@ -4003,18 +4008,18 @@ EOT;
      * nSeg is not allowed to be less than 2, as this will simply draw a line (and will even draw a
      * pretty crappy shape at 2, as we are approximating with bezier curves.
      *
-     * @param $x0
-     * @param $y0
-     * @param $r1
-     * @param int $r2
-     * @param int $angle
-     * @param int $nSeg
-     * @param int $astart
-     * @param int $afinish
-     * @param bool $close
-     * @param bool $fill
-     * @param bool $stroke
-     * @param bool $incomplete
+     * @param float $x0
+     * @param float $y0
+     * @param float $r1
+     * @param float $r2
+     * @param float $angle
+     * @param int   $nSeg
+     * @param float $astart
+     * @param float $afinish
+     * @param bool  $close
+     * @param bool  $fill
+     * @param bool  $stroke
+     * @param bool  $incomplete
      */
     function ellipse(
         $x0,
@@ -4128,11 +4133,11 @@ EOT;
      *   (2,1) is 2 on, 1 off, 2 on, 1 off.. etc
      * phase is a modifier on the dash pattern which is used to shift the point at which the pattern starts.
      *
-     * @param int $width
+     * @param float  $width
      * @param string $cap
      * @param string $join
-     * @param string $dash
-     * @param int $phase
+     * @param array  $dash
+     * @param int    $phase
      */
     function setLineStyle($width = 1, $cap = '', $join = '', $dash = '', $phase = 0)
     {
@@ -4166,9 +4171,9 @@ EOT;
     /**
      * draw a polygon, the syntax for this is similar to the GD polygon command
      *
-     * @param $p
-     * @param $np
-     * @param bool $f
+     * @param float[] $p
+     * @param int     $np
+     * @param bool    $f
      */
     function polygon($p, $np, $f = false)
     {
@@ -4189,10 +4194,10 @@ EOT;
      * a filled rectangle, note that it is the width and height of the rectangle which are the secondary parameters, not
      * the coordinates of the upper-right corner
      *
-     * @param $x1
-     * @param $y1
-     * @param $width
-     * @param $height
+     * @param float $x1
+     * @param float $y1
+     * @param float $width
+     * @param float $height
      */
     function filledRectangle($x1, $y1, $width, $height)
     {
@@ -4203,10 +4208,10 @@ EOT;
      * draw a rectangle, note that it is the width and height of the rectangle which are the secondary parameters, not
      * the coordinates of the upper-right corner
      *
-     * @param $x1
-     * @param $y1
-     * @param $width
-     * @param $height
+     * @param float $x1
+     * @param float $y1
+     * @param float $width
+     * @param float $height
      */
     function rectangle($x1, $y1, $width, $height)
     {
@@ -4217,10 +4222,10 @@ EOT;
      * draw a rectangle, note that it is the width and height of the rectangle which are the secondary parameters, not
      * the coordinates of the upper-right corner
      *
-     * @param $x1
-     * @param $y1
-     * @param $width
-     * @param $height
+     * @param float $x1
+     * @param float $y1
+     * @param float $width
+     * @param float $height
      */
     function rect($x1, $y1, $width, $height)
     {
@@ -4448,10 +4453,10 @@ EOT;
     /**
      * draw a clipping rectangle, all the elements added after this will be clipped
      *
-     * @param $x1
-     * @param $y1
-     * @param $width
-     * @param $height
+     * @param float $x1
+     * @param float $y1
+     * @param float $width
+     * @param float $height
      */
     function clippingRectangle($x1, $y1, $width, $height)
     {
@@ -4462,14 +4467,14 @@ EOT;
     /**
      * draw a clipping rounded rectangle, all the elements added after this will be clipped
      *
-     * @param $x1
-     * @param $y1
-     * @param $w
-     * @param $h
-     * @param $rTL
-     * @param $rTR
-     * @param $rBR
-     * @param $rBL
+     * @param float $x1
+     * @param float $y1
+     * @param float $w
+     * @param float $h
+     * @param float $rTL
+     * @param float $rTR
+     * @param float $rBR
+     * @param float $rBL
      */
     function clippingRectangleRounded($x1, $y1, $w, $h, $rTL, $rTR, $rBR, $rBL)
     {
@@ -5001,8 +5006,8 @@ EOT;
     /**
      * register text for font subsetting
      *
-     * @param $font
-     * @param $text
+     * @param string $font
+     * @param string $text
      */
     function registerText($font, $text)
     {
@@ -5022,14 +5027,14 @@ EOT;
     /**
      * add text to the document, at a specified location, size and angle on the page
      *
-     * @param $x
-     * @param $y
-     * @param $size
-     * @param $text
-     * @param int $angle
-     * @param int $wordSpaceAdjust
-     * @param int $charSpaceAdjust
-     * @param bool $smallCaps
+     * @param float  $x
+     * @param float  $y
+     * @param float  $size
+     * @param string $text
+     * @param float  $angle
+     * @param float  $wordSpaceAdjust
+     * @param float  $charSpaceAdjust
+     * @param bool   $smallCaps
      */
     function addText($x, $y, $size, $text, $angle = 0, $wordSpaceAdjust = 0, $charSpaceAdjust = 0, $smallCaps = false)
     {
@@ -5144,12 +5149,12 @@ EOT;
      *
      * @param float  $size
      * @param string $text
-     * @param float  $word_spacing
-     * @param float  $char_spacing
+     * @param float  $wordSpacing
+     * @param float  $charSpacing
      *
      * @return float
      */
-    public function getTextWidth(float $size, string $text, float $word_spacing = 0.0, float $char_spacing = 0.0): float
+    public function getTextWidth(float $size, string $text, float $wordSpacing = 0.0, float $charSpacing = 0.0): float
     {
         static $ord_cache = [];
 
@@ -5190,14 +5195,14 @@ EOT;
 
                     // add additional padding for space
                     if (isset($current_font['codeToName'][$char]) && $current_font['codeToName'][$char] === 'space') {  // Space
-                        $w += $word_spacing * $space_scale;
+                        $w += $wordSpacing * $space_scale;
                     }
                 }
             }
 
             // add additional char spacing
-            if ($char_spacing != 0) {
-                $w += $char_spacing * $space_scale * count($unicode);
+            if ($charSpacing != 0) {
+                $w += $charSpacing * $space_scale * count($unicode);
             }
 
         } else {
@@ -5225,14 +5230,14 @@ EOT;
 
                     // add additional padding for space
                     if (isset($current_font['codeToName'][$char]) && $current_font['codeToName'][$char] === 'space') {  // Space
-                        $w += $word_spacing * $space_scale;
+                        $w += $wordSpacing * $space_scale;
                     }
                 }
             }
 
             // add additional char spacing
-            if ($char_spacing != 0) {
-                $w += $char_spacing * $space_scale * $len;
+            if ($charSpacing != 0) {
+                $w += $charSpacing * $space_scale * $len;
             }
         }
 

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4172,18 +4172,18 @@ EOT;
      * draw a polygon, the syntax for this is similar to the GD polygon command
      *
      * @param float[] $p
-     * @param int     $np
-     * @param bool    $f
+     * @param bool    $fill
      */
-    function polygon($p, $np, $f = false)
+    public function polygon(array $p, bool $fill = false): void
     {
         $this->addContent(sprintf("\n%.3F %.3F m ", $p[0], $p[1]));
 
-        for ($i = 2; $i < $np * 2; $i = $i + 2) {
+        $n = count($p);
+        for ($i = 2; $i < $n; $i = $i + 2) {
             $this->addContent(sprintf("%.3F %.3F l ", $p[$i], $p[$i + 1]));
         }
 
-        if ($f) {
+        if ($fill) {
             $this->addContent(' f');
         } else {
             $this->addContent(' S');

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -678,7 +678,7 @@ class CPDF implements Canvas
             $points[$i] = $this->y($points[$i]);
         }
 
-        $this->_pdf->polygon($points, count($points) / 2, $fill);
+        $this->_pdf->polygon($points, $fill);
 
         $this->_set_fill_transparency("Normal", $this->_current_opacity);
         $this->_set_line_transparency("Normal", $this->_current_opacity);

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -206,9 +206,6 @@ class CPDF implements Canvas
         $this->_pages = [$this->_pdf->getFirstPageId()];
     }
 
-    /**
-     * @return Dompdf
-     */
     public function get_dompdf()
     {
         return $this->_dompdf;
@@ -328,37 +325,21 @@ class CPDF implements Canvas
 
     //........................................................................
 
-    /**
-     * Returns the PDF's width in points
-     * @return float
-     */
     public function get_width()
     {
         return $this->_width;
     }
 
-    /**
-     * Returns the PDF's height in points
-     * @return float
-     */
     public function get_height()
     {
         return $this->_height;
     }
 
-    /**
-     * Returns the current page number
-     * @return int
-     */
     public function get_page_number()
     {
         return $this->_page_number;
     }
 
-    /**
-     * Returns the total number of pages in the document
-     * @return int
-     */
     public function get_page_count()
     {
         return $this->_page_count;
@@ -374,11 +355,6 @@ class CPDF implements Canvas
         $this->_page_number = $num;
     }
 
-    /**
-     * Sets the page count
-     *
-     * @param int $count
-     */
     public function set_page_count($count)
     {
         $this->_page_count = $count;
@@ -388,6 +364,7 @@ class CPDF implements Canvas
      * Sets the stroke color
      *
      * See {@link Style::set_color()} for the format of the color array.
+     *
      * @param array $color
      */
     protected function _set_stroke_color($color)
@@ -402,6 +379,7 @@ class CPDF implements Canvas
      * Sets the fill colour
      *
      * See {@link Style::set_color()} for the format of the colour array.
+     *
      * @param array $color
      */
     protected function _set_fill_color($color)
@@ -422,8 +400,8 @@ class CPDF implements Canvas
      * ColorDodge, ColorBurn, HardLight, SoftLight, Difference,
      * Exclusion
      *
-     * @param string $mode the blending mode to use
-     * @param float $opacity 0.0 fully transparent, 1.0 fully opaque
+     * @param string $mode    the blending mode to use
+     * @param float  $opacity 0.0 fully transparent, 1.0 fully opaque
      */
     protected function _set_line_transparency($mode, $opacity)
     {
@@ -440,8 +418,8 @@ class CPDF implements Canvas
      * ColorDogde, ColorBurn, HardLight, SoftLight, Difference,
      * Exclusion
      *
-     * @param string $mode the blending mode to use
-     * @param float $opacity 0.0 fully transparent, 1.0 fully opaque
+     * @param string $mode    the blending mode to use
+     * @param float  $opacity 0.0 fully transparent, 1.0 fully opaque
      */
     protected function _set_fill_transparency($mode, $opacity)
     {
@@ -453,10 +431,10 @@ class CPDF implements Canvas
      *
      * @see Cpdf::setLineStyle()
      *
-     * @param float $width
+     * @param float  $width
      * @param string $cap
      * @param string $join
-     * @param array $dash
+     * @param array  $dash
      */
     protected function _set_line_style($width, $cap, $join, $dash)
     {
@@ -487,15 +465,6 @@ class CPDF implements Canvas
         return $this->_height - $y;
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $x2
-     * @param float $y2
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function line($x1, $y1, $x2, $y2, $color, $width, $style = [])
     {
         $this->_set_stroke_color($color);
@@ -506,17 +475,6 @@ class CPDF implements Canvas
         $this->_set_line_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param float $x
-     * @param float $y
-     * @param float $r1
-     * @param float $r2
-     * @param float $astart
-     * @param float $aend
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function arc($x, $y, $r1, $r2, $astart, $aend, $color, $width, $style = [])
     {
         $this->_set_stroke_color($color);
@@ -526,15 +484,6 @@ class CPDF implements Canvas
         $this->_set_line_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function rectangle($x1, $y1, $w, $h, $color, $width, $style = [])
     {
         $this->_set_stroke_color($color);
@@ -543,13 +492,6 @@ class CPDF implements Canvas
         $this->_set_line_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     */
     public function filled_rectangle($x1, $y1, $w, $h, $color)
     {
         $this->_set_fill_color($color);
@@ -557,117 +499,56 @@ class CPDF implements Canvas
         $this->_set_fill_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     */
     public function clipping_rectangle($x1, $y1, $w, $h)
     {
         $this->_pdf->clippingRectangle($x1, $this->y($y1) - $h, $w, $h);
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param float $rTL
-     * @param float $rTR
-     * @param float $rBR
-     * @param float $rBL
-     */
     public function clipping_roundrectangle($x1, $y1, $w, $h, $rTL, $rTR, $rBR, $rBL)
     {
         $this->_pdf->clippingRectangleRounded($x1, $this->y($y1) - $h, $w, $h, $rTL, $rTR, $rBR, $rBL);
     }
 
-    /**
-     *
-     */
     public function clipping_end()
     {
         $this->_pdf->clippingEnd();
     }
 
-    /**
-     *
-     */
     public function save()
     {
         $this->_pdf->saveState();
     }
 
-    /**
-     *
-     */
     public function restore()
     {
         $this->_pdf->restoreState();
     }
 
-    /**
-     * @param $angle
-     * @param $x
-     * @param $y
-     */
     public function rotate($angle, $x, $y)
     {
         $this->_pdf->rotate($angle, $x, $y);
     }
 
-    /**
-     * @param $angle_x
-     * @param $angle_y
-     * @param $x
-     * @param $y
-     */
     public function skew($angle_x, $angle_y, $x, $y)
     {
         $this->_pdf->skew($angle_x, $angle_y, $x, $y);
     }
 
-    /**
-     * @param $s_x
-     * @param $s_y
-     * @param $x
-     * @param $y
-     */
     public function scale($s_x, $s_y, $x, $y)
     {
         $this->_pdf->scale($s_x, $s_y, $x, $y);
     }
 
-    /**
-     * @param $t_x
-     * @param $t_y
-     */
     public function translate($t_x, $t_y)
     {
         $this->_pdf->translate($t_x, $t_y);
     }
 
-    /**
-     * @param $a
-     * @param $b
-     * @param $c
-     * @param $d
-     * @param $e
-     * @param $f
-     */
     public function transform($a, $b, $c, $d, $e, $f)
     {
         $this->_pdf->transform([$a, $b, $c, $d, $e, $f]);
     }
 
-    /**
-     * @param array $points
-     * @param array $color
-     * @param null $width
-     * @param array $style
-     * @param bool $fill
-     */
     public function polygon($points, $color, $width = null, $style = [], $fill = false)
     {
         $this->_set_fill_color($color);
@@ -684,16 +565,7 @@ class CPDF implements Canvas
         $this->_set_line_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param float $x
-     * @param float $y
-     * @param float $r1
-     * @param array $color
-     * @param null $width
-     * @param null $style
-     * @param bool $fill
-     */
-    public function circle($x, $y, $r1, $color, $width = null, $style = null, $fill = false)
+    public function circle($x, $y, $r, $color, $width = null, $style = null, $fill = false)
     {
         $this->_set_fill_color($color);
         $this->_set_stroke_color($color);
@@ -702,7 +574,7 @@ class CPDF implements Canvas
             $this->_set_line_style($width, "round", "round", $style);
         }
 
-        $this->_pdf->ellipse($x, $this->y($y), $r1, 0, 0, 8, 0, 360, 1, $fill);
+        $this->_pdf->ellipse($x, $this->y($y), $r, 0, 0, 8, 0, 360, 1, $fill);
 
         $this->_set_fill_transparency("Normal", $this->_current_opacity);
         $this->_set_line_transparency("Normal", $this->_current_opacity);
@@ -762,14 +634,6 @@ class CPDF implements Canvas
         return $filename;
     }
 
-    /**
-     * @param string $img
-     * @param float $x
-     * @param float $y
-     * @param int $w
-     * @param int $h
-     * @param string $resolution
-     */
     public function image($img, $x, $y, $w, $h, $resolution = "normal")
     {
         [$width, $height, $type] = Helpers::dompdf_getimagesize($img, $this->get_dompdf()->getHttpContext());
@@ -883,17 +747,6 @@ class CPDF implements Canvas
         $pdf->addFormField($ft, rand(), $x, $this->y($y) - $h, $x + $w, $this->y($y), $ff, $size, $color);
     }
 
-    /**
-     * @param float $x
-     * @param float $y
-     * @param string $text
-     * @param string $font
-     * @param float $size
-     * @param array $color
-     * @param float $word_space
-     * @param float $char_space
-     * @param float $angle
-     */
     public function text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0)
     {
         $pdf = $this->_pdf;
@@ -908,9 +761,6 @@ class CPDF implements Canvas
         $this->_set_fill_transparency("Normal", $this->_current_opacity);
     }
 
-    /**
-     * @param string $code
-     */
     public function javascript($code)
     {
         $this->_pdf->addJavascript($code);
@@ -918,25 +768,11 @@ class CPDF implements Canvas
 
     //........................................................................
 
-    /**
-     * Add a named destination (similar to <a name="foo">...</a> in html)
-     *
-     * @param string $anchorname The name of the named destination
-     */
     public function add_named_dest($anchorname)
     {
         $this->_pdf->addDestination($anchorname, "Fit");
     }
 
-    /**
-     * Add a link to the pdf
-     *
-     * @param string $url The url to link to
-     * @param float $x The x position of the link
-     * @param float $y The y position of the link
-     * @param float $width The width of the link
-     * @param float $height The height of the link
-     */
     public function add_link($url, $x, $y, $width, $height)
     {
         $y = $this->y($y) - $height;
@@ -1071,12 +907,6 @@ class CPDF implements Canvas
         }
     }
 
-    /**
-     * Streams the PDF to the client.
-     *
-     * @param string $filename The filename to present to the client.
-     * @param array $options Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
-     */
     public function stream($filename = "document.pdf", $options = [])
     {
         if (headers_sent()) {
@@ -1103,12 +933,6 @@ class CPDF implements Canvas
         flush();
     }
 
-    /**
-     * Returns the PDF as a string.
-     *
-     * @param array $options Associative array: 'compress' => 1 or 0 (default 1).
-     * @return string
-     */
     public function output($options = [])
     {
         if (!isset($options["compress"])) $options["compress"] = true;

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -185,9 +185,6 @@ class GD implements Canvas
         $this->new_page();
     }
 
-    /**
-     * @return Dompdf
-     */
     public function get_dompdf()
     {
         return $this->_dompdf;
@@ -223,21 +220,11 @@ class GD implements Canvas
         return round($this->_height / $this->_aa_factor);
     }
 
-    /**
-     * Returns the current page number
-     *
-     * @return int
-     */
     public function get_page_number()
     {
         return $this->_page_number;
     }
 
-    /**
-     * Returns the total number of pages in the document
-     *
-     * @return int
-     */
     public function get_page_count()
     {
         return $this->_page_count;
@@ -253,11 +240,6 @@ class GD implements Canvas
         $this->_page_number = $num;
     }
 
-    /**
-     * Sets the page count
-     *
-     * @param int $count
-     */
     public function set_page_count($count)
     {
         $this->_page_count = $count;
@@ -273,7 +255,7 @@ class GD implements Canvas
      * previously allocated colors in $this->_colors.
      *
      * @param array $color The new current color
-     * @return int           The allocated color
+     * @return int The allocated color
      */
     protected function _allocate_color($color)
     {
@@ -338,24 +320,8 @@ class GD implements Canvas
         return round(($length / $this->dpi * 72) / $this->_aa_factor);
     }
 
-    /**
-     * Draws a line from x1,y1 to x2,y2
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the format of the
-     * $style parameter (aka dash).
-     *
-     * @param float $x1
-     * @param float $y1
-     * @param float $x2
-     * @param float $y2
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function line($x1, $y1, $x2, $y2, $color, $width, $style = null)
     {
-
         // Scale by the AA factor and DPI
         $x1 = $this->_upscale($x1);
         $y1 = $this->_upscale($y1);
@@ -407,40 +373,13 @@ class GD implements Canvas
         imageline($this->get_image(), $x1, $y1, $x2, $y2, $c);
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $r1
-     * @param float $r2
-     * @param float $astart
-     * @param float $aend
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
-    public function arc($x1, $y1, $r1, $r2, $astart, $aend, $color, $width, $style = [])
+    public function arc($x, $y, $r1, $r2, $astart, $aend, $color, $width, $style = [])
     {
         // @todo
     }
 
-    /**
-     * Draws a rectangle at x1,y1 with width w and height h
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
-     *
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function rectangle($x1, $y1, $w, $h, $color, $width, $style = null)
     {
-
         // Scale by the AA factor and DPI
         $x1 = $this->_upscale($x1);
         $y1 = $this->_upscale($y1);
@@ -471,17 +410,6 @@ class GD implements Canvas
         imagerectangle($this->get_image(), $x1, $y1, $x1 + $w, $y1 + $h, $c);
     }
 
-    /**
-     * Draws a filled rectangle at x1,y1 with width w and height h
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     *
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     */
     public function filled_rectangle($x1, $y1, $w, $h, $color)
     {
         // Scale by the AA factor and DPI
@@ -495,14 +423,6 @@ class GD implements Canvas
         imagefilledrectangle($this->get_image(), $x1, $y1, $x1 + $w, $y1 + $h, $c);
     }
 
-    /**
-     * Starts a clipping rectangle at x1,y1 with width w and height h
-     *
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     */
     public function clipping_rectangle($x1, $y1, $w, $h)
     {
         // @todo
@@ -513,108 +433,46 @@ class GD implements Canvas
         // @todo
     }
 
-    /**
-     * Ends the last clipping shape
-     */
     public function clipping_end()
     {
         // @todo
     }
 
-    /**
-     *
-     */
     public function save()
     {
         $this->get_dompdf()->getOptions()->setDpi(72);
     }
 
-    /**
-     *
-     */
     public function restore()
     {
         $this->get_dompdf()->getOptions()->setDpi($this->dpi);
     }
 
-    /**
-     * @param $angle
-     * @param $x
-     * @param $y
-     */
     public function rotate($angle, $x, $y)
     {
         // @todo
     }
 
-    /**
-     * @param $angle_x
-     * @param $angle_y
-     * @param $x
-     * @param $y
-     */
     public function skew($angle_x, $angle_y, $x, $y)
     {
         // @todo
     }
 
-    /**
-     * @param $s_x
-     * @param $s_y
-     * @param $x
-     * @param $y
-     */
     public function scale($s_x, $s_y, $x, $y)
     {
         // @todo
     }
 
-    /**
-     * @param $t_x
-     * @param $t_y
-     */
     public function translate($t_x, $t_y)
     {
         // @todo
     }
 
-    /**
-     * @param $a
-     * @param $b
-     * @param $c
-     * @param $d
-     * @param $e
-     * @param $f
-     */
     public function transform($a, $b, $c, $d, $e, $f)
     {
         // @todo
     }
 
-    /**
-     * Draws a polygon
-     *
-     * The polygon is formed by joining all the points stored in the $points
-     * array.  $points has the following structure:
-     * <code>
-     * array(0 => x1,
-     *       1 => y1,
-     *       2 => x2,
-     *       3 => y2,
-     *       ...
-     *       );
-     * </code>
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
-     *
-     * @param array $points
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     * @param bool $fill Fills the polygon if true
-     */
     public function polygon($points, $color, $width = null, $style = null, $fill = false)
     {
 
@@ -650,21 +508,6 @@ class GD implements Canvas
         }
     }
 
-    /**
-     * Draws a circle at $x,$y with radius $r
-     *
-     * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
-     *
-     * @param float $x
-     * @param float $y
-     * @param float $r
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     * @param bool $fill Fills the circle if true
-     */
     public function circle($x, $y, $r, $color, $width = null, $style = null, $fill = false)
     {
         // Scale by the AA factor and DPI
@@ -700,22 +543,11 @@ class GD implements Canvas
     }
 
     /**
-     * Add an image to the pdf.
-     * The image is placed at the specified x and y coordinates with the
-     * given width and height.
-     *
-     * @param string $img_url the path to the image
-     * @param float $x x position
-     * @param float $y y position
-     * @param int $w width (in pixels)
-     * @param int $h height (in pixels)
-     * @param string $resolution
-     *
      * @throws \Exception
      */
-    public function image($img_url, $x, $y, $w, $h, $resolution = "normal")
+    public function image($img, $x, $y, $w, $h, $resolution = "normal")
     {
-        $img_type = Cache::detect_type($img_url, $this->get_dompdf()->getHttpContext());
+        $img_type = Cache::detect_type($img, $this->get_dompdf()->getHttpContext());
 
         if (!$img_type) {
             return;
@@ -724,11 +556,11 @@ class GD implements Canvas
         $func_name = "imagecreatefrom$img_type";
         if (!function_exists($func_name)) {
             if (!method_exists(Helpers::class, $func_name)) {
-                throw new \Exception("Function $func_name() not found.  Cannot convert $img_type image: $img_url.  Please install the image PHP extension.");
+                throw new \Exception("Function $func_name() not found.  Cannot convert $img_type image: $img.  Please install the image PHP extension.");
             }
             $func_name = [Helpers::class, $func_name];
         }
-        $src = @call_user_func($func_name, $img_url);
+        $src = @call_user_func($func_name, $img);
 
         if (!$src) {
             return; // Probably should add to $_dompdf_errors or whatever here
@@ -747,20 +579,6 @@ class GD implements Canvas
         imagecopyresampled($this->get_image(), $src, $x, $y, 0, 0, $w, $h, $img_w, $img_h);
     }
 
-    /**
-     * Writes text at the specified x and y coordinates
-     * See {@link Style::munge_color()} for the format of the color array.
-     *
-     * @param float $x
-     * @param float $y
-     * @param string $text the text to write
-     * @param string $font the font file to use
-     * @param float $size the font size, in points
-     * @param array $color
-     * @param float $word_spacing word spacing adjustment
-     * @param float $char_spacing
-     * @param float $angle Text angle
-     */
     public function text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_spacing = 0.0, $char_spacing = 0.0, $angle = 0.0)
     {
         // Scale by the AA factor and DPI
@@ -790,25 +608,11 @@ class GD implements Canvas
         // Not implemented
     }
 
-    /**
-     * Add a named destination (similar to <a name="foo">...</a> in html)
-     *
-     * @param string $anchorname The name of the named destination
-     */
     public function add_named_dest($anchorname)
     {
         // Not implemented
     }
 
-    /**
-     * Add a link to the pdf
-     *
-     * @param string $url The url to link to
-     * @param float $x The x position of the link
-     * @param float $y The y position of the link
-     * @param float $width The width of the link
-     * @param float $height The height of the link
-     */
     public function add_link($url, $x, $y, $width, $height)
     {
         // Not implemented
@@ -819,10 +623,6 @@ class GD implements Canvas
         // N/A
     }
 
-    /**
-     * @param string $view
-     * @param array $options
-     */
     public function set_default_view($view, $options = [])
     {
         // N/A
@@ -892,7 +692,8 @@ class GD implements Canvas
 
     /**
      * @param string $font
-     * @param float $size
+     * @param float  $size
+     *
      * @return float
      */
     protected function get_font_height_actual($font, $size)
@@ -960,7 +761,7 @@ class GD implements Canvas
      * Streams the image to the client.
      *
      * @param string $filename The filename to present to the client.
-     * @param array $options Associative array: 'type' => jpeg|jpg|png; 'quality' => 0 - 100 (JPEG only);
+     * @param array  $options  Associative array: 'type' => jpeg|jpg|png; 'quality' => 0 - 100 (JPEG only);
      *     'page' => Number of the page to output (defaults to the first); 'Attachment': 1 or 0 (default 1).
      */
     public function stream($filename, $options = [])

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -269,9 +269,6 @@ class PDFLib implements Canvas
         $this->_objs = [];
     }
 
-    /**
-     * @return Dompdf
-     */
     function get_dompdf()
     {
         return $this->_dompdf;
@@ -449,33 +446,21 @@ class PDFLib implements Canvas
         }
     }
 
-    /**
-     * @return float|mixed
-     */
     public function get_width()
     {
         return $this->_width;
     }
 
-    /**
-     * @return float|mixed
-     */
     public function get_height()
     {
         return $this->_height;
     }
 
-    /**
-     * @return int
-     */
     public function get_page_number()
     {
         return $this->_page_number;
     }
 
-    /**
-     * @return int
-     */
     public function get_page_count()
     {
         return $this->_page_count;
@@ -489,9 +474,6 @@ class PDFLib implements Canvas
         $this->_page_number = (int)$num;
     }
 
-    /**
-     * @param int $count
-     */
     public function set_page_count($count)
     {
         $this->_page_count = (int)$count;
@@ -501,11 +483,9 @@ class PDFLib implements Canvas
      * Sets the line style
      *
      * @param float  $width
-     * @param        $cap
+     * @param string $cap
      * @param string $join
      * @param array  $dash
-     *
-     * @return void
      */
     protected function _set_line_style($width, $cap, $join, $dash)
     {
@@ -669,8 +649,8 @@ class PDFLib implements Canvas
     /**
      * Sets the fill opacity
      *
-     * @param $opacity
-     * @param $mode
+     * @param float  $opacity
+     * @param string $mode
      */
     public function _set_fill_opacity($opacity, $mode = "Normal")
     {
@@ -682,8 +662,8 @@ class PDFLib implements Canvas
     /**
      * Sets the stroke opacity
      *
-     * @param $opacity
-     * @param $mode
+     * @param float  $opacity
+     * @param string $mode
      */
     public function _set_stroke_opacity($opacity, $mode = "Normal")
     {
@@ -853,15 +833,6 @@ class PDFLib implements Canvas
         return $this->_height - $y;
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $x2
-     * @param float $y2
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
     public function line($x1, $y1, $x2, $y2, $color, $width, $style = null)
     {
         $this->_set_line_style($width, "butt", "", $style);
@@ -877,39 +848,19 @@ class PDFLib implements Canvas
         $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $r1
-     * @param float $r2
-     * @param float $astart
-     * @param float $aend
-     * @param array $color
-     * @param float $width
-     * @param array $style
-     */
-    public function arc($x1, $y1, $r1, $r2, $astart, $aend, $color, $width, $style = [])
+    public function arc($x, $y, $r1, $r2, $astart, $aend, $color, $width, $style = [])
     {
         $this->_set_line_style($width, "butt", "", $style);
         $this->_set_stroke_color($color);
 
-        $y1 = $this->y($y1);
+        $y = $this->y($y);
 
-        $this->_pdf->arc($x1, $y1, $r1, $astart, $aend);
+        $this->_pdf->arc($x, $y, $r1, $astart, $aend);
         $this->_pdf->stroke();
 
         $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     * @param float $width
-     * @param null  $style
-     */
     public function rectangle($x1, $y1, $w, $h, $color, $width, $style = null)
     {
         $this->_set_stroke_color($color);
@@ -923,13 +874,6 @@ class PDFLib implements Canvas
         $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param array $color
-     */
     public function filled_rectangle($x1, $y1, $w, $h, $color)
     {
         $this->_set_fill_color($color);
@@ -942,12 +886,6 @@ class PDFLib implements Canvas
         $this->_set_fill_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     */
     public function clipping_rectangle($x1, $y1, $w, $h)
     {
         $this->_pdf->save();
@@ -958,16 +896,6 @@ class PDFLib implements Canvas
         $this->_pdf->clip();
     }
 
-    /**
-     * @param float $x1
-     * @param float $y1
-     * @param float $w
-     * @param float $h
-     * @param float $rTL
-     * @param float $rTR
-     * @param float $rBR
-     * @param float $rBL
-     */
     public function clipping_roundrectangle($x1, $y1, $w, $h, $rTL, $rTR, $rBR, $rBL)
     {
         if ($this->getPDFLibMajorVersion() < 9) {
@@ -1003,17 +931,11 @@ class PDFLib implements Canvas
         $this->_pdf->draw_path($path, $x1, $this->_height-$y1-$h, "clip=true");
     }
 
-    /**
-     *
-     */
     public function clipping_end()
     {
         $this->_pdf->restore();
     }
 
-    /**
-     *
-     */
     public function save()
     {
         $this->_pdf->save();
@@ -1024,11 +946,6 @@ class PDFLib implements Canvas
         $this->_pdf->restore();
     }
 
-    /**
-     * @param $angle
-     * @param $x
-     * @param $y
-     */
     public function rotate($angle, $x, $y)
     {
         $pdf = $this->_pdf;
@@ -1037,12 +954,6 @@ class PDFLib implements Canvas
         $pdf->translate(-$x, -$this->_height + $y);
     }
 
-    /**
-     * @param $angle_x
-     * @param $angle_y
-     * @param $x
-     * @param $y
-     */
     public function skew($angle_x, $angle_y, $x, $y)
     {
         $pdf = $this->_pdf;
@@ -1051,12 +962,6 @@ class PDFLib implements Canvas
         $pdf->translate(-$x, -$this->_height + $y);
     }
 
-    /**
-     * @param $s_x
-     * @param $s_y
-     * @param $x
-     * @param $y
-     */
     public function scale($s_x, $s_y, $x, $y)
     {
         $pdf = $this->_pdf;
@@ -1065,35 +970,16 @@ class PDFLib implements Canvas
         $pdf->translate(-$x, -$this->_height + $y);
     }
 
-    /**
-     * @param $t_x
-     * @param $t_y
-     */
     public function translate($t_x, $t_y)
     {
         $this->_pdf->translate($t_x, -$t_y);
     }
 
-    /**
-     * @param $a
-     * @param $b
-     * @param $c
-     * @param $d
-     * @param $e
-     * @param $f
-     */
     public function transform($a, $b, $c, $d, $e, $f)
     {
         $this->_pdf->concat($a, $b, $c, $d, $e, $f);
     }
 
-    /**
-     * @param array $points
-     * @param array $color
-     * @param null  $width
-     * @param null  $style
-     * @param bool  $fill
-     */
     public function polygon($points, $color, $width = null, $style = null, $fill = false)
     {
         $this->_set_fill_color($color);
@@ -1123,15 +1009,6 @@ class PDFLib implements Canvas
         $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param float $x
-     * @param float $y
-     * @param float $r
-     * @param array $color
-     * @param null  $width
-     * @param null  $style
-     * @param bool  $fill
-     */
     public function circle($x, $y, $r, $color, $width = null, $style = null, $fill = false)
     {
         $this->_set_fill_color($color);
@@ -1155,37 +1032,29 @@ class PDFLib implements Canvas
         $this->_set_stroke_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param string $img_url
-     * @param float  $x
-     * @param float  $y
-     * @param int    $w
-     * @param int    $h
-     * @param string $resolution
-     */
-    public function image($img_url, $x, $y, $w, $h, $resolution = "normal")
+    public function image($img, $x, $y, $w, $h, $resolution = "normal")
     {
         $w = (int)$w;
         $h = (int)$h;
 
-        $img_type = Cache::detect_type($img_url, $this->get_dompdf()->getHttpContext());
+        $img_type = Cache::detect_type($img, $this->get_dompdf()->getHttpContext());
 
-        if (!isset($this->_imgs[$img_url])) {
+        if (!isset($this->_imgs[$img])) {
             if (strtolower($img_type) === "svg") {
                 //FIXME: PDFLib loads SVG but returns error message "Function must not be called in 'page' scope"
-                $image_load_response = $this->_pdf->load_graphics($img_type, $img_url, "");
+                $image_load_response = $this->_pdf->load_graphics($img_type, $img, "");
             } else {
-                $image_load_response = $this->_pdf->load_image($img_type, $img_url, "");
+                $image_load_response = $this->_pdf->load_image($img_type, $img, "");
             }
             if ($image_load_response === 0) {
                 //TODO: should do something with the error message
                 $error = $this->_pdf->get_errmsg();
                 return;
             }
-            $this->_imgs[$img_url] = $image_load_response;
+            $this->_imgs[$img] = $image_load_response;
         }
 
-        $img = $this->_imgs[$img_url];
+        $img = $this->_imgs[$img];
 
         $y = $this->y($y) - $h;
         if (strtolower($img_type) === "svg") {
@@ -1195,17 +1064,6 @@ class PDFLib implements Canvas
         }
     }
 
-    /**
-     * @param float  $x
-     * @param float  $y
-     * @param string $text
-     * @param string $font
-     * @param float  $size
-     * @param array  $color
-     * @param int    $word_spacing
-     * @param int    $char_spacing
-     * @param int    $angle
-     */
     public function text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_spacing = 0, $char_spacing = 0, $angle = 0)
     {
         $fh = $this->_load_font($font);
@@ -1224,9 +1082,6 @@ class PDFLib implements Canvas
         $this->_set_fill_opacity($this->_current_opacity, "Normal");
     }
 
-    /**
-     * @param string $code
-     */
     public function javascript($code)
     {
         if (strlen($this->_dompdf->getOptions()->getPdflibLicense()) > 0) {
@@ -1234,25 +1089,11 @@ class PDFLib implements Canvas
         }
     }
 
-    /**
-     * Add a named destination (similar to <a name="foo">...</a> in html)
-     *
-     * @param string $anchorname The name of the named destination
-     */
     public function add_named_dest($anchorname)
     {
         $this->_pdf->add_nameddest($anchorname, "");
     }
 
-    /**
-     * Add a link to the pdf
-     *
-     * @param string $url    The url to link to
-     * @param float  $x      The x position of the link
-     * @param float  $y      The y position of the link
-     * @param float  $width  The width of the link
-     * @param float  $height The height of the link
-     */
     public function add_link($url, $x, $y, $width, $height)
     {
         $y = $this->y($y) - $height;
@@ -1394,10 +1235,6 @@ class PDFLib implements Canvas
     }
 
     /**
-     * Streams the PDF to the client.
-     *
-     * @param string $filename The filename to present to the client.
-     * @param array  $options  Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
      * @throws Exception
      */
     public function stream($filename = "document.pdf", $options = [])
@@ -1469,12 +1306,6 @@ class PDFLib implements Canvas
         flush();
     }
 
-    /**
-     * Returns the PDF as a string.
-     *
-     * @param array $options Associative array: 'compress' => 1 or 0 (default 1).
-     * @return string
-     */
     public function output($options = [])
     {
         if (!isset($options["compress"])) {

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -45,7 +45,7 @@ interface Canvas
     function get_page_number();
 
     /**
-     * Returns the total number of pages
+     * Returns the total number of pages in the document
      *
      * @return int
      */
@@ -79,8 +79,8 @@ interface Canvas
      * Draws a rectangle at x1,y1 with width w and height h
      *
      * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
+     * See {@link Cpdf::setLineStyle()} for a description of the format of the
+     * $style parameter (aka dash).
      *
      * @param float $x1
      * @param float $y1
@@ -126,8 +126,6 @@ interface Canvas
      * @param float $tr
      * @param float $br
      * @param float $bl
-     *
-     * @return
      */
     function clipping_roundrectangle($x1, $y1, $w, $h, $tl, $tr, $br, $bl);
 
@@ -209,8 +207,8 @@ interface Canvas
      *
      * @param float $angle_x
      * @param float $angle_y
-     * @param float $x Origin abscissa
-     * @param float $y Origin ordinate
+     * @param float $x       Origin abscissa
+     * @param float $y       Origin ordinate
      */
     function skew($angle_x, $angle_y, $x, $y);
 
@@ -235,13 +233,12 @@ interface Canvas
     /**
      * Transform
      *
-     * @param $a
-     * @param $b
-     * @param $c
-     * @param $d
-     * @param $e
-     * @param $f
-     * @return
+     * @param float $a
+     * @param float $b
+     * @param float $c
+     * @param float $d
+     * @param float $e
+     * @param float $f
      */
     function transform($a, $b, $c, $d, $e, $f);
 
@@ -260,14 +257,14 @@ interface Canvas
      * </code>
      *
      * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
+     * See {@link Cpdf::setLineStyle()} for a description of the format of the
+     * $style parameter (aka dash).
      *
      * @param array $points
      * @param array $color
      * @param float $width
      * @param array $style
-     * @param bool $fill Fills the polygon if true
+     * @param bool  $fill   Fills the polygon if true
      */
     function polygon($points, $color, $width = null, $style = null, $fill = false);
 
@@ -275,8 +272,8 @@ interface Canvas
      * Draws a circle at $x,$y with radius $r
      *
      * See {@link Style::munge_color()} for the format of the color array.
-     * See {@link Cpdf::setLineStyle()} for a description of the $style
-     * parameter (aka dash)
+     * See {@link Cpdf::setLineStyle()} for a description of the format of the
+     * $style parameter (aka dash).
      *
      * @param float $x
      * @param float $y
@@ -284,7 +281,7 @@ interface Canvas
      * @param array $color
      * @param float $width
      * @param array $style
-     * @param bool $fill Fills the circle if true
+     * @param bool  $fill  Fills the circle if true
      */
     function circle($x, $y, $r, $color, $width = null, $style = null, $fill = false);
 
@@ -294,26 +291,29 @@ interface Canvas
      * The image is placed at the specified x and y coordinates with the
      * given width and height.
      *
-     * @param string $img_url the path to the image
-     * @param float $x x position
-     * @param float $y y position
-     * @param int $w width (in pixels)
-     * @param int $h height (in pixels)
+     * @param string $img        the path to the image
+     * @param float  $x          x position
+     * @param float  $y          y position
+     * @param float  $w          width
+     * @param float  $h          height
      * @param string $resolution The resolution of the image
      */
-    function image($img_url, $x, $y, $w, $h, $resolution = "normal");
+    function image($img, $x, $y, $w, $h, $resolution = "normal");
 
     /**
-     * Add an arc to the PDF
-     * See {@link Style::munge_color()} for the format of the color array.
+     * Draws an arc
      *
-     * @param float $x X coordinate of the arc
-     * @param float $y Y coordinate of the arc
-     * @param float $r1 Radius 1
-     * @param float $r2 Radius 2
+     * See {@link Style::munge_color()} for the format of the color array.
+     * See {@link Cpdf::setLineStyle()} for a description of the format of the
+     * $style parameter (aka dash).
+     *
+     * @param float $x      X coordinate of the arc
+     * @param float $y      Y coordinate of the arc
+     * @param float $r1     Radius 1
+     * @param float $r2     Radius 2
      * @param float $astart Start angle in degrees
-     * @param float $aend End angle in degrees
-     * @param array $color Color
+     * @param float $aend   End angle in degrees
+     * @param array $color  Color
      * @param float $width
      * @param array $style
      */
@@ -321,17 +321,18 @@ interface Canvas
 
     /**
      * Writes text at the specified x and y coordinates
+     *
      * See {@link Style::munge_color()} for the format of the color array.
      *
-     * @param float $x
-     * @param float $y
-     * @param string $text the text to write
-     * @param string $font the font file to use
-     * @param float $size the font size, in points
-     * @param array $color
-     * @param float $word_space word spacing adjustment
-     * @param float $char_space char spacing adjustment
-     * @param float $angle angle
+     * @param float  $x
+     * @param float  $y
+     * @param string $text        the text to write
+     * @param string $font        the font file to use
+     * @param float  $size        the font size, in points
+     * @param array  $color
+     * @param float  $word_space  word spacing adjustment
+     * @param float  $char_space  char spacing adjustment
+     * @param float  $angle       angle to write the text at, measured CW starting from the x-axis
      */
     function text($x, $y, $text, $font, $size, $color = [0, 0, 0], $word_space = 0.0, $char_space = 0.0, $angle = 0.0);
 
@@ -345,11 +346,11 @@ interface Canvas
     /**
      * Add a link to the pdf
      *
-     * @param string $url The url to link to
-     * @param float $x The x position of the link
-     * @param float $y The y position of the link
-     * @param float $width The width of the link
-     * @param float $height The height of the link
+     * @param string $url    The url to link to
+     * @param float  $x      The x position of the link
+     * @param float  $y      The y position of the link
+     * @param float  $width  The width of the link
+     * @param float  $height The height of the link
      */
     function add_link($url, $x, $y, $width, $height);
 
@@ -439,17 +440,13 @@ interface Canvas
      * 'FitBH' top
      * 'FitBV' left
      * @param array $options
-     *
-     * @return void
      */
     function set_default_view($view, $options = []);
 
     /**
-     * @param string $script
-     *
-     * @return void
+     * @param string $code
      */
-    function javascript($script);
+    function javascript($code);
 
     /**
      * Starts a new page
@@ -459,10 +456,10 @@ interface Canvas
     function new_page();
 
     /**
-     * Streams the PDF directly to the browser.
+     * Streams the PDF to the client.
      *
-     * @param string $filename The filename to present to the browser.
-     * @param array $options Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
+     * @param string $filename The filename to present to the client.
+     * @param array  $options  Associative array: 'compress' => 1 or 0 (default 1); 'Attachment' => 1 or 0 (default 1).
      */
     function stream($filename, $options = []);
 
@@ -470,6 +467,7 @@ interface Canvas
      * Returns the PDF as a string.
      *
      * @param array $options Associative array: 'compress' => 1 or 0 (default 1).
+     *
      * @return string
      */
     function output($options = []);


### PR DESCRIPTION
Includes dropping the `$np` parameter from the `Cpdf::polygon` method. Similar to the GD `imagepolygon` function, where the corresponding parameter has been deprecated, the parameter is dubious and expected to be `count($p) / 2` usually. Passing more will try to access undefined array keys and passing less is essentially a built-in `array_slice`; which can easily be applied manually if needed.

https://www.php.net/manual/en/function.imagepolygon.php