### PR TITLE
Make all test providers static

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         package-release: [dist]
         extensions: ['gd']
         include:
@@ -27,7 +27,7 @@ jobs:
             extensions: 'imagick'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-gd": "*",
         "ext-json": "*",
         "ext-zip": "*",
-        "phpunit/phpunit": "^7.5 || ^8 || ^9",
+        "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10",
         "squizlabs/php_codesniffer": "^3.5",
         "mockery/mockery": "^1.3",
         "symfony/process": "^4.4 || ^5.4 || ^6.2"

--- a/tests/Css/AttributeTranslatorTest.php
+++ b/tests/Css/AttributeTranslatorTest.php
@@ -7,7 +7,7 @@ use Dompdf\Tests\TestCase;
 
 final class AttributeTranslatorTest extends TestCase
 {
-    public function attributeToStyleTranslationProvider(): array
+    public static function attributeToStyleTranslationProvider(): array
     {
         return [
             // TODO: Heredocs can be nicely indented starting with PHP 7.3

--- a/tests/Css/ColorTest.php
+++ b/tests/Css/ColorTest.php
@@ -6,7 +6,7 @@ use Dompdf\Tests\TestCase;
 
 class ColorTest extends TestCase
 {
-    public function validColorProvider(): array
+    public static function validColorProvider(): array
     {
         return [
             // Color names

--- a/tests/Css/SelectorTest.php
+++ b/tests/Css/SelectorTest.php
@@ -37,7 +37,7 @@ class SelectorTest extends TestCase
         return preg_replace($patterns, $replacements, $selector);
     }
 
-    public function selectorMatchesProvider(): array
+    public static function selectorMatchesProvider(): array
     {
         // Elements expected to matched by each selector are marked with the
         // attribute `data-match`. The optional third parameter defines whether
@@ -788,7 +788,7 @@ class SelectorTest extends TestCase
         }
     }
 
-    public function selectorInvalidProvider(): array
+    public static function selectorInvalidProvider(): array
     {
         return [
             // Valid but unsupported selector syntax

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -17,7 +17,7 @@ class ShorthandTest extends TestCase
         return new Style($sheet);
     }
 
-    public function marginPaddingShorthandProvider(): array
+    public static function marginPaddingShorthandProvider(): array
     {
         return [
             ["5pt", "5pt", "5pt", "5pt", "5pt"],
@@ -103,7 +103,7 @@ class ShorthandTest extends TestCase
         $this->assertSame($left, $style->get_specified("border_left_{$type}"));
     }
 
-    public function borderWidthShorthandProvider(): array
+    public static function borderWidthShorthandProvider(): array
     {
         return [
             ["thin", "thin", "thin", "thin", "thin"],
@@ -126,7 +126,7 @@ class ShorthandTest extends TestCase
         $this->borderTypeShorthandTest("width", $value, $top, $right, $bottom, $left);
     }
 
-    public function borderStyleShorthandProvider(): array
+    public static function borderStyleShorthandProvider(): array
     {
         return [
             ["solid", "solid", "solid", "solid", "solid"],
@@ -149,7 +149,7 @@ class ShorthandTest extends TestCase
         $this->borderTypeShorthandTest("style", $value, $top, $right, $bottom, $left);
     }
 
-    public function borderColorShorthandProvider(): array
+    public static function borderColorShorthandProvider(): array
     {
         return [
             ["transparent", "transparent", "transparent", "transparent", "transparent"],
@@ -172,7 +172,7 @@ class ShorthandTest extends TestCase
         $this->borderTypeShorthandTest("color", $value, $top, $right, $bottom, $left);
     }
 
-    public function borderShorthandProvider(): array
+    public static function borderShorthandProvider(): array
     {
         return [
             ["transparent", "medium", "none", "transparent"],
@@ -206,7 +206,7 @@ class ShorthandTest extends TestCase
         }
     }
 
-    public function outlineShorthandProvider(): array
+    public static function outlineShorthandProvider(): array
     {
         return [
             ["transparent", "medium", "none", "transparent"],
@@ -236,7 +236,7 @@ class ShorthandTest extends TestCase
         $this->assertSame($expectedColor, $style->get_specified("outline_color"));
     }
 
-    public function borderRadiusShorthandProvider(): array
+    public static function borderRadiusShorthandProvider(): array
     {
         return [
             ["5pt", "5pt", "5pt", "5pt", "5pt"],
@@ -265,7 +265,7 @@ class ShorthandTest extends TestCase
         $this->assertSame($bl, $style->get_specified("border_bottom_left_radius"));
     }
 
-    public function backgroundShorthandProvider(): array
+    public static function backgroundShorthandProvider(): array
     {
         $basePath = realpath(__DIR__ . "/..");
         $imagePath = "$basePath/_files/jamaica.jpg";
@@ -303,7 +303,7 @@ class ShorthandTest extends TestCase
         $this->assertSame($color, $style->get_specified("background_color"));
     }
 
-    public function fontShorthandProvider(): array
+    public static function fontShorthandProvider(): array
     {
         return [
             ["8.5mm Helvetica", "normal", "normal", 400, "8.5mm", "normal", "helvetica"],
@@ -339,7 +339,7 @@ class ShorthandTest extends TestCase
         $this->assertSame($fontFamily, $style->get_specified("font_family"));
     }
 
-    public function listStyleShorthandProvider(): array
+    public static function listStyleShorthandProvider(): array
     {
         $basePath = realpath(__DIR__ . "/..");
         $imagePath = "$basePath/_files/jamaica.jpg";

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -19,7 +19,7 @@ use Dompdf\Tests\TestCase;
 
 class StyleTest extends TestCase
 {
-    public function lengthInPtProvider(): array
+    public static function lengthInPtProvider(): array
     {
         return [
             ["auto", null, "auto"],
@@ -49,7 +49,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
-    public function cssImageBasicProvider(): array
+    public static function cssImageBasicProvider(): array
     {
         return [
             "no value" => ["", "none"],
@@ -60,7 +60,7 @@ class StyleTest extends TestCase
         ];
     }
 
-    public function cssImageNoBaseHrefProvider(): array
+    public static function cssImageNoBaseHrefProvider(): array
     {
         $basePath = realpath(__DIR__ . "/..");
         return [
@@ -69,7 +69,7 @@ class StyleTest extends TestCase
         ];
     }
 
-    public function cssImageWithBaseHrefProvider(): array
+    public static function cssImageWithBaseHrefProvider(): array
     {
         $basePath = realpath(__DIR__ . "/..");
         return [
@@ -78,7 +78,7 @@ class StyleTest extends TestCase
         ];
     }
 
-    public function cssImageWithStylesheetBaseHrefProvider(): array
+    public static function cssImageWithStylesheetBaseHrefProvider(): array
     {
         return [
             "local absolute" => ["url(/_files/jamaica.jpg)", "https://example.com/_files/jamaica.jpg"],
@@ -139,7 +139,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $s->background_image);
     }
 
-    public function backgroundPositionProvider(): array
+    public static function backgroundPositionProvider(): array
     {
         return [
             // One value
@@ -213,7 +213,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->background_position);
     }
 
-    public function fontWeightProvider(): array
+    public static function fontWeightProvider(): array
     {
         return [
             // Absolute
@@ -300,7 +300,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->$prop);
     }
 
-    public function widthHeightProvider(): array
+    public static function widthHeightProvider(): array
     {
         return [
             // Keywords
@@ -340,7 +340,7 @@ class StyleTest extends TestCase
         $this->testLengthProperty("height", $value, $fontSize, $expected, ["height" => $initial]);
     }
 
-    public function minWidthHeightProvider(): array
+    public static function minWidthHeightProvider(): array
     {
         return [
             // Keywords
@@ -382,7 +382,7 @@ class StyleTest extends TestCase
         $this->testLengthProperty("min_height", $value, $fontSize, $expected, ["min_height" => $initial]);
     }
 
-    public function maxWidthHeightProvider(): array
+    public static function maxWidthHeightProvider(): array
     {
         return [
             // Keywords
@@ -424,7 +424,7 @@ class StyleTest extends TestCase
         $this->testLengthProperty("max_height", $value, $fontSize, $expected, ["max_height" => $initial]);
     }
 
-    public function lineWidthProvider(): array
+    public static function lineWidthProvider(): array
     {
         return [
             // Keywords
@@ -479,7 +479,7 @@ class StyleTest extends TestCase
         }
     }
 
-    public function counterIncrementProvider(): array
+    public static function counterIncrementProvider(): array
     {
         return [
             // Keywords
@@ -530,7 +530,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->counter_increment);
     }
 
-    public function counterResetProvider(): array
+    public static function counterResetProvider(): array
     {
         return [
             // Keywords
@@ -581,7 +581,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->counter_reset);
     }
 
-    public function quotesProvider(): array
+    public static function quotesProvider(): array
     {
         $autoResolved = [['"', '"'], ["'", "'"]];
 
@@ -621,7 +621,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->quotes);
     }
 
-    public function contentProvider(): array
+    public static function contentProvider(): array
     {
         return [
             // Keywords
@@ -751,7 +751,7 @@ class StyleTest extends TestCase
         }
     }
 
-    public function sizeProvider(): array
+    public static function sizeProvider(): array
     {
         return [
             // Keywords
@@ -801,7 +801,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->size);
     }
 
-    public function opacityProvider(): array
+    public static function opacityProvider(): array
     {
         return [
             // Valid values
@@ -841,7 +841,7 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->opacity);
     }
 
-    public function zIndexProvider(): array
+    public static function zIndexProvider(): array
     {
         return [
             // Valid values

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -77,7 +77,7 @@ class DompdfTest extends TestCase
         $this->assertEquals('', $dompdf->getDom()->textContent);
     }
 
-    public function callbacksProvider(): array
+    public static function callbacksProvider(): array
     {
         return [
             ["begin_page_reflow", 1],
@@ -138,7 +138,7 @@ class DompdfTest extends TestCase
         $this->assertSame(2, $called);
     }
 
-    public function customCanvasProvider(): array
+    public static function customCanvasProvider(): array
     {
         return [
             ["A4", "portrait", true, "auto"],

--- a/tests/GeneratedContentTest.php
+++ b/tests/GeneratedContentTest.php
@@ -7,7 +7,7 @@ use Dompdf\Tests\TestCase;
 
 final class GeneratedContentTest extends TestCase
 {
-    public function countersProvider(): array
+    public static function countersProvider(): array
     {
         return [
             // TODO: Heredocs can be nicely indented starting with PHP 7.3

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -21,7 +21,7 @@ AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
         );
     }
 
-    public function dec2RomanProvider(): array
+    public static function dec2RomanProvider(): array
     {
         return [
             [-5, "-5"],
@@ -43,7 +43,7 @@ AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
         $this->assertSame($expected, $roman);
     }
 
-    public function lengthEqualProvider(): array
+    public static function lengthEqualProvider(): array
     {
         // Adapted from
         // https://floating-point-gui.de/errors/NearlyEqualsTest.java

--- a/tests/LayoutTest/ImageTest.php
+++ b/tests/LayoutTest/ImageTest.php
@@ -9,7 +9,7 @@ use Dompdf\Tests\TestCase;
 
 class ImageTest extends TestCase
 {
-    public function imageDimensionsProvider(): array
+    public static function imageDimensionsProvider(): array
     {
         $filepath = "../_files/jamaica.jpg";
         $dpiFactor = 72 / 96;

--- a/tests/LayoutTest/PageTest.php
+++ b/tests/LayoutTest/PageTest.php
@@ -10,7 +10,7 @@ use Dompdf\Tests\TestCase;
 
 class PageTest extends TestCase
 {
-    public function pageBreakProvider(): array
+    public static function pageBreakProvider(): array
     {
         return [
             // TODO: Heredocs can be nicely indented starting with PHP 7.3

--- a/tests/Renderer/RendererTest.php
+++ b/tests/Renderer/RendererTest.php
@@ -22,7 +22,7 @@ class RendererTest extends TestCase
     }
 
     /**
-     * @dataProvider providerTestResizeBackgroundImage
+     * @dataProvider testResizeBackgroundImageProvider
      */
     public function testResizeBackgroundImage(
         $img_width,
@@ -48,7 +48,7 @@ class RendererTest extends TestCase
         $this->assertEquals([$new_img_width, $new_img_height], $result);
     }
 
-    public function providerTestResizeBackgroundImage()
+    public static function testResizeBackgroundImageProvider(): array
     {
         return [
             "cover scale up" => [100.0, 200.0, 400.0, 300.0, "cover", 400.0, 800.0],


### PR DESCRIPTION
Ref: https://sources.debian.org/src/php-dompdf/2.0.3+dfsg-2/debian/patches/0004-Adapt-for-phpunit-10.patch/

This has no backwards compatibility breaks.
But makes phpunit 10 happy
