### PR TITLE
Fix rendering performance with large number of nested inline elements

### DIFF
--- a/src/Renderer/Inline.php
+++ b/src/Renderer/Inline.php
@@ -95,20 +95,24 @@ class Inline extends AbstractRenderer
             }
 
             $style = $child->get_style();
-            list(, , $child_w, $child_h) = $child->get_padding_box();
+            $auto_width = $style->width === "auto";
+            $auto_height = $style->height === "auto";
+            [, , $child_w, $child_h] = $child->get_padding_box();
 
-            $child_h2 = 0.0;
+            if ($auto_width || $auto_height) {
+                [$child_w2, $child_h2] = $this->get_child_size($child, $do_debug_layout_line);
 
-            if ($style->width === "auto") {
-                list($child_w, $child_h2) = $this->get_child_size($child, $do_debug_layout_line);
-            }
-
-            if ($style->height === "auto") {
-                list(, $child_h2) = $this->get_child_size($child, $do_debug_layout_line);
+                if ($auto_width) {
+                    $child_w = $child_w2;
+                }
+    
+                if ($auto_height) {
+                    $child_h = $child_h2;
+                }
             }
 
             $w += $child_w;
-            $h = max($h, $child_h, $child_h2);
+            $h = max($h, $child_h);
 
             if ($do_debug_layout_line) {
                 $this->_debug_layout($child->get_border_box(), "blue");


### PR DESCRIPTION
The algorithm for determining the final size of inline frames had exponential complexity in the number of nested inline frames due to calling itself recursively twice for every level.

Addresses #639