### PR TITLE
Fix automatic counter reset

### DIFF
--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -805,36 +805,33 @@ abstract class AbstractFrameDecorator extends Frame
      */
     public function increment_counter(string $id = self::DEFAULT_COUNTER, int $increment = 1): void
     {
-        $counter_frame = $this->lookup_counter_frame($id);
-
-        if ($counter_frame) {
-            if (!isset($counter_frame->_counters[$id])) {
-                $counter_frame->_counters[$id] = 0;
-            }
-
-            $counter_frame->_counters[$id] += $increment;
-        }
+        $counter_frame = $this->lookup_counter_frame($id, true);
+        $counter_frame->_counters[$id] += $increment;
     }
 
     /**
      * @param string $id
+     * @param bool   $auto_reset Instantiate a new counter if none with the given name is in scope.
+     *
      * @return AbstractFrameDecorator|null
      */
-    function lookup_counter_frame($id = self::DEFAULT_COUNTER)
-    {
+    public function lookup_counter_frame(
+        string $id = self::DEFAULT_COUNTER,
+        bool $auto_reset = false
+    ): ?AbstractFrameDecorator {
         $f = $this->get_parent();
 
         while ($f) {
             if (isset($f->_counters[$id])) {
                 return $f;
             }
-            $fp = $f->get_parent();
+            $f = $f->get_parent();
+        }
 
-            if (!$fp) {
-                return $f;
-            }
-
-            $f = $fp;
+        if ($auto_reset) {
+            $f = $this->get_parent();
+            $f->_counters[$id] = 0;
+            return $f;
         }
 
         return null;
@@ -843,19 +840,15 @@ abstract class AbstractFrameDecorator extends Frame
     /**
      * @param string $id
      * @param string $type
+     *
      * @return bool|string
      *
      * TODO: What version is the best : this one or the one in ListBullet ?
      */
-    function counter_value(string $id = self::DEFAULT_COUNTER, string $type = "decimal")
+    public function counter_value(string $id = self::DEFAULT_COUNTER, string $type = "decimal")
     {
         $type = mb_strtolower($type);
-
-        if (!isset($this->_counters[$id])) {
-            $this->_counters[$id] = 0;
-        }
-
-        $value = $this->_counters[$id];
+        $value = $this->_counters[$id] ?? 0;
 
         switch ($type) {
             default:

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -623,7 +623,8 @@ abstract class AbstractFrameReflower
                     } else {
                         $type = "decimal";
                     }
-                    $p = $this->_frame->lookup_counter_frame($counter_id);
+
+                    $p = $this->_frame->lookup_counter_frame($counter_id, true);
 
                     $text .= $p->counter_value($counter_id, $type);
                 } elseif (strtolower($args[1]) === "counters") {
@@ -640,13 +641,10 @@ abstract class AbstractFrameReflower
                         $type = "decimal";
                     }
 
-                    $p = $this->_frame->lookup_counter_frame($counter_id);
+                    $p = $this->_frame->lookup_counter_frame($counter_id, true);
                     $tmp = [];
                     while ($p) {
-                        // We only want to use the counter values when they actually increment the counter
-                        if (array_key_exists($counter_id, $p->_counters)) {
-                            array_unshift($tmp, $p->counter_value($counter_id, $type));
-                        }
+                        array_unshift($tmp, $p->counter_value($counter_id, $type));
                         $p = $p->lookup_counter_frame($counter_id);
                     }
                     $text .= implode($string, $tmp);

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -128,6 +128,82 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $s->background_image);
     }
 
