### PR TITLE
Make exception of corrupt tables fetchable

### DIFF
--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -37,6 +37,9 @@ class TableCell extends Block
         $style = $this->_frame->get_style();
 
         $table = TableFrameDecorator::find_parent_table($this->_frame);
+
+        if(is_null($table)) throw new Exception("table corrupt");
+
         $cellmap = $table->get_cellmap();
 
         list($x, $y) = $cellmap->get_frame_position($this->_frame);

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -38,7 +38,7 @@ class TableCell extends Block
 
         $table = TableFrameDecorator::find_parent_table($this->_frame);
 
-        if(is_null($table)) throw new Exception("table corrupt");
+        if(is_null($table)) throw new \Exception("table corrupt");
 
         $cellmap = $table->get_cellmap();
 


### PR DESCRIPTION
Our customers can enter html by their own. When they forget to close a tr element for example, there is an uncaught exception because get_cellmap is executed on null. To fetch this we add a simple exception. 