### PR TITLE
Allow negative length values when part of `calc()`

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1134,14 +1134,14 @@ class Style
             if ($part === '(') {
                 $opStack[] = $part;
             } elseif ($part === ')') {
-                while (count($opStack) > 0 && end($opStack) !== '(') {
+                while (\count($opStack) > 0 && end($opStack) !== '(') {
                     $queue[] = array_pop($opStack);
                 }
                 if (end($opStack) === '(') {
                     array_pop($opStack);
                 }
-            } elseif (array_key_exists($part, $precedence)) {
-                while (count($opStack) > 0 && end($opStack) !== '(' && $precedence[end($opStack)] >= $precedence[$part]) {
+            } elseif (\array_key_exists($part, $precedence)) {
+                while (\count($opStack) > 0 && end($opStack) !== '(' && $precedence[end($opStack)] >= $precedence[$part]) {
                     $queue[] = array_pop($opStack);
                 }
                 $opStack[] = $part;
@@ -1150,7 +1150,7 @@ class Style
             }
         }
 
-        while (count($opStack) > 0) {
+        while (\count($opStack) > 0) {
             $queue[] = array_pop($opStack);
         }
 
@@ -1166,7 +1166,7 @@ class Style
      */
     private function evaluate_func_calc(array $rpn, float $ref_size = 0, ?float $font_size = null): ?float
     {
-        if (count($rpn) === 0) {
+        if (\count($rpn) === 0) {
             return null;
         }
 
@@ -1175,7 +1175,7 @@ class Style
         $stack = [];
 
         foreach ($rpn as $part) {
-            if (in_array($part, $ops, true)) {
+            if (\in_array($part, $ops, true)) {
                 $rightValue = array_pop($stack);
                 $leftValue = array_pop($stack);
                 switch ($part) {
@@ -1204,7 +1204,7 @@ class Style
             }
         }
 
-        if (count($stack) > 1) {
+        if (\count($stack) > 1) {
             return null;
         }
 

--- a/src/FrameDecorator/Text.php
+++ b/src/FrameDecorator/Text.php
@@ -199,7 +199,8 @@ class Text extends AbstractFrameDecorator
      * Determines the optimal font that applies to the frame and splits
      * the frame where the optimal font changes.
      */
-    function apply_font_mapping() {
+    function apply_font_mapping(): void
+    {
         if (!empty($this->mapped_font)) {
             return;
         }

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -388,7 +388,6 @@ class Text extends AbstractFrameReflower
         }
 
         $style = $frame->get_style();
-        $font_metrics = $this->getFontMetrics();
 
         // Handle text transform and white space
         $frame->set_text($this->pre_process_text($frame->get_text()));

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -344,7 +344,34 @@ class StyleTest extends TestCase
         ];
     }
 
-    public static function widthHeightProvider(): array
+    public static function lengthPercentageProvider(): array
+    {
+        return [
+            // Lengths
+            ["0", 12.0, 0.0],
+            ["1em", 20.0, 20.0],
+            ["100pt", 12.0, 100.0],
+            ["-100pt", 12.0, -100.0],
+            ["50%", 12.0, "50%"],
+            ["-50%", 12.0, "-50%"],
+
+            // Calc values
+            ["calc(6pt - 2em)", 12.0, -18.0],
+            ["calc(50% + 2em)", 12.0, "calc(50% + 2em)"],
+            ["calc(100% - 100pt)", 12.0, "calc(100% - 100pt)"],
+            ["calc(-100pt)", 12.0, -100.0],
+            ["calc(-50%)", 12.0, "calc(-50%)"],
+
+            // Case variations
+            ["1EM", 20.0, 20.0],
+
+            // Invalid values
+            ["invalid", 12.0, 79.0, 79.0],
+            ["-50% + 2em", 12.0, 79.0, 79.0]
+        ];
+    }
+
+    public static function autoKeywordProvider(): array
     {
         return [
             // Keywords
@@ -360,7 +387,7 @@ class StyleTest extends TestCase
     }
 
     /**
-     * @dataProvider widthHeightProvider
+     * @dataProvider autoKeywordProvider
      * @dataProvider lengthPercentagePositiveProvider
      */
     public function testWidth(string $value, float $fontSize, $expected, $initial = "auto"): void
@@ -369,7 +396,7 @@ class StyleTest extends TestCase
     }
 
     /**
-     * @dataProvider widthHeightProvider
+     * @dataProvider autoKeywordProvider
      * @dataProvider lengthPercentagePositiveProvider
      */
     public function testHeight(string $value, float $fontSize, $expected, $initial = "auto"): void
@@ -449,6 +476,71 @@ class StyleTest extends TestCase
         $this->testLengthProperty("max_height", $value, $fontSize, $expected, ["max_height" => $initial]);
     }
 
+    /**
+     * @dataProvider autoKeywordProvider
+     * @dataProvider lengthPercentageProvider
+     */
+    public function testBoxInset(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("top", $value, $fontSize, $expected, ["top" => $initial]);
+        $this->testLengthProperty("right", $value, $fontSize, $expected, ["right" => $initial]);
+        $this->testLengthProperty("bottom", $value, $fontSize, $expected, ["bottom" => $initial]);
+        $this->testLengthProperty("left", $value, $fontSize, $expected, ["left" => $initial]);
+    }
+
+    public static function marginProvider(): array
+    {
+        return [
+            // Keywords
+            ["auto", 12.0, "auto", 0.0],
+
+            // Legacy keywords
+            ["none", 12.0, 0.0, 0.0],
+
+            // Case variations
+            ["Auto", 12.0, "auto", 0.0],
+            ["AUTO", 12.0, "auto", 0.0],
+
+            // Invalid values
+            ["other", 12.0, 79.0, 79.0]
+        ];
+    }
+
+    /**
+     * @dataProvider marginProvider
+     * @dataProvider lengthPercentageProvider
+     */
+    public function testMargin(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("margin_top", $value, $fontSize, $expected, ["margin_top" => $initial]);
+        $this->testLengthProperty("margin_right", $value, $fontSize, $expected, ["margin_right" => $initial]);
+        $this->testLengthProperty("margin_bottom", $value, $fontSize, $expected, ["margin_bottom" => $initial]);
+        $this->testLengthProperty("margin_left", $value, $fontSize, $expected, ["margin_left" => $initial]);
+    }
+
+    public static function paddingProvider(): array
+    {
+        return [
+            // Legacy keywords
+            ["none", 12.0, 0.0, 0.0],
+
+            // Invalid values
+            ["auto", 12.0, 79.0, 79.0]
+        ];
+    }
+
+    /**
+     * @dataProvider paddingProvider
+     * @dataProvider lengthPercentagePositiveProvider
+     */
+    public function testPadding(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("padding_top", $value, $fontSize, $expected, ["padding_top" => $initial]);
+        $this->testLengthProperty("padding_right", $value, $fontSize, $expected, ["padding_right" => $initial]);
+        $this->testLengthProperty("padding_bottom", $value, $fontSize, $expected, ["padding_bottom" => $initial]);
+        $this->testLengthProperty("padding_left", $value, $fontSize, $expected, ["padding_left" => $initial]);
+    }
+
     public static function lineWidthProvider(): array
     {
         return [
@@ -507,6 +599,27 @@ class StyleTest extends TestCase
             $this->testLengthProperty("{$prop}_width", $value, $fontSize, $expectedStyleSolid, $initialPropsSolid);
             $this->testLengthProperty("{$prop}_width", $value, $fontSize, $expectedStyleNone, $initialPropsNone);
         }
+    }
+
+    public static function borderRadiusProvider(): array
+    {
+        return [
+            // Invalid values
+            ["auto", 12.0, 79.0, 79.0],
+            ["none", 12.0, 79.0, 79.0]
+        ];
+    }
+
+    /**
+     * @dataProvider borderRadiusProvider
+     * @dataProvider lengthPercentagePositiveProvider
+     */
+    public function testBorderRadius(string $value, float $fontSize, $expected, $initial = "auto"): void
+    {
+        $this->testLengthProperty("border_top_left_radius", $value, $fontSize, $expected, ["border_top_left_radius" => $initial]);
+        $this->testLengthProperty("border_top_right_radius", $value, $fontSize, $expected, ["border_top_right_radius" => $initial]);
+        $this->testLengthProperty("border_bottom_right_radius", $value, $fontSize, $expected, ["border_bottom_right_radius" => $initial]);
+        $this->testLengthProperty("border_bottom_left_radius", $value, $fontSize, $expected, ["border_bottom_left_radius" => $initial]);
     }
 
     public static function counterIncrementProvider(): array

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -50,7 +50,8 @@ class StyleTest extends TestCase
             ["calc(5pt - x)", 100, 0.0],                   // invalid
             ["calc((50% + 10) 1pt)", 100, 0.0],            // invalid - missing op
             ["calc(50% -1pt)", 100, 0.0],                  // invalid - missing op
-            ["calc((50% + 10) + 2pt))", 100, 0.0]          // invalid - extra bracket
+            ["calc((50% + 10) + 2pt))", 100, 0.0],         // invalid - extra bracket
+            ["calc(100pt / 0)", null, 0.0]                 // invalid - division by zero
         ];
     }
 
@@ -318,32 +319,49 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $style->$prop);
     }
 
-    public static function widthHeightProvider(): array
+    public static function lengthPercentagePositiveProvider(): array
     {
         return [
-            // Keywords
-            ["auto", 12.0, "auto", 0.0],
-
             // Lengths
             ["0", 12.0, 0.0],
             ["1em", 20.0, 20.0],
             ["100pt", 12.0, 100.0],
             ["50%", 12.0, "50%"],
 
+            // Calc values
+            ["calc(6pt + 2em)", 12.0, 30.0],
+            ["calc(50% + 2em)", 12.0, "calc(50% + 2em)"],
+            ["calc(100% - 100pt)", 12.0, "calc(100% - 100pt)"],
+            ["calc(-100pt)", 12.0, -100.0], // Negative calc values are valid
+            ["calc(-50%)", 12.0, "calc(-50%)"],
+
             // Case variations
-            ["Auto", 12.0, "auto", 0.0],
-            ["AUTO", 12.0, "auto", 0.0],
             ["1EM", 20.0, 20.0],
 
             // Invalid values
-            ["none", 12.0, "auto"],
-            ["-100pt", 12.0, "auto"],
-            ["-50%", 12.0, "auto"]
+            ["-100pt", 12.0, 79.0, 79.0],
+            ["-50%", 12.0, 79.0, 79.0]
+        ];
+    }
+
+    public static function widthHeightProvider(): array
+    {
+        return [
+            // Keywords
+            ["auto", 12.0, "auto", 0.0],
+
+            // Case variations
+            ["Auto", 12.0, "auto", 0.0],
+            ["AUTO", 12.0, "auto", 0.0],
+
+            // Invalid values
+            ["none", 12.0, 79.0, 79.0]
         ];
     }
 
     /**
      * @dataProvider widthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testWidth(string $value, float $fontSize, $expected, $initial = "auto"): void
     {
@@ -352,6 +370,7 @@ class StyleTest extends TestCase
 
     /**
      * @dataProvider widthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testHeight(string $value, float $fontSize, $expected, $initial = "auto"): void
     {
@@ -367,25 +386,18 @@ class StyleTest extends TestCase
             // Legacy keywords
             ["none", 12.0, "auto", 0.0],
 
-            // Lengths
-            ["0", 12.0, 0.0],
-            ["1em", 20.0, 20.0],
-            ["100pt", 12.0, 100.0],
-            ["50%", 12.0, "50%"],
-
             // Case variations
             ["Auto", 12.0, "auto", 0.0],
             ["AUTO", 12.0, "auto", 0.0],
-            ["1EM", 20.0, 20.0],
 
             // Invalid values
-            ["-100pt", 12.0, "auto"],
-            ["-50%", 12.0, "auto"]
+            ["other", 12.0, 79.0, 79.0]
         ];
     }
 
     /**
      * @dataProvider minWidthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testMinWidth(string $value, float $fontSize, $expected, $initial = "auto"): void
     {
@@ -394,6 +406,7 @@ class StyleTest extends TestCase
 
     /**
      * @dataProvider minWidthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testMinHeight(string $value, float $fontSize, $expected, $initial = "auto"): void
     {
@@ -409,25 +422,18 @@ class StyleTest extends TestCase
             // Legacy keywords
             ["auto", 12.0, "none", 0.0],
 
-            // Lengths
-            ["0", 12.0, 0.0],
-            ["1em", 20.0, 20.0],
-            ["100pt", 12.0, 100.0],
-            ["50%", 12.0, "50%"],
-
             // Case variations
             ["None", 12.0, "none", 0.0],
             ["NONE", 12.0, "none", 0.0],
-            ["1EM", 20.0, 20.0],
 
             // Invalid values
-            ["-100pt", 12.0, "none"],
-            ["-50%", 12.0, "none"]
+            ["other", 12.0, 79.0, 79.0]
         ];
     }
 
     /**
      * @dataProvider maxWidthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testMaxWidth(string $value, float $fontSize, $expected, $initial = "none"): void
     {
@@ -436,6 +442,7 @@ class StyleTest extends TestCase
 
     /**
      * @dataProvider maxWidthHeightProvider
+     * @dataProvider lengthPercentagePositiveProvider
      */
     public function testMaxHeight(string $value, float $fontSize, $expected, $initial = "none"): void
     {
@@ -455,6 +462,10 @@ class StyleTest extends TestCase
             ["1em", 20.0, 20.0],
             ["100pt", 12.0, 100.0],
 
+            // Calc values
+            ["calc(6pt + 2em)", 12.0, 30.0],
+            ["calc(-100pt)", 12.0, -100.0], // Negative calc values are valid
+
             // Case variations
             ["THIN", 12.0, 0.5],
             ["Medium", 12.0, 1.5],
@@ -466,7 +477,8 @@ class StyleTest extends TestCase
             ["none", 12.0, 5.0, 5.0, 5.0],
             ["-100pt", 12.0, 5.0, 5.0, 5.0],
             ["50%", 12.0, 5.0, 5.0, 5.0],
-            ["-50%", 12.0, 5.0, 5.0, 5.0]
+            ["-50%", 12.0, 5.0, 5.0, 5.0],
+            ["calc(50% + 2em)", 12.0, 5.0, 5.0, 5.0]
         ];
     }
 

