### PR TITLE
Use uppercase Imagick format

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5706,7 +5706,7 @@ EOT;
             }
 
             $imagick = new \Imagick($file);
-            $imagick->setFormat('png');
+            $imagick->setFormat('PNG');
 
             // Get opacity channel (negative of alpha channel)
             if ($imagick->getImageAlphaChannel()) {

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5716,7 +5716,14 @@ EOT;
                 if (\Imagick::getVersion()['versionNumber'] < 1800) {
                     $alpha_channel->negateImage(true);
                 }
-                $alpha_channel->writeImage($tempfile_alpha);
+
+                try {
+                    $alpha_channel->writeImage($tempfile_alpha);
+                } catch (\ImagickException $th) {
+                    // Backwards compatible retry attempt in case the IMagick policy is still configured in lowercase
+                    $alpha_channel->setFormat('png');
+                    $alpha_channel->writeImage($tempfile_alpha);
+                }
 
                 // Cast to 8bit+palette
                 $imgalpha_ = @imagecreatefrompng($tempfile_alpha);


### PR DESCRIPTION
The canonical way to represent ImageMagick formats is uppercase. ImageMagick generally does not care and will still work with lowercase formats except when applying coders policies from policy.xml as these are case sensitive. In this instance, lowercase formats would fail the policy despite being authorized.

Here is the policy suggested by ImageMagick that previously failed :
```xml
<policy domain="delegate" rights="none" pattern="*" />
<policy domain="filter" rights="none" pattern="*" />
<policy domain="coder" rights="none" pattern="*" />
<policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,WEBP,BMP}" />
```

It fails because PNG is listed in uppercase on the last line. The current workaround is to add the lowercase version like so :
```xml
<policy domain="coder" rights="read|write" pattern="{GIF,JPEG,PNG,png,WEBP,BMP}" />
```

I'm submitting the PR because I believe some hosts come with a restrictive policy and will not allow you to customize this policy. This would allow using this library on such hosts and to provide a better experience to ImageMagick users.