### PR TITLE
Try to create config directories if non existant

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -848,6 +848,9 @@ class Options
      */
     public function setFontCache($fontCache)
     {
+        if (!is_dir($fontCache) && !mkdir($fontCache)) {
+            trigger_error("Unable to create fontCache - a valid value should be specified.", E_USER_WARNING);
+        }
         $this->fontCache = $fontCache;
         return $this;
     }
@@ -866,6 +869,9 @@ class Options
      */
     public function setFontDir($fontDir)
     {
+        if (!is_dir($fontDir) && !mkdir($fontDir)) {
+            trigger_error("Unable to create fontDir - a valid value should be specified.", E_USER_WARNING);
+        }
         $this->fontDir = $fontDir;
         return $this;
     }
@@ -1053,6 +1059,9 @@ class Options
      */
     public function setTempDir($tempDir)
     {
+        if (!is_dir($tempDir) && !mkdir($tempDir)) {
+            trigger_error("Unable to create tempDir - a valid value should be specified.", E_USER_WARNING);
+        }
         $this->tempDir = $tempDir;
         return $this;
     }


### PR DESCRIPTION
The patch will allow dompdf to try creating tmpDir, fontDir and fontCache if they do not exist on the filesystem - and will trigger a warning if they can't be created.

Even if the Options.php file mention that pathes should exist, a number of people will set the options and won't even see that the folders weren't created.

Trying to create them by default will : 
- Avoid bugs / lack of performances when directories are created
- Will warn the user that his configurations are not suitable if necessary.

Later, it might also be possible to change the trigger_error to an exception, but right now, it would be a BC break.