### PR TITLE
Improve handling of case-insensitivity during style parsing

### DIFF
--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -333,7 +333,6 @@ class PDFLib implements Canvas
      * @param int $object the ID of a previously opened object
      *
      * @throws Exception
-     * @return void
      */
     public function reopen_object($object)
     {

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -167,14 +167,14 @@ class AttributeTranslator
         'ol' => [
             'compact' => 'margin: 0.5em 0;',
             'start' => 'counter-reset: -dompdf-default-counter %d;',
-            'type' => 'list-style-type: %s;',
+            'type' => '_set_list_style_type',
         ],
         'ul' => [
             'compact' => 'margin: 0.5em 0;',
-            'type' => 'list-style-type: %s;',
+            'type' => '_set_list_style_type',
         ],
         'li' => [
-            'type' => 'list-style-type: %s;',
+            'type' => '_set_list_style_type',
             'value' => 'counter-reset: -dompdf-default-counter %d;',
         ],
         'pre' => [
@@ -648,5 +648,33 @@ class AttributeTranslator
         }
 
         return ltrim($style, "; ");
+    }
+
+    protected static function _set_list_style_type(\DOMElement $node, string $value): string
+    {
+        $v = trim($value);
+
+        switch ($v) {
+            case "1":
+                $type = "decimal";
+                break;
+            case "a":
+                $type = "lower-alpha";
+                break;
+            case "A":
+                $type = "upper-alpha";
+                break;
+            case "i":
+                $type = "lower-roman";
+                break;
+            case "I":
+                $type = "upper-roman";
+                break;
+            default:
+                $type = $v;
+                break;
+        }
+
+        return "list-style-type: $type;";
     }
 }

--- a/src/Css/Content/Attr.php
+++ b/src/Css/Content/Attr.php
@@ -1,0 +1,26 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class Attr extends ContentPart
+{
+    /**
+     * @var string
+     */
+    public $attribute;
+
+    public function __construct(string $attribute)
+    {
+        $this->attribute = $attribute;
+    }
+
+    public function equals(ContentPart $other): bool
+    {
+        return $other instanceof self
+            && $other->attribute === $this->attribute;
+    }
+
+    public function __toString(): string
+    {
+        return "attr($this->attribute)";
+    }
+}

--- a/src/Css/Content/CloseQuote.php
+++ b/src/Css/Content/CloseQuote.php
@@ -1,0 +1,10 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class CloseQuote extends ContentPart
+{
+    public function __toString(): string
+    {
+        return "close-quote";
+    }
+}

--- a/src/Css/Content/ContentPart.php
+++ b/src/Css/Content/ContentPart.php
@@ -1,0 +1,10 @@
+<?php
+namespace Dompdf\Css\Content;
+
+abstract class ContentPart
+{
+    public function equals(self $other): bool
+    {
+        return $other instanceof static;
+    }
+}

--- a/src/Css/Content/Counter.php
+++ b/src/Css/Content/Counter.php
@@ -1,0 +1,33 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class Counter extends ContentPart
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $style;
+
+    public function __construct(string $name, string $style)
+    {
+        $this->name = $name;
+        $this->style = $style;
+    }
+
+    public function equals(ContentPart $other): bool
+    {
+        return $other instanceof self
+            && $other->name === $this->name
+            && $other->style === $this->style;
+    }
+
+    public function __toString(): string
+    {
+        return "counter($this->name, $this->style)";
+    }
+}

--- a/src/Css/Content/Counters.php
+++ b/src/Css/Content/Counters.php
@@ -1,0 +1,40 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class Counters extends ContentPart
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $string;
+
+    /**
+     * @var string
+     */
+    public $style;
+
+    public function __construct(string $name, string $string, string $style)
+    {
+        $this->name = $name;
+        $this->string = $string;
+        $this->style = $style;
+    }
+
+    public function equals(ContentPart $other): bool
+    {
+        return $other instanceof self
+            && $other->name === $this->name
+            && $other->string === $this->string
+            && $other->style === $this->style;
+    }
+
+    public function __toString(): string
+    {
+        return "counters($this->name, \"$this->string\", $this->style)";
+    }
+}

--- a/src/Css/Content/NoCloseQuote.php
+++ b/src/Css/Content/NoCloseQuote.php
@@ -1,0 +1,10 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class NoCloseQuote extends ContentPart
+{
+    public function __toString(): string
+    {
+        return "no-close-quote";
+    }
+}

--- a/src/Css/Content/NoOpenQuote.php
+++ b/src/Css/Content/NoOpenQuote.php
@@ -1,0 +1,10 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class NoOpenQuote extends ContentPart
+{
+    public function __toString(): string
+    {
+        return "no-open-quote";
+    }
+}

--- a/src/Css/Content/OpenQuote.php
+++ b/src/Css/Content/OpenQuote.php
@@ -1,0 +1,10 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class OpenQuote extends ContentPart
+{
+    public function __toString(): string
+    {
+        return "open-quote";
+    }
+}

--- a/src/Css/Content/StringPart.php
+++ b/src/Css/Content/StringPart.php
@@ -1,0 +1,26 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class StringPart extends ContentPart
+{
+    /**
+     * @var string
+     */
+    public $string;
+
+    public function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+
+    public function equals(ContentPart $other): bool
+    {
+        return $other instanceof self
+            && $other->string === $this->string;
+    }
+
+    public function __toString(): string
+    {
+        return '"' . $this->string . '"';
+    }
+}

