### PR TITLE
Frame: Always clear parent cache when modifying tree

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -931,6 +931,11 @@ class Frame
         }
 
         $child->_parent = $this;
+        $decorator = $child->get_decorator();
+        // force an update to the cached parent
+        if ($decorator !== null) {
+            $decorator->get_parent(false);
+        }
         $child->_prev_sibling = null;
 
         // Handle the first child
@@ -1020,6 +1025,11 @@ class Frame
         }
 
         $new_child->_parent = $this;
+        $decorator = $new_child->get_decorator();
+        // force an update to the cached parent
+        if ($decorator !== null) {
+            $decorator->get_parent(false);
+        }
         $new_child->_next_sibling = $ref;
         $new_child->_prev_sibling = $ref->_prev_sibling;
 
@@ -1073,6 +1083,11 @@ class Frame
         }
 
         $new_child->_parent = $this;
+        $decorator = $new_child->get_decorator();
+        // force an update to the cached parent
+        if ($decorator !== null) {
+            $decorator->get_parent(false);
+        }
         $new_child->_prev_sibling = $ref;
         $new_child->_next_sibling = $ref->_next_sibling;
 


### PR DESCRIPTION
When moving an existing frame via `prepend_child`, `append_child`, `insert_child_before`, and `insert_child_after`, the parent cache of the decorator must be cleared, otherwise `get_parent()` keeps returning the old parent. This was only done in `append_child`; apply it to the other methods as well.