### PR TITLE
tinyfix Uninitialized string offset for minmax() attr

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -713,7 +713,7 @@ class Stylesheet
                         $query .= "/*";
                     }
 
-                    $attr_delimiters = ["=", "]", "~", "|", "$", "^", "*"];
+                    $attr_delimiters = ["=", "]", "~", "|", "$", "^", "*", ")"];
                     $tok_len = mb_strlen($tok);
                     $j = 0;
 


### PR DESCRIPTION
In stack laravel/vite - after bulid application assets i try use app-xxxxxxxx.css file and get error "Uninitialized string offset"
in my case - minmax() function break the PDF processing, this fix can avoid this and can use this in future for minmax aplying in package

sorry for my english