--- a/src/Css/Content/Url.php
+++ b/src/Css/Content/Url.php
@@ -1,0 +1,26 @@
+<?php
+namespace Dompdf\Css\Content;
+
+final class Url extends ContentPart
+{
+    /**
+     * @var string
+     */
+    public $url;
+
+    public function __construct(string $url)
+    {
+        $this->url = $url;
+    }
+
+    public function equals(ContentPart $other): bool
+    {
+        return $other instanceof self
+            && $other->url === $this->url;
+    }
+
+    public function __toString(): string
+    {
+        return "url($this->url)";
+    }
+}

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -858,8 +858,6 @@ class Style
 
     /**
      * Clear all non-final used values.
-     *
-     * @return void
      */
     public function reset(): void
     {

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -7,9 +7,20 @@
 namespace Dompdf\Css;
 
 use Dompdf\Adapter\CPDF;
+use Dompdf\Css\Content\Attr;
+use Dompdf\Css\Content\CloseQuote;
+use Dompdf\Css\Content\ContentPart;
+use Dompdf\Css\Content\Counter;
+use Dompdf\Css\Content\Counters;
+use Dompdf\Css\Content\NoCloseQuote;
+use Dompdf\Css\Content\NoOpenQuote;
+use Dompdf\Css\Content\OpenQuote;
+use Dompdf\Css\Content\StringPart;
+use Dompdf\Css\Content\Url;
 use Dompdf\Exception;
 use Dompdf\FontMetrics;
 use Dompdf\Frame;
+use Dompdf\Helpers;
 
 /**
  * Represents CSS properties.
@@ -39,131 +50,131 @@ use Dompdf\Frame;
  *
  * Actual CSS parsing is performed in the {@link Stylesheet} class.
  *
- * @property string          $azimuth
- * @property string          $background_attachment
- * @property array|string    $background_color
- * @property string          $background_image            Image URL or `none`
- * @property string          $background_image_resolution
- * @property array           $background_position
- * @property string          $background_repeat
- * @property array|string    $background_size             `cover`, `contain`, or `[width, height]`, each being a length, percentage, or `auto`
- * @property string          $border_collapse
- * @property string          $border_color                Only use for setting all sides to the same color
- * @property float[]         $border_spacing              Pair of `[horizontal, vertical]` spacing
- * @property string          $border_style                Only use for setting all sides to the same style
- * @property array|string    $border_top_color
- * @property array|string    $border_right_color
- * @property array|string    $border_bottom_color
- * @property array|string    $border_left_color
- * @property string          $border_top_style            Valid border style
- * @property string          $border_right_style          Valid border style
- * @property string          $border_bottom_style         Valid border style
- * @property string          $border_left_style           Valid border style
- * @property float           $border_top_width            Length in pt
- * @property float           $border_right_width          Length in pt
- * @property float           $border_bottom_width         Length in pt
- * @property float           $border_left_width           Length in pt
- * @property string          $border_width                Only use for setting all sides to the same width
- * @property float|string    $border_bottom_left_radius   Radius in pt or a percentage value
- * @property float|string    $border_bottom_right_radius  Radius in pt or a percentage value
- * @property float|string    $border_top_left_radius      Radius in pt or a percentage value
- * @property float|string    $border_top_right_radius     Radius in pt or a percentage value
- * @property string          $border_radius               Only use for setting all corners to the same radius
- * @property float|string    $bottom                      Length in pt, a percentage value, or `auto`
- * @property string          $caption_side
- * @property string          $clear
- * @property string          $clip
- * @property array|string    $color
- * @property string[]|string $content                     List of content components, `normal`, or `none`
- * @property array|string    $counter_increment           Array defining the counters to increment or `none`
- * @property array|string    $counter_reset               Array defining the counters to reset or `none`
- * @property string          $cue_after
- * @property string          $cue_before
- * @property string          $cue
- * @property string          $cursor
- * @property string          $direction
- * @property string          $display
- * @property string          $elevation
- * @property string          $empty_cells
- * @property string          $float
- * @property string          $font_family
- * @property float           $font_size                   Length in pt
- * @property string          $font_style
- * @property string          $font_variant
- * @property string          $font_weight
- * @property float|string    $height                      Length in pt, a percentage value, or `auto`
- * @property string          $image_resolution
- * @property string          $inset                       Only use for setting all box insets to the same length
- * @property float|string    $left                        Length in pt, a percentage value, or `auto`
- * @property float           $letter_spacing              Length in pt
- * @property float           $line_height                 Length in pt
- * @property string          $list_style_image            Image URL or `none`
- * @property string          $list_style_position
- * @property string          $list_style_type
- * @property float|string    $margin_right                Length in pt, a percentage value, or `auto`
- * @property float|string    $margin_left                 Length in pt, a percentage value, or `auto`
- * @property float|string    $margin_top                  Length in pt, a percentage value, or `auto`
- * @property float|string    $margin_bottom               Length in pt, a percentage value, or `auto`
- * @property string          $margin                      Only use for setting all sides to the same length
- * @property float|string    $max_height                  Length in pt, a percentage value, or `none`
- * @property float|string    $max_width                   Length in pt, a percentage value, or `none`
- * @property float|string    $min_height                  Length in pt, a percentage value, or `auto`
- * @property float|string    $min_width                   Length in pt, a percentage value, or `auto`
- * @property float           $opacity                     Number in the range [0, 1]
- * @property int             $orphans
- * @property array|string    $outline_color
- * @property string          $outline_style               Valid border style, except for `hidden`
- * @property float           $outline_width               Length in pt
- * @property float           $outline_offset              Length in pt
- * @property string          $overflow
- * @property string          $overflow_wrap
- * @property float|string    $padding_top                 Length in pt or a percentage value
- * @property float|string    $padding_right               Length in pt or a percentage value
- * @property float|string    $padding_bottom              Length in pt or a percentage value
- * @property float|string    $padding_left                Length in pt or a percentage value
- * @property string          $padding                     Only use for setting all sides to the same length
- * @property string          $page_break_after
- * @property string          $page_break_before
- * @property string          $page_break_inside
- * @property string          $pause_after
- * @property string          $pause_before
- * @property string          $pause
- * @property string          $pitch_range
- * @property string          $pitch
- * @property string          $play_during
- * @property string          $position
- * @property string          $quotes
- * @property string          $richness
- * @property float|string    $right                       Length in pt, a percentage value, or `auto`
- * @property float[]|string  $size                        Pair of `[width, height]` or `auto`
- * @property string          $speak_header
- * @property string          $speak_numeral
- * @property string          $speak_punctuation
- * @property string          $speak
- * @property string          $speech_rate
- * @property string          $src
- * @property string          $stress
- * @property string          $table_layout
- * @property string          $text_align
- * @property string          $text_decoration
- * @property float|string    $text_indent                 Length in pt or a percentage value
- * @property string          $text_transform
- * @property float|string    $top                         Length in pt, a percentage value, or `auto`
- * @property array           $transform                   List of transforms
- * @property array           $transform_origin
- * @property string          $unicode_bidi
- * @property string          $unicode_range
- * @property string          $vertical_align
- * @property string          $visibility
- * @property string          $voice_family
- * @property string          $volume
- * @property string          $white_space
- * @property int             $widows
- * @property float|string    $width                       Length in pt, a percentage value, or `auto`
- * @property string          $word_break
- * @property float           $word_spacing                Length in pt
- * @property int|string      $z_index                     Integer value or `auto`
- * @property string          $_dompdf_keep
+ * @property string               $azimuth
+ * @property string               $background_attachment
+ * @property array|string         $background_color
+ * @property string               $background_image            Image URL or `none`
+ * @property string               $background_image_resolution
+ * @property array                $background_position
+ * @property string               $background_repeat
+ * @property array|string         $background_size             `cover`, `contain`, or `[width, height]`, each being a length, percentage, or `auto`
+ * @property string               $border_collapse
+ * @property string               $border_color                Only use for setting all sides to the same color
+ * @property float[]              $border_spacing              Pair of `[horizontal, vertical]` spacing
+ * @property string               $border_style                Only use for setting all sides to the same style
+ * @property array|string         $border_top_color
+ * @property array|string         $border_right_color
+ * @property array|string         $border_bottom_color
+ * @property array|string         $border_left_color
+ * @property string               $border_top_style            Valid border style
+ * @property string               $border_right_style          Valid border style
+ * @property string               $border_bottom_style         Valid border style
+ * @property string               $border_left_style           Valid border style
+ * @property float                $border_top_width            Length in pt
+ * @property float                $border_right_width          Length in pt
+ * @property float                $border_bottom_width         Length in pt
+ * @property float                $border_left_width           Length in pt
+ * @property string               $border_width                Only use for setting all sides to the same width
+ * @property float|string         $border_bottom_left_radius   Radius in pt or a percentage value
+ * @property float|string         $border_bottom_right_radius  Radius in pt or a percentage value
+ * @property float|string         $border_top_left_radius      Radius in pt or a percentage value
+ * @property float|string         $border_top_right_radius     Radius in pt or a percentage value
+ * @property string               $border_radius               Only use for setting all corners to the same radius
+ * @property float|string         $bottom                      Length in pt, a percentage value, or `auto`
+ * @property string               $caption_side
+ * @property string               $clear
+ * @property string               $clip
+ * @property array|string         $color
+ * @property ContentPart[]|string $content                     List of content components, `normal`, or `none`
+ * @property array|string         $counter_increment           Array defining the counters to increment or `none`
+ * @property array|string         $counter_reset               Array defining the counters to reset or `none`
+ * @property string               $cue_after
+ * @property string               $cue_before
+ * @property string               $cue
+ * @property string               $cursor
+ * @property string               $direction
+ * @property string               $display
+ * @property string               $elevation
+ * @property string               $empty_cells
+ * @property string               $float
+ * @property string               $font_family
+ * @property float                $font_size                   Length in pt
+ * @property string               $font_style
+ * @property string               $font_variant
+ * @property string               $font_weight
+ * @property float|string         $height                      Length in pt, a percentage value, or `auto`
+ * @property string               $image_resolution
+ * @property string               $inset                       Only use for setting all box insets to the same length
+ * @property float|string         $left                        Length in pt, a percentage value, or `auto`
+ * @property float                $letter_spacing              Length in pt
+ * @property float                $line_height                 Length in pt
+ * @property string               $list_style_image            Image URL or `none`
+ * @property string               $list_style_position
+ * @property string               $list_style_type
+ * @property float|string         $margin_right                Length in pt, a percentage value, or `auto`
+ * @property float|string         $margin_left                 Length in pt, a percentage value, or `auto`
+ * @property float|string         $margin_top                  Length in pt, a percentage value, or `auto`
+ * @property float|string         $margin_bottom               Length in pt, a percentage value, or `auto`
+ * @property string               $margin                      Only use for setting all sides to the same length
+ * @property float|string         $max_height                  Length in pt, a percentage value, or `none`
+ * @property float|string         $max_width                   Length in pt, a percentage value, or `none`
+ * @property float|string         $min_height                  Length in pt, a percentage value, or `auto`
+ * @property float|string         $min_width                   Length in pt, a percentage value, or `auto`
+ * @property float                $opacity                     Number in the range [0, 1]
+ * @property int                  $orphans
+ * @property array|string         $outline_color
+ * @property string               $outline_style               Valid border style, except for `hidden`
+ * @property float                $outline_width               Length in pt
+ * @property float                $outline_offset              Length in pt
+ * @property string               $overflow
+ * @property string               $overflow_wrap
+ * @property float|string         $padding_top                 Length in pt or a percentage value
+ * @property float|string         $padding_right               Length in pt or a percentage value
+ * @property float|string         $padding_bottom              Length in pt or a percentage value
+ * @property float|string         $padding_left                Length in pt or a percentage value
+ * @property string               $padding                     Only use for setting all sides to the same length
+ * @property string               $page_break_after
+ * @property string               $page_break_before
+ * @property string               $page_break_inside
+ * @property string               $pause_after
+ * @property string               $pause_before
+ * @property string               $pause
+ * @property string               $pitch_range
+ * @property string               $pitch
+ * @property string               $play_during
+ * @property string               $position
+ * @property array|string         $quotes                      List of quote pairs, or `none`
+ * @property string               $richness
+ * @property float|string         $right                       Length in pt, a percentage value, or `auto`
+ * @property float[]|string       $size                        Pair of `[width, height]` or `auto`
+ * @property string               $speak_header
+ * @property string               $speak_numeral
+ * @property string               $speak_punctuation
+ * @property string               $speak
+ * @property string               $speech_rate
+ * @property string               $src
+ * @property string               $stress
+ * @property string               $table_layout
+ * @property string               $text_align
+ * @property string               $text_decoration
+ * @property float|string         $text_indent                 Length in pt or a percentage value
+ * @property string               $text_transform
+ * @property float|string         $top                         Length in pt, a percentage value, or `auto`
+ * @property array                $transform                   List of transforms
+ * @property array                $transform_origin
+ * @property string               $unicode_bidi
+ * @property string               $unicode_range
+ * @property string               $vertical_align
+ * @property string               $visibility
+ * @property string               $voice_family
+ * @property string               $volume
+ * @property string               $white_space
+ * @property int                  $widows
+ * @property float|string         $width                       Length in pt, a percentage value, or `auto`
+ * @property string               $word_break
+ * @property float                $word_spacing                Length in pt
+ * @property int|string           $z_index                     Integer value or `auto`
+ * @property string               $_dompdf_keep
  *
  * @package dompdf
  */
@@ -172,6 +183,14 @@ class Style
     protected const CSS_IDENTIFIER = "-?[_a-zA-Z]+[_a-zA-Z0-9-]*";
     protected const CSS_INTEGER = "[+-]?\d+";
     protected const CSS_NUMBER = "[+-]?\d*\.?\d+(?:[eE][+-]?\d+)?";
+    protected const CSS_STRING = "" .
+        '"(?:[^"]|\\\\["])*(?<!\\\\)"|' . // String ""
+        "'(?:[^']|\\\\['])*(?<!\\\\)'";   // String ''
+
+    /**
+     * https://www.w3.org/TR/css-values-3/#custom-idents
+     */
+    protected const CUSTOM_IDENT_FORBIDDEN = ["inherit", "initial", "unset", "default"];
 
     /**
      * Default font size, in points.
@@ -2064,21 +2083,44 @@ class Style
     }
 
     /**
-     * @param string $computed
-     * @return string[]|string
+     * @param array|string $computed
+     * @return array|string
      *
-     * @link https://www.w3.org/TR/CSS21/generate.html#propdef-content
+     * @link https://www.w3.org/TR/css-content-3/#quotes
      */
-    protected function _get_content($computed)
+    protected function _get_quotes($computed)
     {
-        if ($computed === "normal" || $computed === "none") {
-            return $computed;
+        if ($computed === "auto") {
+            // TODO: Use typographically appropriate quotes for the current
+            // language here
+            return [['"', '"'], ["'", "'"]];
         }
 
-        return $this->parse_property_value($computed);
+        return $computed;
     }
 
     /*==============================*/
+
+    /**
+     * Parses a CSS string containing quotes and escaped hex characters.
+     *
+     * @param string $string The string to parse.
+     *
+     * @return string
+     */
+    protected function parse_string(string $string): string
+    {
+        // Strip string quotes and escapes
+        $string = preg_replace('/^[\"\']|[\"\']$/', "", $string);
+        $string = str_replace(["\\\n", '\\"', "\\'"], ["", '"', "'"], $string);
+
+        // Convert escaped hex characters into ascii characters (e.g. \A => newline)
+        return preg_replace_callback(
+            "/\\\\([0-9a-fA-F]{0,6})/",
+            function ($matches) { return Helpers::unichr(hexdec($matches[1])); },
+            $string
+        ) ?? "";
+    }
 
     /**
      * Parse a property value into its components.
@@ -2089,17 +2131,17 @@ class Style
      */
     protected function parse_property_value(string $value): array
     {
+        $string = self::CSS_STRING;
         $ident = self::CSS_IDENTIFIER;
         $number = self::CSS_NUMBER;
 
         $pattern = "/\n" .
-            "\s* \" ( (?:[^\"]|\\\\[\"])* ) (?<!\\\\)\" |\n" . // String ""
-            "\s* '  ( (?:[^']|\\\\['])* )   (?<!\\\\)'  |\n" . // String ''
-            "\s* ($ident \\([^)]*\\) )                  |\n" . // Functional
-            "\s* ($ident)                               |\n" . // Keyword
-            "\s* (\#[0-9a-fA-F]*)                       |\n" . // Hex value
-            "\s* ($number [a-zA-Z%]*)                   |\n" . // Number (+ unit/percentage)
-            "\s* ([\/,;])                                \n" . // Delimiter
+            "\s* ($string)             |\n" . // String
+            "\s* ($ident \\([^)]*\\) ) |\n" . // Functional
+            "\s* ($ident)              |\n" . // Keyword
+            "\s* (\#[0-9a-fA-F]*)      |\n" . // Hex value
+            "\s* ($number [a-zA-Z%]*)  |\n" . // Number (+ unit/percentage)
+            "\s* ([\/,;])               \n" . // Delimiter
             "/Sx";
 
         if (!preg_match_all($pattern, $value, $matches)) {
@@ -2153,7 +2195,7 @@ class Style
      */
     protected function compute_length(string $val): ?float
     {
-        return mb_strpos($val, "%") === false
+        return strpos($val, "%") === false
             ? $this->single_length_in_pt($val)
             : null;
     }
@@ -2183,7 +2225,7 @@ class Style
         }
 
         // Retain valid percentage declarations
-        return mb_strpos($val, "%") === false ? $computed : $val;
+        return strpos($val, "%") === false ? $computed : $val;
     }
 
     /**
@@ -2201,7 +2243,7 @@ class Style
         }
 
         // Retain valid percentage declarations
-        return mb_strpos($val, "%") === false ? $computed : $val;
+        return strpos($val, "%") === false ? $computed : $val;
     }
 
     /**
@@ -2245,6 +2287,24 @@ class Style
     protected function compute_border_style(string $val): ?string
     {
         return \in_array($val, self::BORDER_STYLES, true) ? $val : null;
+    }
+
+    /**
+     * @link https://www.w3.org/TR/css-lists-3/#typedef-counter-name
+     */
+    protected function isValidCounterName(string $name): bool
+    {
+        return $name !== "none"
+            && !in_array($name, self::CUSTOM_IDENT_FORBIDDEN, true);
+    }
+
+    /**
+     * @link https://www.w3.org/TR/css-counter-styles-3/#typedef-counter-style-name
+     */
+    protected function isValidCounterStyleName(string $name): bool
+    {
+        return $name !== "none"
+            && !in_array($name, self::CUSTOM_IDENT_FORBIDDEN, true);
     }
 
     /**
@@ -3318,6 +3378,7 @@ class Style
     /**
      * @param string $value
      * @param int    $default
+     * @param bool   $sumDuplicates
      *
      * @return array|string|null
      */
@@ -3340,10 +3401,15 @@ class Style
         $counters = [];
 
         foreach ($matches as $match) {
-            $counter = $match[1];
+            $name = $match[1];
+
+            if (!$this->isValidCounterName($name)) {
+                return null;
+            }
+
             $value = isset($match[2]) ? (int) $match[2] : $default;
-            $counters[$counter] = $sumDuplicates
-                ? ($counters[$counter] ?? 0) + $value
+            $counters[$name] = $sumDuplicates
+                ? ($counters[$name] ?? 0) + $value
                 : $value;
         }
 
@@ -3364,6 +3430,156 @@ class Style
     protected function _compute_counter_reset(string $val)
     {
         return $this->compute_counter_prop($val, 0);
+    }
+
+    /**
+     * @link https://www.w3.org/TR/css-content-3/#quotes
+     */
+    protected function _compute_quotes(string $val)
+    {
+        // `auto` is resolved in the getter, so it can inherit as is
+        if ($val === "none" || $val === "auto") {
+            return $val;
+        }
+
+        $components = $this->parse_property_value($val);
+        $quotes = [];
+
+        foreach ($components as $value) {
+            if (strncmp($value, '"', 1) !== 0
+                && strncmp($value, "'", 1) !== 0
+            ) {
+                return null;
+            }
+
+            $quotes[] = $this->parse_string($value);
+        }
+
+        if ($quotes === [] || \count($quotes) % 2 !== 0) {
+            return null;
+        }
+
+        return array_chunk($quotes, 2);
+    }
+
+    /**
+     * @link https://www.w3.org/TR/CSS21/generate.html#propdef-content
+     * @link https://www.w3.org/TR/css-content-3/#propdef-content
+     */
+    protected function _compute_content(string $val)
+    {
+        if ($val === "normal" || $val === "none") {
+            return $val;
+        }
+
+        $components = $this->parse_property_value($val);
+        $parts = [];
+
+        if ($components === []) {
+            return null;
+        }
+
+        foreach ($components as $value) {
+            // String
+            if (strncmp($value, '"', 1) === 0 || strncmp($value, "'", 1) === 0) {
+                $parts[] = new StringPart($this->parse_string($value));
+                continue;
+            }
+
+            $lower = strtolower($value);
+
+            // Keywords
+            if ($lower === "open-quote") {
+                $parts[] = new OpenQuote;
+                continue;
+            } elseif ($lower === "close-quote") {
+                $parts[] = new CloseQuote;
+                continue;
+            } elseif ($lower === "no-open-quote") {
+                $parts[] = new NoOpenQuote;
+                continue;
+            } elseif ($lower === "no-close-quote") {
+                $parts[] = new NoCloseQuote;
+                continue;
+            }
+
+            // Functional components
+            $pos = strpos($lower, "(");
+
+            if ($pos === false) {
+                return null;
+            }
+
+            // `parse_property_value` ensures that the value is of the form
+            // `function(arguments)` at this point
+            $function = substr($lower, 0, $pos);
+            $arguments = trim(substr($value, $pos + 1, -1));
+
+            // attr()
+            if ($function === "attr") {
+                $attr = strtolower($arguments);
+
+                if ($attr === "") {
+                    return null;
+                }
+
+                $parts[] = new Attr($attr);
+            }
+
+            // counter(name [, style])
+            elseif ($function === "counter") {
+                $ident = self::CSS_IDENTIFIER;
+
+                if (!preg_match("/^($ident)(?:\s*,\s*($ident))?$/", $arguments, $matches)) {
+                    return null;
+                }
+
+                $name = $matches[1];
+                $type = isset($matches[2]) ? strtolower($matches[2]) : "decimal";
+
+                if (!$this->isValidCounterName($name)
+                    || !$this->isValidCounterStyleName($type)
+                ) {
+                    return null;
+                }
+
+                $parts[] = new Counter($name, $type);
+            }
+
+            // counters(name, string [, style])
+            elseif ($function === "counters") {
+                $ident = self::CSS_IDENTIFIER;
+                $string = self::CSS_STRING;
+
+                if (!preg_match("/^($ident)\s*,\s*($string)(?:\s*,\s*($ident))?$/", $arguments, $matches)) {
+                    return null;
+                }
+
+                $name = $matches[1];
+                $string = $this->parse_string($matches[2]);
+                $type = isset($matches[3]) ? strtolower($matches[3]) : "decimal";
+
+                if (!$this->isValidCounterName($name)
+                    || !$this->isValidCounterStyleName($type)
+                ) {
+                    return null;
+                }
+
+                $parts[] = new Counters($name, $string, $type);
+            }
+
+            // url()
+            elseif ($function === "url") {
+                $url = $this->parse_string($arguments);
+                $parts[] = new Url($url);
+            }
+
+            else {
+                return null;
+            }
+        }
+
+        return $parts;
     }
 
     /**

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1368,12 +1368,12 @@ class Stylesheet
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();
         $parsed_url = "none";
 
-        if (empty($val) || $val === "none") {
+        if ($val === null || $val === "" || strcasecmp($val, "none") === 0) {
             $path = "none";
-        } elseif (mb_strpos($val, "url") === false) {
+        } elseif (strncasecmp($val, "url(", 4) !== 0) {
             $path = "none"; //Don't resolve no image -> otherwise would prefix path and no longer recognize as none
         } else {
-            $val = preg_replace("/url\(\s*['\"]?([^'\")]+)['\"]?\s*\)/", "\\1", trim($val));
+            $val = preg_replace("/url\(\s*['\"]?([^'\")]+)['\"]?\s*\)/i", "\\1", trim($val));
 
             // Resolve the url now in the context of the current stylesheet
             $path = Helpers::build_url($this->_protocol,

--- a/src/FrameDecorator/Page.php
+++ b/src/FrameDecorator/Page.php
@@ -699,8 +699,6 @@ class Page extends AbstractFrameDecorator
      * Add a floating frame
      *
      * @param Frame $frame
-     *
-     * @return void
      */
     function add_floating_frame(Frame $frame)
     {

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -6,8 +6,15 @@
  */
 namespace Dompdf\FrameReflower;
 
+use Dompdf\Css\Content\Attr;
+use Dompdf\Css\Content\CloseQuote;
+use Dompdf\Css\Content\Counter;
+use Dompdf\Css\Content\Counters;
+use Dompdf\Css\Content\NoCloseQuote;
+use Dompdf\Css\Content\NoOpenQuote;
+use Dompdf\Css\Content\OpenQuote;
+use Dompdf\Css\Content\StringPart;
 use Dompdf\Dompdf;
-use Dompdf\Helpers;
 use Dompdf\Frame;
 use Dompdf\Frame\Factory;
 use Dompdf\FrameDecorator\AbstractFrameDecorator;
@@ -476,183 +483,69 @@ abstract class AbstractFrameReflower
     }
 
     /**
-     * Parses a CSS string containing quotes and escaped hex characters
-     *
-     * @param $string string The CSS string to parse
-     * @param $single_trim
-     * @return string
-     */
-    protected function _parse_string($string, $single_trim = false)
-    {
-        if ($single_trim) {
-            $string = preg_replace('/^[\"\']/', "", $string);
-            $string = preg_replace('/[\"\']$/', "", $string);
-        } else {
-            $string = trim($string, "'\"");
-        }
-
-        $string = str_replace(["\\\n", '\\"', "\\'"],
-            ["", '"', "'"], $string);
-
-        // Convert escaped hex characters into ascii characters (e.g. \A => newline)
-        $string = preg_replace_callback("/\\\\([0-9a-fA-F]{0,6})/",
-            function ($matches) { return \Dompdf\Helpers::unichr(hexdec($matches[1])); },
-            $string);
-        return $string;
-    }
-
-    /**
-     * Parses a CSS "quotes" property
-     *
-     * https://www.w3.org/TR/css-content-3/#quotes
-     *
-     * @return array An array of pairs of quotes
-     */
-    protected function _parse_quotes(): array
-    {
-        $quotes = $this->_frame->get_style()->quotes;
-
-        if ($quotes === "none") {
-            return [];
-        }
-
-        if ($quotes === "auto") {
-            // TODO: Use typographically appropriate quotes for the current
-            // language here
-            return [['"', '"'], ["'", "'"]];
-        }
-
-        // Matches quote types
-        $re = '/(\'[^\']*\')|(\"[^\"]*\")/';
-
-        // Split on spaces, except within quotes
-        if (!preg_match_all($re, $quotes, $matches, PREG_SET_ORDER)) {
-            return [];
-        }
-
-        $quotes_array = [];
-        foreach ($matches as $_quote) {
-            $quotes_array[] = $this->_parse_string($_quote[0], true);
-        }
-
-        return array_chunk($quotes_array, 2);
-    }
-
-    /**
-     * Parses the CSS "content" property
+     * Resolves the `content` property to string.
      *
      * https://www.w3.org/TR/CSS21/generate.html#content
      *
      * @return string The resulting string
      */
-    protected function _parse_content(): string
+    protected function resolve_content(): string
     {
-        $style = $this->_frame->get_style();
+        $frame = $this->_frame;
+        $style = $frame->get_style();
         $content = $style->content;
 
         if ($content === "normal" || $content === "none") {
             return "";
         }
 
-        $quotes = $this->_parse_quotes();
+        $quotes = $style->quotes;
         $text = "";
 
         foreach ($content as $val) {
-            // String
-            if (in_array(mb_substr($val, 0, 1), ['"', "'"], true)) {
-                $text .= $this->_parse_string($val);
-                continue;
+            if ($val instanceof StringPart) {
+                $text .= $val->string;
             }
 
-            $val = mb_strtolower($val);
-
-            // Keywords
-            if ($val === "open-quote") {
+            elseif ($val instanceof OpenQuote) {
                 // FIXME: Take quotation depth into account
-                if (isset($quotes[0][0])) {
+                if ($quotes !== "none" && isset($quotes[0][0])) {
                     $text .= $quotes[0][0];
                 }
-                continue;
-            } elseif ($val === "close-quote") {
+            }
+
+            elseif ($val instanceof CloseQuote) {
                 // FIXME: Take quotation depth into account
-                if (isset($quotes[0][1])) {
+                if ($quotes !== "none" && isset($quotes[0][1])) {
                     $text .= $quotes[0][1];
                 }
-                continue;
-            } elseif ($val === "no-open-quote") {
+            }
+            
+            elseif ($val instanceof NoOpenQuote) {
                 // FIXME: Increment quotation depth
-                continue;
-            } elseif ($val === "no-close-quote") {
+            }
+
+            elseif ($val instanceof NoCloseQuote) {
                 // FIXME: Decrement quotation depth
-                continue;
             }
 
-            // attr()
-            if (mb_substr($val, 0, 5) === "attr(") {
-                $i = mb_strpos($val, ")");
-                if ($i === false) {
-                    continue;
-                }
-
-                $attr = trim(mb_substr($val, 5, $i - 5));
-                if ($attr === "") {
-                    continue;
-                }
-
-                $text .= $this->_frame->get_parent()->get_node()->getAttribute($attr);
-                continue;
+            elseif ($val instanceof Attr) {
+                $text .= $frame->get_parent()->get_node()->getAttribute($val->attribute);
             }
 
-            // counter()/counters()
-            if (mb_substr($val, 0, 7) === "counter") {
-                // Handle counter() references:
-                // http://www.w3.org/TR/CSS21/generate.html#content
+            elseif ($val instanceof Counter) {
+                $p = $frame->lookup_counter_frame($val->name, true);
+                $text .= $p->counter_value($val->name, $val->style);
+            }
 
-                $i = mb_strpos($val, ")");
-                if ($i === false) {
-                    continue;
+            elseif ($val instanceof Counters) {
+                $p = $frame->lookup_counter_frame($val->name, true);
+                $tmp = [];
+                while ($p) {
+                    array_unshift($tmp, $p->counter_value($val->name, $val->style));
+                    $p = $p->lookup_counter_frame($val->name);
                 }
-
-                preg_match('/(counters?)(^\()*?\(\s*([^\s,]+)\s*(,\s*["\']?([^"\'\)]*)["\']?\s*(,\s*([^\s)]+)\s*)?)?\)/i', $val, $args);
-                $counter_id = $args[3];
-
-                if (strtolower($args[1]) === "counter") {
-                    // counter(name [,style])
-                    if (isset($args[5])) {
-                        $type = trim($args[5]);
-                    } else {
-                        $type = "decimal";
-                    }
-
-                    $p = $this->_frame->lookup_counter_frame($counter_id, true);
-
-                    $text .= $p->counter_value($counter_id, $type);
-                } elseif (strtolower($args[1]) === "counters") {
-                    // counters(name, string [,style])
-                    if (isset($args[5])) {
-                        $string = $this->_parse_string($args[5]);
-                    } else {
-                        $string = "";
-                    }
-
-                    if (isset($args[7])) {
-                        $type = trim($args[7]);
-                    } else {
-                        $type = "decimal";
-                    }
-
-                    $p = $this->_frame->lookup_counter_frame($counter_id, true);
-                    $tmp = [];
-                    while ($p) {
-                        array_unshift($tmp, $p->counter_value($counter_id, $type));
-                        $p = $p->lookup_counter_frame($counter_id);
-                    }
-                    $text .= implode($string, $tmp);
-                } else {
-                    // countertops?
-                }
-
-                continue;
+                $text .= implode($val->string, $tmp);
             }
         }
 
@@ -682,7 +575,7 @@ abstract class AbstractFrameReflower
         }
 
         if ($frame->get_node()->nodeName === "dompdf_generated") {
-            $content = $this->_parse_content();
+            $content = $this->resolve_content();
 
             if ($content !== "") {
                 $node = $frame->get_node()->ownerDocument->createTextNode($content);

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -35,26 +35,22 @@ class ListBullet extends AbstractRenderer
         $text = "";
 
         switch ($type) {
-            case "decimal-leading-zero":
+            default:
             case "decimal":
-            case "1":
+            case "decimal-leading-zero":
                 return "0123456789";
 
             case "upper-alpha":
             case "upper-latin":
-            case "A":
                 $uppercase = true;
             case "lower-alpha":
             case "lower-latin":
-            case "a":
                 $text = "abcdefghijklmnopqrstuvwxyz";
                 break;
 
             case "upper-roman":
-            case "I":
                 $uppercase = true;
             case "lower-roman":
-            case "i":
                 $text = "ivxlcdm";
                 break;
 
@@ -86,9 +82,9 @@ class ListBullet extends AbstractRenderer
         $uppercase = false;
 
         switch ($type) {
-            case "decimal-leading-zero":
+            default:
             case "decimal":
-            case "1":
+            case "decimal-leading-zero":
                 if ($pad) {
                     $text = str_pad($n, $pad, "0", STR_PAD_LEFT);
                 } else {
@@ -98,19 +94,15 @@ class ListBullet extends AbstractRenderer
 
             case "upper-alpha":
             case "upper-latin":
-            case "A":
                 $uppercase = true;
             case "lower-alpha":
             case "lower-latin":
-            case "a":
                 $text = chr((($n - 1) % 26) + ord('a'));
                 break;
 
             case "upper-roman":
-            case "I":
                 $uppercase = true;
             case "lower-roman":
-            case "i":
                 $text = Helpers::dec2roman($n);
                 break;
 
@@ -158,7 +150,6 @@ class ListBullet extends AbstractRenderer
             $bullet_style = $style->list_style_type;
 
             switch ($bullet_style) {
-                default:
                 case "disc":
                 case "circle":
                     [$x, $y] = $frame->get_position();
@@ -178,8 +169,9 @@ class ListBullet extends AbstractRenderer
                     $this->_canvas->filled_rectangle($x, $y, $w, $w, $style->color);
                     break;
 
-                case "decimal-leading-zero":
+                default:
                 case "decimal":
+                case "decimal-leading-zero":
                 case "lower-alpha":
                 case "lower-latin":
                 case "lower-roman":
@@ -187,11 +179,6 @@ class ListBullet extends AbstractRenderer
                 case "upper-alpha":
                 case "upper-latin":
                 case "upper-roman":
-                case "1": // HTML 4.0 compatibility
-                case "a":
-                case "i":
-                case "A":
-                case "I":
                     $pad = null;
                     if ($bullet_style === "decimal-leading-zero") {
                         $pad = strlen($li->get_parent()->get_node()->getAttribute("dompdf-children-count"));

--- a/tests/Css/AttributeTranslatorTest.php
+++ b/tests/Css/AttributeTranslatorTest.php
@@ -1,0 +1,122 @@
+<?php
+namespace Dompdf\Tests\Css;
+
+use Dompdf\Dompdf;
+use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\Tests\TestCase;
+
+final class AttributeTranslatorTest extends TestCase
+{
+    public function attributeToStyleTranslationProvider(): array
+    {
+        return [
+            // TODO: Heredocs can be nicely indented starting with PHP 7.3
+            "list type ol" => [
+                <<<HTML
+<ol type="1"></ol>
+<ol type="a"></ol>
+<ol type="A"></ol>
+<ol type="i"></ol>
+<ol type="I"></ol>
+HTML
+,
+                [
+                    "ol" => [
+                        ["list-style-type" => "decimal"],
+                        ["list-style-type" => "lower-alpha"],
+                        ["list-style-type" => "upper-alpha"],
+                        ["list-style-type" => "lower-roman"],
+                        ["list-style-type" => "upper-roman"]
+                    ]
+                ]
+            ],
+            "list type ul" => [
+                <<<HTML
+<ul type="1"></ul>
+<ul type="a"></ul>
+<ul type="A"></ul>
+<ul type="i"></ul>
+<ul type="I"></ul>
+HTML
+,
+                [
+                    "ul" => [
+                        ["list-style-type" => "decimal"],
+                        ["list-style-type" => "lower-alpha"],
+                        ["list-style-type" => "upper-alpha"],
+                        ["list-style-type" => "lower-roman"],
+                        ["list-style-type" => "upper-roman"]
+                    ]
+                ]
+            ],
+            "list type li" => [
+                <<<HTML
+<ol>
+    <li type="1"></li>
+    <li type="a"></li>
+    <li type="A"></li>
+    <li type="i"></li>
+    <li type="I"></li>
+</ol>
+HTML
+,
+                [
+                    "li" => [
+                        ["list-style-type" => "decimal"],
+                        ["list-style-type" => "lower-alpha"],
+                        ["list-style-type" => "upper-alpha"],
+                        ["list-style-type" => "lower-roman"],
+                        ["list-style-type" => "upper-roman"]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The expected styles defines the nodes to check by node name. For each
+     * name, the corresponding nodes have to match the expected styles in
+     * order before render.
+     *
+     * @dataProvider attributeToStyleTranslationProvider
+     */
+    public function testAttributeToStyleTranslation(
+        string $body,
+        array $expectedStyles
+    ): void {
+        $styles = array_fill_keys(array_keys($expectedStyles), []);
+
+        // Use callback to inspect frame tree
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function (AbstractFrameDecorator $frame) use ($expectedStyles, &$styles) {
+                    $node = $frame->get_node();
+                    $name = $node->nodeName;
+
+                    if (isset($expectedStyles[$name])) {
+                        $translateProp = function ($prop) {
+                            return str_replace("-", "_", $prop);
+                        };
+
+                        $style = $frame->get_style();
+                        $index = count($styles[$name]);
+                        $keys = array_keys($expectedStyles[$name][$index]);
+                        $props = array_map($translateProp, $keys);
+                        $values = array_map(function ($prop) use ($style) {
+                            return $style->$prop;
+                        }, $props);
+
+                        $styles[$name][] = array_combine($keys, $values);
+                    }
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml("<html><body>$body</body></html>");
+        $dompdf->render();
+
+        $this->assertSame($expectedStyles, $styles);
+    }
+}

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -345,11 +345,16 @@ class ShorthandTest extends TestCase
 
         return [
             ["none", "none", "none"],
+            ["NONE    None", "none", "none"],
             ["url($imagePath)", "disc", "url($imagePath)"],
+            ["url($imagePath) none", "none", "url($imagePath)"],
             ["url( '$imagePath' ) outside", "disc", "url( '$imagePath' )", "outside"],
             ["inside url($imagePath) square", "square", "url($imagePath)", "inside"],
             ["inside decimal", "decimal", "none", "inside"],
-            ["OUTSIDE    LOWER-GREEK", "LOWER-GREEK", "none", "outside"]
+            ["OUTSIDE    LOWER-GREEK", "LOWER-GREEK", "none", "outside"],
+
+            // Invalid values
+            ["inside none none none", "disc"]
         ];
     }
 

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -276,7 +276,7 @@ class ShorthandTest extends TestCase
             ["url( \"$imagePath\" )", "url( \"$imagePath\" )"],
             ["rgba( 5, 5, 5, 1 )", "none", ["0%", "0%"], ["auto", "auto"], "repeat", "scroll", "rgba( 5, 5, 5, 1 )"],
             ["url(non-existing.png) top center no-repeat red fixed", "url(non-existing.png)", "top center", ["auto", "auto"], "no-repeat", "fixed", "red"],
-            ["url($imagePath) left/200pt 30% rgb( 123 16 69/0.8 )no-repeat", "url($imagePath)", "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"]
+            ["url($imagePath) LEFT/200PT 30% RGB( 123 16 69/0.8 )no-REPEAT", "url($imagePath)", "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"]
         ];
     }
 
@@ -348,7 +348,8 @@ class ShorthandTest extends TestCase
             ["url($imagePath)", "disc", "url($imagePath)"],
             ["url( '$imagePath' ) outside", "disc", "url( '$imagePath' )", "outside"],
             ["inside url($imagePath) square", "square", "url($imagePath)", "inside"],
-            ["inside decimal", "decimal", "none", "inside"]
+            ["inside decimal", "decimal", "none", "inside"],
+            ["OUTSIDE    LOWER-GREEK", "LOWER-GREEK", "none", "outside"]
         ];
     }
 

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -274,7 +274,7 @@ class ShorthandTest extends TestCase
             ["none", "none"],
             ["url($imagePath)", "url($imagePath)"],
             ["url( \"$imagePath\" )", "url( \"$imagePath\" )"],
-            ["rgba( 5, 5, 5, 1 )", "none", ["0%", "0%"], ["auto", "auto"], "repeat", "scroll", "rgba( 5, 5, 5, 1 )"],
+            ["rgba( 5, 5, 5, 1 )", "none", [0.0, 0.0], ["auto", "auto"], "repeat", "scroll", "rgba( 5, 5, 5, 1 )"],
             ["url(non-existing.png) top center no-repeat red fixed", "url(non-existing.png)", "top center", ["auto", "auto"], "no-repeat", "fixed", "red"],
             ["url($imagePath) LEFT/200PT 30% RGB( 123 16 69/0.8 )no-REPEAT", "url($imagePath)", "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"]
         ];
@@ -286,7 +286,7 @@ class ShorthandTest extends TestCase
     public function testBackgroundShorthand(
         string $value,
         string $image,
-        $position = ["0%", "0%"],
+        $position = [0.0, 0.0],
         $size = ["auto", "auto"],
         string $repeat = "repeat",
         string $attachment = "scroll",

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -306,12 +306,13 @@ class ShorthandTest extends TestCase
     public function fontShorthandProvider(): array
     {
         return [
-            ["8.5mm Helvetica", "normal", "normal", "normal", "8.5mm", "normal", "helvetica"],
+            ["8.5mm Helvetica", "normal", "normal", 400, "8.5mm", "normal", "helvetica"],
             ["bold 16pt/10pt serif", "normal", "normal", "bold", "16pt", "10pt", "serif"],
             ["italic 700\n\t15.5pt / 2.1 'Courier', sans-serif", "italic", "normal", "700", "15.5pt", "2.1", "'courier',sans-serif"],
             ["700   normal  ITALIC    15.5PT /2.1 'Courier',sans-serif", "italic", "normal", "700", "15.5pt", "2.1", "'courier',sans-serif"],
-            ["normal normal small-caps 100.01% serif, sans-serif", "normal", "small-caps", "normal", "100.01%", "normal", "serif,sans-serif"],
-            ["normal normal normal xx-small/normal monospace", "normal", "normal", "normal", "xx-small", "normal", "monospace"]
+            ["normal normal small-caps 100.01% serif, sans-serif", "normal", "small-caps", 400, "100.01%", "normal", "serif,sans-serif"],
+            ["normal normal normal xx-small/normal monospace", "normal", "normal", 400, "xx-small", "normal", "monospace"],
+            ["1 0 serif", "normal", "normal", "1", "0", "normal", "serif"]
         ];
     }
 
@@ -322,7 +323,7 @@ class ShorthandTest extends TestCase
         string $value,
         string $fontStyle,
         string $fontVariant,
-        string $fontWeight,
+        $fontWeight,
         string $fontSize,
         string $lineHeight,
         string $fontFamily

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -213,6 +213,72 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->background_position);
     }
 
+    public function fontWeightProvider(): array
+    {
+        return [
+            // Absolute
+            ["normal", 400],
+            ["bold", 700],
+            ["1", 1],
+            ["100", 100],
+            ["125", 125],
+            ["400", 400],
+            ["700", 700],
+            ["900", 900],
+            ["1000", 1000],
+            ["+1e3", 1000],
+
+            // Relative
+            ["bolder", 400, 1],
+            ["bolder", 400, 100],
+            ["bolder", 400, 200],
+            ["bolder", 400, 300],
+            ["bolder", 700, 400],
+            ["bolder", 700, 500],
+            ["bolder", 900, 600],
+            ["bolder", 900, 700],
+            ["bolder", 900, 800],
+            ["bolder", 900, 900],
+            ["bolder", 917, 917],
+            ["lighter", 15, 15],
+            ["lighter", 100, 100],
+            ["lighter", 100, 200],
+            ["lighter", 100, 300],
+            ["lighter", 100, 400],
+            ["lighter", 100, 500],
+            ["lighter", 400, 600],
+            ["lighter", 400, 700],
+            ["lighter", 700, 800],
+            ["lighter", 700, 900],
+            ["lighter", 700, 1000],
+
+            // Case variations
+            ["BOLD", 700],
+
+            // Invalid values
+            ["none", 400],
+            ["-100", 400],
+            ["1001", 400]
+        ];
+    }
+
+    /**
+     * @dataProvider fontWeightProvider
+     */
+    public function testFontWeight(string $value, $expected, int $parentWeight = 400): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+        $parentStyle = new Style($sheet);
+
+        $parentStyle->set_prop("font_weight", $parentWeight);
+        $style->inherit($parentStyle);
+
+        $style->set_prop("font_weight", $value);
+        $this->assertSame($expected, $style->font_weight);
+    }
+
     private function testLengthProperty(
         string $prop,
         string $value,

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -139,6 +139,80 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $s->background_image);
     }
 
+    public function backgroundPositionProvider(): array
+    {
+        return [
+            // One value
+            ["left", [0.0, "50%"]],
+            ["right", ["100%", "50%"]],
+            ["top", ["50%", 0.0]],
+            ["bottom", ["50%", "100%"]],
+            ["center", ["50%", "50%"]],
+            ["20pt", [20.0, "50%"]],
+            ["-10pt", [-10.0, "50%"]],
+            ["23%", ["23%", "50%"]],
+            ["-75%", ["-75%", "50%"]],
+
+            // Two values
+            ["left top", [0.0, 0.0]],
+            ["top left", [0.0, 0.0]],
+            ["left bottom", [0.0, "100%"]],
+            ["bottom left", [0.0, "100%"]],
+            ["left center", [0.0, "50%"]],
+            ["center left", [0.0, "50%"]],
+            ["right top", ["100%", 0.0]],
+            ["top right", ["100%", 0.0]],
+            ["right bottom", ["100%", "100%"]],
+            ["bottom right", ["100%", "100%"]],
+            ["right center", ["100%", "50%"]],
+            ["center right", ["100%", "50%"]],
+            ["bottom center", ["50%", "100%"]],
+            ["center bottom", ["50%", "100%"]],
+            ["top center", ["50%", 0.0]],
+            ["center top", ["50%", 0.0]],
+            ["center center", ["50%", "50%"]],
+            ["left 23%", [0.0, "23%"]],
+            ["right 23%", ["100%", "23%"]],
+            ["center 23%", ["50%", "23%"]],
+            ["23% top", ["23%", 0.0]],
+            ["23% bottom", ["23%", "100%"]],
+            ["23% center", ["23%", "50%"]],
+            ["23% 50pt", ["23%", 50.0]],
+            ["50pt 23%", [50.0, "23%"]],
+
+            // Case and whitespace variations
+            ["LEFT", [0.0, "50%"]],
+            ["TOP    Right", ["100%", 0.0]],
+            ["-23PT     BoTTom", [-23.0, "100%"]],
+
+            // Invalid values
+            ["none", [0.0, 0.0]],
+            ["auto", [0.0, 0.0]],
+            ["left left", [0.0, 0.0]],
+            ["left right", [0.0, 0.0]],
+            ["bottom top", [0.0, 0.0]],
+            ["center center center", [0.0, 0.0]],
+            ["1pt 2pt 3pt 4pt", [0.0, 0.0]],
+            ["23% left", [0.0, 0.0]],
+            ["23% right", [0.0, 0.0]],
+            ["top 23%", [0.0, 0.0]],
+            ["bottom 23%", [0.0, 0.0]]
+        ];
+    }
+
+    /**
+     * @dataProvider backgroundPositionProvider
+     */
+    public function testBackgroundPosition(string $value, $expected): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop("background_position", $value);
+        $this->assertSame($expected, $style->background_position);
+    }
+
     private function testLengthProperty(
         string $prop,
         string $value,

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -55,7 +55,8 @@ class StyleTest extends TestCase
             "no value" => ["", "none"],
             "keyword none" => ["none", "none"],
             "bare url" => ["http://example.com/test.png", "none"],
-            "http" => ["url(http://example.com/test.png)", "http://example.com/test.png"]
+            "http" => ["url(http://example.com/test.png)", "http://example.com/test.png"],
+            "case" => ["URL(http://example.com/Test.png)", "http://example.com/Test.png"]
         ];
     }
 
@@ -138,11 +139,213 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $s->background_image);
     }
 
+    private function testLengthProperty(
+        string $prop,
+        string $value,
+        float $fontSize,
+        $expected,
+        $initialProps = []
+    ): void {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->font_size = $fontSize;
+
+        foreach ($initialProps as $p => $v) {
+            $style->$p = $v;
+        }
+
+        $style->set_prop($prop, $value);
+        $this->assertSame($expected, $style->$prop);
+    }
+
+    public function widthHeightProvider(): array
+    {
+        return [
+            // Keywords
+            ["auto", 12.0, "auto", 0.0],
+
+            // Lengths
+            ["0", 12.0, 0.0],
+            ["1em", 20.0, 20.0],
+            ["100pt", 12.0, 100.0],
+            ["50%", 12.0, "50%"],
+
+            // Case variations
+            ["Auto", 12.0, "auto", 0.0],
+            ["AUTO", 12.0, "auto", 0.0],
+            ["1EM", 20.0, 20.0],
+
+            // Invalid values
+            ["none", 12.0, "auto"],
+            ["-100pt", 12.0, "auto"],
+            ["-50%", 12.0, "auto"]
+        ];
+    }
+
+    /**
+     * @dataProvider widthHeightProvider
+     */
+    public function testWidth(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("width", $value, $fontSize, $expected, ["width" => $initial]);
+    }
+
+    /**
+     * @dataProvider widthHeightProvider
+     */
+    public function testHeight(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("height", $value, $fontSize, $expected, ["height" => $initial]);
+    }
+
+    public function minWidthHeightProvider(): array
+    {
+        return [
+            // Keywords
+            ["auto", 12.0, "auto", 0.0],
+
+            // Legacy keywords
+            ["none", 12.0, "auto", 0.0],
+
+            // Lengths
+            ["0", 12.0, 0.0],
+            ["1em", 20.0, 20.0],
+            ["100pt", 12.0, 100.0],
+            ["50%", 12.0, "50%"],
+
+            // Case variations
+            ["Auto", 12.0, "auto", 0.0],
+            ["AUTO", 12.0, "auto", 0.0],
+            ["1EM", 20.0, 20.0],
+
+            // Invalid values
+            ["-100pt", 12.0, "auto"],
+            ["-50%", 12.0, "auto"]
+        ];
+    }
+
+    /**
+     * @dataProvider minWidthHeightProvider
+     */
+    public function testMinWidth(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("min_width", $value, $fontSize, $expected, ["min_width" => $initial]);
+    }
+
+    /**
+     * @dataProvider minWidthHeightProvider
+     */
+    public function testMinHeight(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("min_height", $value, $fontSize, $expected, ["min_height" => $initial]);
+    }
+
+    public function maxWidthHeightProvider(): array
+    {
+        return [
+            // Keywords
+            ["none", 12.0, "none", 0.0],
+
+            // Legacy keywords
+            ["auto", 12.0, "none", 0.0],
+
+            // Lengths
+            ["0", 12.0, 0.0],
+            ["1em", 20.0, 20.0],
+            ["100pt", 12.0, 100.0],
+            ["50%", 12.0, "50%"],
+
+            // Case variations
+            ["None", 12.0, "none", 0.0],
+            ["NONE", 12.0, "none", 0.0],
+            ["1EM", 20.0, 20.0],
+
+            // Invalid values
+            ["-100pt", 12.0, "none"],
+            ["-50%", 12.0, "none"]
+        ];
+    }
+
+    /**
+     * @dataProvider maxWidthHeightProvider
+     */
+    public function testMaxWidth(string $value, float $fontSize, $expected, $initial = "none"): void
+    {
+        $this->testLengthProperty("max_width", $value, $fontSize, $expected, ["max_width" => $initial]);
+    }
+
+    /**
+     * @dataProvider maxWidthHeightProvider
+     */
+    public function testMaxHeight(string $value, float $fontSize, $expected, $initial = "none"): void
+    {
+        $this->testLengthProperty("max_height", $value, $fontSize, $expected, ["max_height" => $initial]);
+    }
+
+    public function lineWidthProvider(): array
+    {
+        return [
+            // Keywords
+            ["thin", 12.0, 0.5],
+            ["medium", 12.0, 1.5],
+            ["thick", 12.0, 2.5],
+
+            // Lengths
+            ["0", 12.0, 0.0],
+            ["1em", 20.0, 20.0],
+            ["100pt", 12.0, 100.0],
+
+            // Case variations
+            ["THIN", 12.0, 0.5],
+            ["Medium", 12.0, 1.5],
+            ["thICK", 12.0, 2.5],
+            ["1EM", 20.0, 20.0],
+
+            // Invalid values
+            ["auto", 12.0, 5.0, 5.0, 5.0],
+            ["none", 12.0, 5.0, 5.0, 5.0],
+            ["-100pt", 12.0, 5.0, 5.0, 5.0],
+            ["50%", 12.0, 5.0, 5.0, 5.0],
+            ["-50%", 12.0, 5.0, 5.0, 5.0]
+        ];
+    }
+
+    /**
+     * @dataProvider lineWidthProvider
+     */
+    public function testBorderOutlineWidth(
+        string $value,
+        float $fontSize,
+        $expectedStyleSolid,
+        $expectedStyleNone = 0.0,
+        $initial = "50.0"
+    ): void {
+        $props = ["border_top", "border_right", "border_bottom", "border_left", "outline"];
+
+        foreach ($props as $prop) {
+            $initialPropsSolid = [
+                "{$prop}_width" => $initial,
+                "{$prop}_style" => "solid"
+            ];
+            $initialPropsNone = [
+                "{$prop}_width" => $initial,
+                "{$prop}_style" => "none"
+            ];
+
+            $this->testLengthProperty("{$prop}_width", $value, $fontSize, $expectedStyleSolid, $initialPropsSolid);
+            $this->testLengthProperty("{$prop}_width", $value, $fontSize, $expectedStyleNone, $initialPropsNone);
+        }
+    }
+
     public function counterIncrementProvider(): array
     {
         return [
-            // Valid values
+            // Keywords
             ["none", "none"],
+
+            // Valid values
             ["c", ["c" => 1]],
             ["c1 c2 c3", ["c1" => 1, "c2" => 1, "c3" => 1]],
             ["c 0", ["c" => 0]],
@@ -151,9 +354,14 @@ class StyleTest extends TestCase
             ["c1 -5 c2 2", ["c1" => -5, "c2" => 2]],
             ["c1 -5 c2", ["c1" => -5, "c2" => 1]],
             ["c1 c2 2", ["c1" => 1, "c2" => 2]],
+            ["UPPER lower", ["UPPER" => 1, "lower" => 1]],
 
             // Duplicate counter
             ["c 2 c 4", ["c" => 6]],
+
+            // Case and whitespace variations
+            ["NONE", "none"],
+            ["UPPER\tlower       \n   5", ["UPPER" => 1, "lower" => 5]],
 
             // Invalid values
             ["", "none"],
@@ -185,8 +393,10 @@ class StyleTest extends TestCase
     public function counterResetProvider(): array
     {
         return [
-            // Valid values
+            // Keywords
             ["none", "none"],
+
+            // Valid values
             ["c", ["c" => 0]],
             ["c1 c2 c3", ["c1" => 0, "c2" => 0, "c3" => 0]],
             ["c 0", ["c" => 0]],
@@ -195,9 +405,14 @@ class StyleTest extends TestCase
             ["c1 -5 c2 2", ["c1" => -5, "c2" => 2]],
             ["c1 -5 c2", ["c1" => -5, "c2" => 0]],
             ["c1 c2 2", ["c1" => 0, "c2" => 2]],
+            ["UPPER lower", ["UPPER" => 0, "lower" => 0]],
 
             // Duplicate counter
             ["c 2 c 4", ["c" => 4]],
+
+            // Case and whitespace variations
+            ["NONE", "none"],
+            ["UPPER\tlower       \n   5", ["UPPER" => 0, "lower" => 5]],
 
             // Invalid values
             ["", "none"],
@@ -231,14 +446,22 @@ class StyleTest extends TestCase
         $autoResolved = [['"', '"'], ["'", "'"]];
 
         return [
-            // Valid values
+            // Keywords
             ["none", "none"],
             ["auto", $autoResolved],
+
+            // Valid values
             ["'\"' '\"'", [['"', '"']]],
             [" '\"'   '\"'   \"'\"   \"'\" ", [['"', '"'], ["'", "'"]]],
             ["'“' '”' '‘' '’'", [['“', '”'], ['‘', '’']]],
             ["'open-quote' 'close-quote'", [["open-quote", "close-quote"]]],
             ["'😀️' '😐️' '\"2\"' '\"2\"' '›' '‹'", [['😀️', '😐️'], ['"2"', '"2"'], ['›', '‹']]],
+
+            // Case and whitespace variations
+            ["NONE", "none"],
+            ["Auto", $autoResolved],
+            ["AUTO", $autoResolved],
+            ["'\"'    '\"'", [['"', '"']]],
 
             // Invalid values
             ["'\''", $autoResolved]
@@ -261,7 +484,7 @@ class StyleTest extends TestCase
     public function contentProvider(): array
     {
         return [
-            // Valid values
+            // Keywords
             ["normal", "normal"],
             ["none", "none"],
 
@@ -274,30 +497,35 @@ class StyleTest extends TestCase
 
             // Attr
             ["attr(title)", [new Attr("title")]],
-            ["ATTR(  TITLE )", [new Attr("title")]],
 
             // Url
             ["url(image.png)", [new Url("image.png")]],
+            ['url("image.png")', [new Url("image.png")]],
             ["url('image.png')", [new Url("image.png")]],
-            ['url(  "image.png"  )', [new Url("image.png")]],
-            ["URL(\"'image.PNG'\")", [new Url("'image.PNG'")]],
+            ["url(\"'image.PNG'\")", [new Url("'image.PNG'")]],
 
             // Counter/Counters
             ["counter(c)", [new Counter("c", "decimal")]],
-            ["COUNTER(  UPPER  ,  UPPER-roman  )", [new Counter("UPPER", "upper-roman")]],
+            ["counter(UPPER, UPPER-roman)", [new Counter("UPPER", "upper-roman")]],
             ["counters(c, '')", [new Counters("c", "", "decimal")]],
             ["counters(c, '', decimal)", [new Counters("c", "", "decimal")]],
-            ["COUNTERS(  UPPER  ,  'UPPER'  , lower-ROMAN  )", [new Counters("UPPER", "UPPER", "lower-roman")]],
+            ["counters(UPPER, 'UPPER', lower-ROMAN)", [new Counters("UPPER", "UPPER", "lower-roman")]],
 
             // Quotes
             ["open-quote", [new OpenQuote]],
-            ["OPEN-QUOTE", [new OpenQuote]],
             ["close-quote", [new CloseQuote]],
-            ["CLOSE-QUOTE", [new CloseQuote]],
             ["no-open-quote", [new NoOpenQuote]],
-            ["NO-OPEN-QUOTE", [new NoOpenQuote]],
             ["no-close-quote", [new NoCloseQuote]],
-            ["NO-CLOSE-QUOTE", [new NoCloseQuote]],
+
+            // Case and whitespace variations
+            ["Normal", "normal"],
+            ["NONE", "none"],
+            ["ATTR(  TITLE )", [new Attr("title")]],
+            ["URL( \n\t \"'image.PNG ' \"  )", [new Url("'image.PNG ' ")]],
+            ["COUNTER(  UPPER  ,  UPPER-roman  )", [new Counter("UPPER", "upper-roman")]],
+            ["COUNTERS(  UPPER  ,  ' \"UPPER\"'  , lower-ROMAN  )", [new Counters("UPPER", " \"UPPER\"", "lower-roman")]],
+            ["OPEN-QUOTE", [new OpenQuote]],
+            ["No-Close-Quote", [new NoCloseQuote]],
 
             // Content lists
             [
@@ -309,7 +537,7 @@ class StyleTest extends TestCase
                 [new Counter("page", "decimal"), new StringPart(" / {PAGES}")]
             ],
             [
-                "counter(li1, decimal)\".\"counters(li2, '.', upper-roman)  ')'URL('IMAGE.png')",
+                "counter(li1, decimal)\".\"counters(li2, '.', upper-roman)   ')'URL('IMAGE.png')",
                 [new Counter("li1", "decimal"), new StringPart("."), new Counters("li2", ".", "upper-roman"), new StringPart(")"), new Url("IMAGE.png")]
             ],
             [
@@ -328,6 +556,7 @@ class StyleTest extends TestCase
             ["counters(c, decimal)", "normal"],
             ["open-quoteclose-quote", "normal"],
             ["😀️()", "normal"],
+            ["attr(title) unknown-keyword", "normal"],
 
             // Reserved names
             ["counter(none)", "normal"],
@@ -385,18 +614,29 @@ class StyleTest extends TestCase
     public function sizeProvider(): array
     {
         return [
-            // Valid values
+            // Keywords
             ["auto", "auto"],
+
+            // Default paper sizes
             ["letter", [612.00, 792.00]],
             ["portrait", [419.53, 595.28]],
             ["landscape", [595.28, 419.53]],
             ["A4 portrait", [595.28, 841.89]],
             ["landscape a4", [841.89, 595.28]],
+
+            // Custom paper sizes
             ["200pt", [200.0, 200.0]],
             ["400pt 300pt", [400.0, 300.0]],
             ["400pt 300pt portrait", [300.0, 400.0]],
             ["landscape 300pt 400pt", [400.0, 300.0]],
             ["landscape 400pt 300pt", [400.0, 300.0]],
+
+            // Case and whitespace variations
+            ["Auto", "auto"],
+            ["AUTO", "auto"],
+            ["LETTER", [612.00, 792.00]],
+            ["a4    PORTRAIT", [595.28, 841.89]],
+            ["LANDSCAPE\n400PT    300PT", [400.0, 300.0]],
 
             // Invalid values
             ["", "auto"],
@@ -471,6 +711,9 @@ class StyleTest extends TestCase
             ["+23", 23],
             ["-100", -100],
 
+            // Case variations
+            ["AUTO", "auto"],
+
             // Invalid values
             ["", "auto"],
             ["5.5", "auto"],
@@ -489,27 +732,6 @@ class StyleTest extends TestCase
 
         $style->set_prop("z_index", $value);
         $this->assertSame($expected, $style->z_index);
-    }
-
-    public function valueCaseProvider(): array
-    {
-        return [
-            ["width", "Auto",           "width", "auto"],
-            ["list-style-type", "A",    "list_style_type", "A"],
-        ];
-    }
-
-    /**
-     * @dataProvider valueCaseProvider
-     */
-    public function testValueCase(string $cssProp, string $inputValue, string $phpProp, string $expectValue): void
-    {
-        $dompdf = new Dompdf();
-        $sheet = new Stylesheet($dompdf);
-        $style = new Style($sheet);
-
-        $style->set_prop($cssProp, $inputValue);
-        $this->assertSame($expectValue, $style->$phpProp);
     }
 
     public function testWordBreakBreakWord(): void

--- a/tests/GeneratedContentTest.php
+++ b/tests/GeneratedContentTest.php
@@ -202,6 +202,220 @@ HTML
 
             // Tests from the CSS2.1 Conformance Test Suite
             // http://test.csswg.org/suites/css21_dev/20110323/
+            "counters-scope-000" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Counter scope</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#scope">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  .scope { counter-reset: c 1; }
+  .scope:before, .scope:after { content: counter(c); }
+  .c:before { content: counter(c); }
+
+  .one:before { counter-reset: c 2; }
+  .two { counter-reset: c 3; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The next 2 lines should be identical:</p>
+
+ <div>
+   <span class="scope"><span class="one c"><span class="c"></span></span><span class="c"></span></span><span class="c"></span>
+   <span class="scope"><span class="two c"><span class="c"></span></span><span class="c"></span></span><span class="c"></span>
+ </div>
+
+ <div>
+   122111
+   133331
+ </div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "122111 133331",
+                        "122111 133331"
+                    ]
+                ]
+            ],
+            "counters-scope-001" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Counter scope and nesting on elements</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#scope">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  span:before { counter-increment: c 1; content: "B" counters(c,".") "-" }
+  span:after  { counter-increment: c 1; content: "A" counters(c,".") "-" }
+
+  body, span#reset { counter-reset: c 0; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following two lines should be the same:</p>
+
+ <div><span><span><span id="reset"><span></span><span></span></span><span><span></span></span></span></span></div>
+ <div>B1-B2-B2.1-B2.2-A2.3-B2.4-A2.5-A2.6-B2.7-B2.8-A2.9-A2.10-A2.11-A3-</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "B1-B2-B2.1-B2.2-A2.3-B2.4-A2.5-A2.6-B2.7-B2.8-A2.9-A2.10-A2.11-A3-",
+                        "B1-B2-B2.1-B2.2-A2.3-B2.4-A2.5-A2.6-B2.7-B2.8-A2.9-A2.10-A2.11-A3-"
+                    ]
+                ]
+            ],
+            "counters-scope-002" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Counter scope and nesting on :before</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#scope">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  span:before { counter-increment: c 1; content: "B" counters(c,".") "-" }
+  span:after  { counter-increment: c 1; content: "A" counters(c,".") "-" }
+
+  body, span#reset:before { counter-reset: c 0; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following two lines should be the same:</p>
+
+ <div><span><span id="reset"><span></span></span></span></div>
+ <div>B1-B1.1-B1.2-A1.3-A1.4-A2-</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "B1-B1.1-B1.2-A1.3-A1.4-A2-",
+                        "B1-B1.1-B1.2-A1.3-A1.4-A2-"
+                    ]
+                ]
+            ],
+            "counters-scope-003" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Counter scope and nesting on :after</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#scope">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  span:before { counter-increment: c 1; content: "B" counters(c,".") "-" }
+  span:after  { counter-increment: c 1; content: "A" counters(c,".") "-" }
+
+  body, span#reset:after { counter-reset: c 0; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The following two lines should be the same:</p>
+
+ <div><span><span id="reset"><span></span></span></span></div>
+ <div>B1-B2-B3-A4-A4.1-A5-</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "B1-B2-B3-A4-A4.1-A5-",
+                        "B1-B2-B3-A4-A4.1-A5-"
+                    ]
+                ]
+            ],
+            "counters-scope-004" => [
+                <<<HTML
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <title>CSS Test: Counter scope and nesting</title>
+  <link rel="author" title="L. David Baron" href="http://dbaron.org/">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#scope">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter">
+  <style type="text/css">
+
+  body { white-space: nowrap; }
+
+
+  .reset { counter-reset: c; }
+  .rb:before { counter-reset: c; content: "R"; }
+  .use { counter-increment: c; }
+  .use:before { content: counters(c, ".") " "; }
+
+  </style>
+ </head>
+ <body>
+
+ <p>The next two lines should be the same:</p>
+
+ <div><span class="reset"></span><span class="use"></span><span class="reset"></span><span class="use"></span><span class="rb"><span class="use"></span><span class="reset"></span><span class="use"></span></span></div>
+ <div>1 1 R1.1 1.1</div>
+
+ </body>
+</html>
+HTML
+,
+                [
+                    "div" => [
+                        "1 1 R1.1 1.1",
+                        "1 1 R1.1 1.1"
+                    ]
+                ]
+            ],
             "counters-scope-implied-000" => [
                 <<<HTML
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">


### PR DESCRIPTION
* **Improve handling of case-insensitivity during style parsing**
Handle case-insensitivity individually per property: Keywords need to be handled case-insensitively, but custom identifiers are case-sensitive; whether something is a keyword or a custom identifier depends on the property in question (e.g. `THIN` is to be treated equivalently to `thin` when parsed as border style, but as a counter name, `THIN` is distinct from `thin`).
* **Remove support for HTML-compatibility `list-style-type` values in CSS**
These are neither in the specs, nor supported by current browsers. The values are mapped to regular counter-style names in the `AttributeTranslator` class now. To clarify: `type="A"` is still supported in HTML, and translated to `list-style-type: upper-alpha;`, but support for `list-style-type: A;` is removed (treated as `list-style-type: decimal;` now because the name is unrecognized).
* **Move `content` property parsing to the `Style` class**
  * Compute the `content` and `quotes` properties to drop invalid  declarations, and make the parsing stricter
  * Do not lower-case the counter name and string arguments for the  `counter` and `counters` functions
  * Only strip outer quotes when parsing CSS strings (e.g.  `content: "'Quoted'"`; would result in the string `Quoted` instead of  `'Quoted'`)
  * Properly inherit the `auto` value for the `quotes` property (will  only make a difference when auto quotes consider the current language)
  * As long as we are dealing with ASCII-only string parts, we don't  need to use the `mb_*` functions
* **Improve `list-style` shorthand parsing**
* **Improve `background-position` parsing**

https://www.w3.org/TR/css-content-3/#content-property
https://www.w3.org/TR/CSS2/generate.html#list-style
https://www.w3.org/TR/css-counter-styles-3/#predefined-counters

Regarding the HTML-compatibility values for `list-style-type`: We could also retain support for these values in CSS as a legacy feature if desired.