+    public function counterIncrementProvider(): array
+    {
+        return [
+            // Valid values
+            ["none", "none"],
+            ["c", ["c" => 1]],
+            ["c1 c2 c3", ["c1" => 1, "c2" => 1, "c3" => 1]],
+            ["c 0", ["c" => 0]],
+            ["c 1", ["c" => 1]],
+            ["c -5", ["c" => -5]],
+            ["c1 -5 c2 2", ["c1" => -5, "c2" => 2]],
+            ["c1 -5 c2", ["c1" => -5, "c2" => 1]],
+            ["c1 c2 2", ["c1" => 1, "c2" => 2]],
+
+            // Duplicate counter
+            ["c 2 c 4", ["c" => 6]],
+
+            // Invalid values
+            ["", "none"],
+            ["3", "none"],
+            ["c 3 7", "none"],
+            ["3 c 7", "none"]
+        ];
+    }
+
+    /**
+     * @dataProvider counterIncrementProvider
+     */
+    public function testCounterIncrement(string $value, $expected): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop("counter_increment", $value);
+        $this->assertSame($expected, $style->counter_increment);
+    }
+
+    public function counterResetProvider(): array
+    {
+        return [
+            // Valid values
+            ["none", "none"],
+            ["c", ["c" => 0]],
+            ["c1 c2 c3", ["c1" => 0, "c2" => 0, "c3" => 0]],
+            ["c 0", ["c" => 0]],
+            ["c 1", ["c" => 1]],
+            ["c -5", ["c" => -5]],
+            ["c1 -5 c2 2", ["c1" => -5, "c2" => 2]],
+            ["c1 -5 c2", ["c1" => -5, "c2" => 0]],
+            ["c1 c2 2", ["c1" => 0, "c2" => 2]],
+
+            // Duplicate counter
+            ["c 2 c 4", ["c" => 4]],
+
+            // Invalid values
+            ["", "none"],
+            ["3", "none"],
+            ["c 3 7", "none"],
+            ["3 c 7", "none"]
+        ];
+    }
+
+    /**
+     * @dataProvider counterResetProvider
+     */
+    public function testCounterReset(string $value, $expected): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop("counter_reset", $value);
+        $this->assertSame($expected, $style->counter_reset);
+    }
+
     public function contentProvider(): array
     {
         return [

--- a/tests/GeneratedContentTest.php
+++ b/tests/GeneratedContentTest.php
@@ -1,0 +1,361 @@
+<?php
+namespace Dompdf\Tests;
+
+use Dompdf\Dompdf;
+use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\Tests\TestCase;
+
+final class GeneratedContentTest extends TestCase
+{
+    public function countersProvider(): array
+    {
+        return [
+            // TODO: Heredocs can be nicely indented starting with PHP 7.3
+            "basic counter" => [
+                <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+span {
+    counter-increment: c;
+}
+
+span::before {
+    content: counter(c) "-";
+}
+</style>
+</head>
+<body>
+    <div><span></span><span></span><span></span></div>
+</body>
+</html>
+HTML
+,
+                [
+                    "div" => ["1-2-3-"]
+                ]
+            ],
+            "nested counters" => [
+                <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+ul {
+    counter-reset: li;
+}
+
+li {
+    counter-increment: li;
+}
+
+span::before {
+    content: counters(li, ".") " ";
+}
+</style>
+</head>
+<body>
+<ul>
+    <li><span>Item 1</span></li>
+    <li><span>Item 2</span>
+        <ul>
+            <li><span>Item 3</span></li>
+            <li><span>Item 4</span></li>
+            <li><span>Item 5</span></li>
+        </ul>
+    </li>
+    <li><span>Item 6</span></li>
+</ul>
+</body>
+</html>
+HTML
+,
+                [
+                    "span" => [
+                        "1 Item 1",
+                        "2 Item 2",
+                        "2.1 Item 3",
+                        "2.2 Item 4",
+                        "2.3 Item 5",
+                        "3 Item 6"
+                    ]
+                ]
+            ],
+            "auto reset nested" => [
+                <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+li {
+    counter-increment: c1;
+}
+
+li li {
+    counter-increment: c2;
+}
+
+span::before {
+    content: counter(c1) "|" counter(c2) " ";
+}
+</style>
+</head>
+<body>
+<ul>
+    <li><span>Item 1</span></li>
+    <li><span>Item 2</span>
+        <ul>
+            <li><span>Item 3</span></li>
+            <li><span>Item 4</span></li>
+            <li><span>Item 5</span></li>
+        </ul>
+    </li>
+    <li><span>Item 6</span>
+        <ul>
+            <li><span>Item 7</span></li>
+            <li><span>Item 8</span></li>
+        </ul>
+    </li>
+</ul>
+</body>
+</html>
+HTML
+,
+                [
+                    "span" => [
+                        "1|0 Item 1",
+                        "2|0 Item 2",
+                        "2|1 Item 3",
+                        "2|2 Item 4",
+                        "2|3 Item 5",
+                        "3|0 Item 6",
+                        "3|1 Item 7",
+                        "3|2 Item 8"
+                    ]
+                ]
+            ],
+            // Note: There have been spec changes in regards to how `counter-reset`
+            // is supposed to work in cases like the following. Firefox 82+
+            // behaves differently here, dompdf is consistent with other browsers
+            // and older Firefox versions:
+            // * https://github.com/mdn/content/issues/13293
+            // * https://github.com/w3c/csswg-drafts/issues/5477
+            "sibling reset" => [
+                <<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+body {
+    counter-reset: c;
+}
+
+li {
+    counter-increment: c;
+}
+
+li::before {
+    content: counters(c, ".") " ";
+}
+
+.reset {
+    counter-reset: c;
+}
+</style>
+</head>
+<body>
+    <ul>
+        <li>Item 1</li>
+        <li class="reset">Item 2</li>
+        <li>Item 3</li>
+        <li class="reset">Item 4</li>
+        <li>Item 5</li>
+    </ul>
+
+    <ul>
+        <li>Item 6</li>
+        <li class="reset">Item 7</li>
+        <li>Item 8</li>
+    </ul>
+</body>
+</html>
+HTML
+,
+                [
+                    "li" => [
+                        "1 Item 1",
+                        "1.1 Item 2",
+                        "1.2 Item 3",
+                        "1.1 Item 4",
+                        "1.2 Item 5",
+                        "2 Item 6",
+                        "2.1 Item 7",
+                        "2.2 Item 8"
+                    ]
+                ]
+            ],
+
+            // Tests from the CSS2.1 Conformance Test Suite
+            // http://test.csswg.org/suites/css21_dev/20110323/
+            "counters-scope-implied-000" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Implied counter scopes with no 'counter-increment' or 'counter-reset'</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  #one:before { content: counter(one) }
+  #two:before { content: counter(two) }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following should be identical:</p>
+
+ <div><span id="one"></span><span id="two"></span></div>
+ <div>00</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "00",
+                        "00"
+                    ]
+                ]
+            ],
+            "counters-scope-implied-001" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Implied counter scopes by counter use</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  .i { counter-increment: c 1; }
+  .r { counter-reset: c 0; }
+  .u:before { content: counters(c, ".") " "; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following two lines should be identical:</p>
+
+ <div><span class="u"></span><span class="r"><span class="i u"></span></span></div>
+
+ <div>0 1</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "0 1",
+                        "0 1"
+                    ]
+                ]
+            ],
+            "counters-scope-implied-002" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Implied counter scopes by 'counter-increment'</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  .i { counter-increment: c 1; }
+  .ib:before { counter-increment: c 1; content: "B" }
+  .r { counter-reset: c 0; }
+  .u:before { content: counters(c, ".") " "; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following two lines should be identical:</p>
+
+ <div><span class="ib"><span class="u"></span><span class="r"><span class="u"></span></span></span><span class="i"><span class="u"></span><span class="r"><span class="u"></span></span></span></div>
+
+ <div>B1 0 1 1.0</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "B1 0 1 1.0",
+                        "B1 0 1 1.0"
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The expected content defines the nodes to check by node name. For each
+     * name, the corresponding nodes have to match the expected text content in
+     * order before render.
+     *
+     * @dataProvider countersProvider
+     */
+    public function testCounters(
+        string $html,
+        array $expectedContent
+    ): void {
+        $content = array_fill_keys(array_keys($expectedContent), []);
+
+        // Use callback to inspect frame tree
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function (AbstractFrameDecorator $frame) use ($expectedContent, &$content) {
+                    $node = $frame->get_node();
+                    $name = $node->nodeName;
+
+                    if (isset($expectedContent[$name])) {
+                        $content[$name][] = $node->textContent;
+                    }
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml($html);
+        $dompdf->render();
+
+        $this->assertSame($expectedContent, $content);
+    }
+}


### PR DESCRIPTION
From the spec [1]:

> If 'counter-increment' or 'content' on an element or pseudo-element
> refers to a counter that is not in the scope of any 'counter-reset',
> implementations should behave as though a 'counter-reset' had reset
> the counter to 0 on that element or pseudo-element.

Test cases are included.

`auto reset nested` is a simplified version of the test from https://eclecticgeek.com/dompdf/core_tests/css_counter.html. Note, how the second and third counters were not reset properly on the last two items before there (_4|14|-15_ and _5|14|-15_ instead of _4|0|0_ and _5|0|0_).

[1] https://www.w3.org/TR/CSS21/generate.html#scope