--- a/tests/Renderer/RendererTest.php
+++ b/tests/Renderer/RendererTest.php
@@ -8,7 +8,7 @@ use Dompdf\Tests\TestCase;
 
 class RendererTest extends TestCase
 {
-    /** @var Renderer  */
+    /** @var Renderer */
     private $renderer;
 
     /** @var \ReflectionMethod */
@@ -22,7 +22,7 @@ class RendererTest extends TestCase
     }
 
     /**
-     * @dataProvider testResizeBackgroundImageProvider
+     * @dataProvider resizeBackgroundImageProvider
      */
     public function testResizeBackgroundImage(
         $img_width,
@@ -48,7 +48,7 @@ class RendererTest extends TestCase
         $this->assertEquals([$new_img_width, $new_img_height], $result);
     }
 
-    public static function testResizeBackgroundImageProvider(): array
+    public static function resizeBackgroundImageProvider(): array
     {
         return [
             "cover scale up" => [100.0, 200.0, 400.0, 300.0, "cover", 400.0, 800.0],


### PR DESCRIPTION
Fix declarations such as `calc(100% - 100pt)` being treated as invalid for width and height (and other non-negative length properties); because the percentage can only be resolved during layout, we cannot know whether final value is negative when computing the property.

Although declarations such as `calc(-100pt)` will always result in a negative value, browsers treat such declarations as valid and just treat it as `0` if negative values are disallowed for the property. I’m still looking into handling such cases during layout.