### PR TITLE
Fixed bug where svg polylines get automatically closed

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -4220,9 +4220,9 @@ EOT;
         $this->addContent(sprintf("\n%.3F %.3F %.3F %.3F re", $x1, $y1, $width, $height));
     }
 
-    function stroke()
+    function stroke(bool $close = false)
     {
-        $this->addContent("\nS");
+        $this->addContent("\n" . ($close ? "s" : "S"));
     }
 
     function fill()
@@ -4230,9 +4230,9 @@ EOT;
         $this->addContent("\nf" . ($this->fillRule === "evenodd" ? "*" : ""));
     }
 
-    function fillStroke()
+    function fillStroke(bool $close = false)
     {
-        $this->addContent("\nb" . ($this->fillRule === "evenodd" ? "*" : ""));
+        $this->addContent("\n" . ($close ? "b" : "B") . ($this->fillRule === "evenodd" ? "*" : ""));
     }
 
     /**


### PR DESCRIPTION
This fixes:

- https://github.com/dompdf/php-svg-lib/issues/101
- https://github.com/dompdf/php-svg-lib/issues/99

The problem is that the cpdf version included in dompdf does not contain the `$close` parameter like the version included in php-svg-lib: https://github.com/dompdf/php-svg-lib/blob/master/src/Svg/Surface/CPdf.php#L4177-L4190

Before:
[before.pdf](https://github.com/dompdf/dompdf/files/10352171/before.pdf)

After:
[after.pdf](https://github.com/dompdf/dompdf/files/10352172/after.pdf)
