### PR TITLE
Several selector fixes

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -441,9 +441,6 @@ class Stylesheet
         // Will contain :before and :after
         $pseudo_elements = [];
 
-        // Will contain :link, etc
-        $pseudo_classes = [];
-
         // Parse the selector
         //$s = preg_split("/([ :>.#+])/", $selector, -1, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -615,7 +612,6 @@ class Stylesheet
                             $el = substr($query, $descendant_delimeter+2);
                             $query = substr($query, 0, strrpos($query, "/")) . ($isChild ? "/" : "//") . $el;
 
-                            $pseudo_classes[$tok] = true;
                             $p = $i + 1;
                             $nth = trim(mb_substr($selector, $p, strpos($selector, ")", $i) - $p));
                             $position = $last ? "(last()-position()+1)" : "position()";
@@ -647,7 +643,6 @@ class Stylesheet
                             $el = substr($query, $descendant_delimeter+2);
                             $query = substr($query, 0, strrpos($query, "/")) . ($isChild ? "/" : "//") . "*";
 
-                            $pseudo_classes[$tok] = true;
                             $p = $i + 1;
                             $nth = trim(mb_substr($selector, $p, strpos($selector, ")", $i) - $p));
                             $position = $last ? "(last()-position()+1)" : "position()";
@@ -675,7 +670,6 @@ class Stylesheet
 
                         //TODO: bit of a hack attempt at matches support, currently only matches against elements
                         case "matches":
-                            $pseudo_classes[$tok] = true;
                             $p = $i + 1;
                             $matchList = trim(mb_substr($selector, $p, strpos($selector, ")", $i) - $p));
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -762,8 +762,8 @@ class Stylesheet
 
                         case "~":
                         case "|":
-                        case "$":
                         case "^":
+                        case "$":
                         case "*":
                             $op .= $tok[$j++];
 
@@ -828,16 +828,22 @@ class Stylesheet
                             $query = rtrim($query, " or ") . "]";
                             break;
 
-                        case "$=":
-                            $query .= "[substring(@$attr, string-length(@$attr)-" . (strlen($value) - 1) . ")=\"$value\"]";
+                        case "^=":
+                            $query .= $value !== ""
+                                ? "[starts-with(@$attr,\"$value\")]"
+                                : "[false()]";
                             break;
 
-                        case "^=":
-                            $query .= "[starts-with(@$attr,\"$value\")]";
+                        case "$=":
+                            $query .= $value !== ""
+                                ? "[substring(@$attr, string-length(@$attr)-" . (strlen($value) - 1) . ")=\"$value\"]"
+                                : "[false()]";
                             break;
 
                         case "*=":
-                            $query .= "[contains(@$attr,\"$value\")]";
+                            $query .= $value !== ""
+                                ? "[contains(@$attr,\"$value\")]"
+                                : "[false()]";
                             break;
                     }
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -522,14 +522,24 @@ class Stylesheet
                     $tok = "";
                     break;
 
-                case ".":
                 case "#":
-                    // All elements matching the current token with a class/id equal to
-                    // the _next_ token.
+                    // https://www.w3.org/TR/selectors-3/#id-selectors
+                    // All elements matching the current token with id equal
+                    // to the _next_ token
 
-                    $attr = $s === "." ? "class" : "id";
+                    if (mb_substr($query, -1, 1) === "/") {
+                        $query .= "*";
+                    }
 
-                    // empty class/id == *
+                    $query .= "[@id=\"$tok\"]";
+                    $tok = "";
+                    break;
+
+                case ".":
+                    // https://www.w3.org/TR/selectors-3/#class-html
+                    // All elements matching the current token with a class
+                    // equal to the _next_ token
+
                     if (mb_substr($query, -1, 1) === "/") {
                         $query .= "*";
                     }
@@ -541,7 +551,7 @@ class Stylesheet
                     // This doesn't work because libxml only supports XPath 1.0...
                     //$query .= "[matches(@$attr,\"^{$tok}\$|^{$tok}[ ]+|[ ]+{$tok}\$|[ ]+{$tok}[ ]+\")]";
 
-                    $query .= "[contains(concat(' ', normalize-space(@$attr), ' '), concat(' ', '$tok', ' '))]";
+                    $query .= "[contains(concat(' ', normalize-space(@class), ' '), concat(' ', '$tok', ' '))]";
                     $tok = "";
                     break;
 

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -812,9 +812,9 @@ class Stylesheet
                         case "~=":
                             // FIXME: this will break if $value contains quoted strings
                             // (e.g. [type~="a b c" "d e f"])
-                            // FIXME: Don't match anything if value contains
-                            // whitespace or is the empty string
-                            $query .= "[contains(concat(' ', normalize-space(@$attr), ' '), concat(' ', '$value', ' '))]";
+                            $query .= $value !== "" && !preg_match("/\s+/", $value)
+                                ? "[contains(concat(' ', normalize-space(@$attr), ' '), concat(' ', \"$value\", ' '))]"
+                                : "[false()]";
                             break;
 
                         case "|=":


### PR DESCRIPTION
* Fix `nth-child` when combined with other conditions
* Fix handling of empty string in attribute selectors
* Fix overzealous ID selector matching

Applies on top of #3057 

Fixes #2222
Partially addresses #3056