### PR TITLE
Handle `null` block in reflower classes

### DIFF
--- a/src/FrameReflower/ListBullet.php
+++ b/src/FrameReflower/ListBullet.php
@@ -31,6 +31,10 @@ class ListBullet extends AbstractFrameReflower
      */
     function reflow(BlockFrameDecorator $block = null)
     {
+        if ($block === null) {
+            return;
+        }
+
         /** @var ListBulletFrameDecorator */
         $frame = $this->_frame;
         $style = $frame->get_style();

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -397,7 +397,11 @@ class Text extends AbstractFrameReflower
         $text = $this->pre_process_text($frame->get_text());
         $frame->set_text($text);
 
-        $add_line = $block !== null ? $this->layout_line($block) : null;
+        if ($block === null) {
+            return;
+        }
+
+        $add_line = $this->layout_line($block);
 
         if ($add_line === null) {
             return;
@@ -405,20 +409,18 @@ class Text extends AbstractFrameReflower
 
         $frame->position();
 
-        if ($block) {
-            $line = $block->add_frame_to_line($frame);
-            $trimmed = trim($frame->get_text());
+        $line = $block->add_frame_to_line($frame);
+        $trimmed = trim($frame->get_text());
 
-            // Split the text into words (used to determine spacing between
-            // words on justified lines)
-            if ($trimmed !== "") {
-                $words = preg_split(self::$_whitespace_pattern, $trimmed);
-                $line->wc += count($words);
-            }
+        // Split the text into words (used to determine spacing between
+        // words on justified lines)
+        if ($trimmed !== "") {
+            $words = preg_split(self::$_whitespace_pattern, $trimmed);
+            $line->wc += count($words);
+        }
 
-            if ($add_line) {
-                $block->add_line();
-            }
+        if ($add_line) {
+            $block->add_line();
         }
     }
 


### PR DESCRIPTION
Follow-up to #3006, see https://github.com/dompdf/dompdf/pull/3006#pullrequestreview-1153368957. Make sure to not throw when no block is passed to the reflow methods.