### PR TITLE
Misc fixes for table rendering and hyperlink handling

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -591,11 +591,15 @@ class Cellmap
                     $style->set_used("border_bottom_width", $bottom["width"] / 2);
                     $style->set_used("border_left_width", $left["width"] / 2);
                     $style->set_used("border_style", "none");
-                } else {
-                    // Clear borders for rows and row groups
-                    $style->set_used("border_width", 0);
-                    $style->set_used("border_style", "none");
                 }
+            }
+
+            if ($frame !== $this->_table) {
+                // Clear borders for rows and row groups. For the collapsed
+                // model, they have been resolved and are used by the cells now.
+                // For the separated model, they are ignored per spec
+                $style->set_used("border_width", 0);
+                $style->set_used("border_style", "none");
             }
 
             if ($frame === $this->_table) {

--- a/src/FrameDecorator/Image.php
+++ b/src/FrameDecorator/Image.php
@@ -43,7 +43,9 @@ class Image extends AbstractFrameDecorator
     function __construct(Frame $frame, Dompdf $dompdf)
     {
         parent::__construct($frame, $dompdf);
-        $url = $frame->get_node()->getAttribute("src");
+
+        $node = $frame->get_node();
+        $url = $node->getAttribute("src");
 
         $debug_png = $dompdf->getOptions()->getDebugPng();
         if ($debug_png) {
@@ -58,9 +60,7 @@ class Image extends AbstractFrameDecorator
             $dompdf->getOptions()
         );
 
-        if (Cache::is_broken($this->_image_url) &&
-            $alt = $frame->get_node()->getAttribute("alt")
-        ) {
+        if (Cache::is_broken($this->_image_url) && ($alt = $node->getAttribute("alt")) !== "") {
             $fontMetrics = $dompdf->getFontMetrics();
             $style = $frame->get_style();
             $font = $style->font_family;
@@ -68,7 +68,7 @@ class Image extends AbstractFrameDecorator
             $word_spacing = $style->word_spacing;
             $letter_spacing = $style->letter_spacing;
 
-            $style->width = (4 / 3) * $fontMetrics->getTextWidth($alt, $font, $size, $word_spacing, $letter_spacing);
+            $style->width = $fontMetrics->getTextWidth($alt, $font, $size, $word_spacing, $letter_spacing);
             $style->height = $fontMetrics->getFontHeight($font, $size);
         }
     }

--- a/src/FrameDecorator/TableCell.php
+++ b/src/FrameDecorator/TableCell.php
@@ -17,11 +17,10 @@ use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
  */
 class TableCell extends BlockFrameDecorator
 {
-
-    protected $_resolved_borders;
-    protected $_content_height;
-
-    //........................................................................
+    /**
+     * @var float
+     */
+    protected $content_height;
 
     /**
      * TableCell constructor.
@@ -31,40 +30,35 @@ class TableCell extends BlockFrameDecorator
     function __construct(Frame $frame, Dompdf $dompdf)
     {
         parent::__construct($frame, $dompdf);
-        $this->_resolved_borders = [];
-        $this->_content_height = 0;
+        $this->content_height = 0.0;
     }
-
-    //........................................................................
 
     function reset()
     {
         parent::reset();
-        $this->_resolved_borders = [];
-        $this->_content_height = 0;
-        $this->_frame->reset();
+        $this->content_height = 0.0;
     }
 
     /**
-     * @return int
+     * @return float
      */
-    function get_content_height()
+    public function get_content_height(): float
     {
-        return $this->_content_height;
+        return $this->content_height;
     }
 
     /**
-     * @param $height
+     * @param float $height
      */
-    function set_content_height($height)
+    public function set_content_height(float $height): void
     {
-        $this->_content_height = $height;
+        $this->content_height = $height;
     }
 
     /**
-     * @param $height
+     * @param float $height
      */
-    function set_cell_height($height)
+    public function set_cell_height(float $height): void
     {
         $style = $this->get_style();
         $v_space = (float)$style->length_in_pt(
@@ -82,7 +76,7 @@ class TableCell extends BlockFrameDecorator
         $new_height = $height - $v_space;
         $style->set_used("height", $new_height);
 
-        if ($new_height > $this->_content_height) {
+        if ($new_height > $this->content_height) {
             $y_offset = 0;
 
             // Adjust our vertical alignment
@@ -96,11 +90,11 @@ class TableCell extends BlockFrameDecorator
                     return;
 
                 case "middle":
-                    $y_offset = ($new_height - $this->_content_height) / 2;
+                    $y_offset = ($new_height - $this->content_height) / 2;
                     break;
 
                 case "bottom":
-                    $y_offset = $new_height - $this->_content_height;
+                    $y_offset = $new_height - $this->content_height;
                     break;
             }
 
@@ -113,31 +107,5 @@ class TableCell extends BlockFrameDecorator
                 }
             }
         }
-    }
-
-    /**
-     * @param $side
-     * @param $border_spec
-     */
-    function set_resolved_border($side, $border_spec)
-    {
-        $this->_resolved_borders[$side] = $border_spec;
-    }
-
-    /**
-     * @param $side
-     * @return mixed
-     */
-    function get_resolved_border($side)
-    {
-        return $this->_resolved_borders[$side];
-    }
-
-    /**
-     * @return array
-     */
-    function get_resolved_borders()
-    {
-        return $this->_resolved_borders;
     }
 }

--- a/src/FrameReflower/Block.php
+++ b/src/FrameReflower/Block.php
@@ -273,9 +273,9 @@ class Block extends AbstractFrameReflower
      *
      * @return float
      */
-    protected function _calculate_content_height()
+    protected function _calculate_content_height(): float
     {
-        $height = 0;
+        $height = 0.0;
         $lines = $this->_frame->get_line_boxes();
         if (count($lines) > 0) {
             $last_line = end($lines);

--- a/src/FrameReflower/TableCell.php
+++ b/src/FrameReflower/TableCell.php
@@ -9,6 +9,7 @@ namespace Dompdf\FrameReflower;
 use Dompdf\Exception;
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
 use Dompdf\FrameDecorator\Table as TableFrameDecorator;
+use Dompdf\FrameDecorator\TableCell as TableCellFrameDecorator;
 use Dompdf\Helpers;
 
 /**
@@ -32,21 +33,23 @@ class TableCell extends Block
      */
     function reflow(BlockFrameDecorator $block = null)
     {
-        // Counters and generated content
-        $this->_set_content();
-
-        $style = $this->_frame->get_style();
-
-        $table = TableFrameDecorator::find_parent_table($this->_frame);
+        /** @var TableCellFrameDecorator */
+        $frame = $this->_frame;
+        $table = TableFrameDecorator::find_parent_table($frame);
         if ($table === null) {
             throw new Exception("Parent table not found for table cell");
         }
+
+        // Counters and generated content
+        $this->_set_content();
+
+        $style = $frame->get_style();
         $cellmap = $table->get_cellmap();
 
-        list($x, $y) = $cellmap->get_frame_position($this->_frame);
-        $this->_frame->set_position($x, $y);
+        [$x, $y] = $cellmap->get_frame_position($frame);
+        $frame->set_position($x, $y);
 
-        $cells = $cellmap->get_spanned_cells($this->_frame);
+        $cells = $cellmap->get_spanned_cells($frame);
 
         $w = 0;
         foreach ($cells["columns"] as $i) {
@@ -55,7 +58,7 @@ class TableCell extends Block
         }
 
         //FIXME?
-        $h = $this->_frame->get_containing_block("h");
+        $h = $frame->get_containing_block("h");
 
         $left_space = (float)$style->length_in_pt([$style->margin_left,
                 $style->padding_left,
@@ -84,19 +87,19 @@ class TableCell extends Block
 
         // Adjust the first line based on the text-indent property
         $indent = (float)$style->length_in_pt($style->text_indent, $w);
-        $this->_frame->increase_line_width($indent);
+        $frame->increase_line_width($indent);
 
-        $page = $this->_frame->get_root();
+        $page = $frame->get_root();
 
         // Set the y position of the first line in the cell
-        $line_box = $this->_frame->get_current_line_box();
+        $line_box = $frame->get_current_line_box();
         $line_box->y = $line_y;
 
         // Set the containing blocks and reflow each child
-        foreach ($this->_frame->get_children() as $child) {
+        foreach ($frame->get_children() as $child) {
             $child->set_containing_block($content_x, $content_y, $cb_w, $h);
             $this->process_clear($child);
-            $child->reflow($this->_frame);
+            $child->reflow($frame);
             $this->process_float($child, $content_x, $cb_w);
 
             if ($page->is_full()) {
@@ -105,14 +108,11 @@ class TableCell extends Block
         }
 
         // Determine our height
-        $style_height = (float)$style->length_in_pt($style->height, $h);
+        $style_height = (float) $style->length_in_pt($style->height, $h);
+        $content_height = $this->_calculate_content_height();
+        $height = max($style_height, $content_height);
 
-        /** @var FrameDecorator\TableCell */
-        $frame = $this->_frame;
-
-        $frame->set_content_height($this->_calculate_content_height());
-
-        $height = max($style_height, (float)$frame->get_content_height());
+        $frame->set_content_height($content_height);
 
         // Let the cellmap know our height
         $cell_height = $height / count($cells["rows"]);
@@ -131,7 +131,7 @@ class TableCell extends Block
         $this->vertical_align();
 
         // Handle relative positioning
-        foreach ($this->_frame->get_children() as $child) {
+        foreach ($frame->get_children() as $child) {
             $this->position_relative($child);
         }
     }

--- a/src/FrameReflower/TableRow.php
+++ b/src/FrameReflower/TableRow.php
@@ -47,11 +47,11 @@ class TableRow extends AbstractFrameReflower
         // Counters and generated content
         $this->_set_content();
 
-        $this->_frame->position();
-        $style = $this->_frame->get_style();
-        $cb = $this->_frame->get_containing_block();
+        $frame->position();
+        $style = $frame->get_style();
+        $cb = $frame->get_containing_block();
 
-        foreach ($this->_frame->get_children() as $child) {
+        foreach ($frame->get_children() as $child) {
             $child->set_containing_block($cb);
             $child->reflow();
 
@@ -64,15 +64,16 @@ class TableRow extends AbstractFrameReflower
             return;
         }
 
-        $table = TableFrameDecorator::find_parent_table($this->_frame);
+        $table = TableFrameDecorator::find_parent_table($frame);
         if ($table === null) {
             throw new Exception("Parent table not found for table row");
         }
         $cellmap = $table->get_cellmap();
-        $style->set_used("width", $cellmap->get_frame_width($this->_frame));
-        $style->set_used("height", $cellmap->get_frame_height($this->_frame));
 
-        $this->_frame->set_position($cellmap->get_frame_position($this->_frame));
+        $style->set_used("width", $cellmap->get_frame_width($frame));
+        $style->set_used("height", $cellmap->get_frame_height($frame));
+
+        $frame->set_position($cellmap->get_frame_position($frame));
     }
 
     /**

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -9,8 +9,10 @@ namespace Dompdf;
 use Dompdf\Renderer\AbstractRenderer;
 use Dompdf\Renderer\Block;
 use Dompdf\Renderer\Image;
+use Dompdf\Renderer\Inline;
 use Dompdf\Renderer\ListBullet;
 use Dompdf\Renderer\TableCell;
+use Dompdf\Renderer\TableRow;
 use Dompdf\Renderer\TableRowGroup;
 use Dompdf\Renderer\Text;
 
@@ -112,6 +114,10 @@ class Renderer extends AbstractRenderer
 
             case "table-cell":
                 $this->_render_frame("table-cell", $frame);
+                break;
+
+            case "table-row":
+                $this->_render_frame("table-row", $frame);
                 break;
 
             case "table-row-group":
@@ -252,7 +258,7 @@ class Renderer extends AbstractRenderer
                     break;
 
                 case "inline":
-                    $this->_renderers[$type] = new Renderer\Inline($this->_dompdf);
+                    $this->_renderers[$type] = new Inline($this->_dompdf);
                     break;
 
                 case "text":
@@ -265,6 +271,10 @@ class Renderer extends AbstractRenderer
 
                 case "table-cell":
                     $this->_renderers[$type] = new TableCell($this->_dompdf);
+                    break;
+
+                case "table-row":
+                    $this->_renderers[$type] = new TableRow($this->_dompdf);
                     break;
 
                 case "table-row-group":

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -6,12 +6,13 @@
  */
 namespace Dompdf\Renderer;
 
+use DOMElement;
 use Dompdf\Adapter\CPDF;
 use Dompdf\Css\Color;
 use Dompdf\Css\Style;
 use Dompdf\Dompdf;
-use Dompdf\Helpers;
 use Dompdf\Frame;
+use Dompdf\Helpers;
 use Dompdf\Image\Cache;
 
 /**
@@ -1152,6 +1153,49 @@ abstract class AbstractRenderer
     {
         if ($opacity >= 0.0 && $opacity <= 1.0) {
             $this->_canvas->set_opacity($opacity);
+        }
+    }
+
+    /**
+     * Add a named destination if the element has an ID or is an anchor element
+     * with `name` attribute.
+     *
+     * @param DOMElement $node
+     */
+    protected function addNamedDest(DOMElement $node): void
+    {
+        $id = $node->getAttribute("id");
+        if ($id !== "") {
+            $this->_canvas->add_named_dest($id);
+        }
+
+        if ($node->nodeName === "a") {
+            $name = $node->getAttribute("name");
+            if ($name !== "") {
+                $this->_canvas->add_named_dest($name);
+            }
+        }
+    }
+
+    /**
+     * Add a hyperlink if the element is an anchor element with `href`
+     * attribute.
+     *
+     * @param DOMElement $node
+     * @param float[]    $borderBox
+     */
+    protected function addHyperlink(DOMElement $node, array $borderBox): void
+    {
+        if ($node->nodeName === "a" && ($href = $node->getAttribute("href")) !== "") {
+            [$x, $y, $w, $h] = $borderBox;
+            $dompdf = $this->_dompdf;
+            $href = Helpers::build_url(
+                $dompdf->getProtocol(),
+                $dompdf->getBaseHost(),
+                $dompdf->getBasePath(),
+                $href
+            ) ?? $href;
+            $this->_canvas->add_link($href, $x, $y, $w, $h);
         }
     }
 

--- a/src/Renderer/Block.php
+++ b/src/Renderer/Block.php
@@ -8,7 +8,6 @@ namespace Dompdf\Renderer;
 
 use Dompdf\Frame;
 use Dompdf\FrameDecorator\Block as BlockFrameDecorator;
-use Dompdf\Helpers;
 
 /**
  * Renders block frames
@@ -17,7 +16,6 @@ use Dompdf\Helpers;
  */
 class Block extends AbstractRenderer
 {
-
     /**
      * @param Frame $frame
      */
@@ -25,7 +23,6 @@ class Block extends AbstractRenderer
     {
         $style = $frame->get_style();
         $node = $frame->get_node();
-        $dompdf = $this->_dompdf;
 
         $this->_set_opacity($frame->get_opacity($style->opacity));
 
@@ -45,17 +42,8 @@ class Block extends AbstractRenderer
         $this->_render_border($frame, $border_box);
         $this->_render_outline($frame, $border_box);
 
-        // Handle anchors & links
-        if ($node->nodeName === "a" && $href = $node->getAttribute("href")) {
-            $href = Helpers::build_url($dompdf->getProtocol(), $dompdf->getBaseHost(), $dompdf->getBasePath(), $href) ?? $href;
-            $this->_canvas->add_link($href, $x, $y, $w, $h);
-        }
-
-        $id = $frame->get_node()->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
-
+        $this->addNamedDest($node);
+        $this->addHyperlink($node, $border_box);
         $this->debugBlockLayout($frame, "red", false);
     }
 

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -68,17 +68,6 @@ class Image extends Block
             }
         }
 
-        if ($msg = $frame->get_image_msg()) {
-            $parts = preg_split("/\s*\n\s*/", $msg);
-            $font = $style->font_family;
-            $height = 10;
-            $offset = $alt !== "" ? $h : 0;
-
-            foreach ($parts as $i => $part) {
-                $this->_canvas->text($x, $y + $offset + $i * $height, $part, $font, $height * 0.8, [0.5, 0.5, 0.5]);
-            }
-        }
-
         $this->addNamedDest($node);
         $this->debugBlockLayout($frame, "blue");
     }

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -36,11 +36,9 @@ class Image extends Block
         [$x, $y, $w, $h] = $content_box;
 
         $src = $frame->get_image_url();
-        $alt = null;
+        $alt = "";
 
-        if (Cache::is_broken($src) &&
-            $alt = $frame->get_node()->getAttribute("alt")
-        ) {
+        if (Cache::is_broken($src) && ($alt = $frame->get_node()->getAttribute("alt")) !== "") {
             $font = $style->font_family;
             $size = $style->font_size;
             $word_spacing = $style->word_spacing;
@@ -73,10 +71,10 @@ class Image extends Block
             $parts = preg_split("/\s*\n\s*/", $msg);
             $font = $style->font_family;
             $height = 10;
-            $_y = $alt ? $y + $h - count($parts) * $height : $y;
+            $offset = $alt !== "" ? $h : 0;
 
-            foreach ($parts as $i => $_part) {
-                $this->_canvas->text($x, $_y + $i * $height, $_part, $font, $height * 0.8, [0.5, 0.5, 0.5]);
+            foreach ($parts as $i => $part) {
+                $this->_canvas->text($x, $y + $offset + $i * $height, $part, $font, $height * 0.8, [0.5, 0.5, 0.5]);
             }
         }
 

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -23,6 +23,7 @@ class Image extends Block
     function render(Frame $frame)
     {
         $style = $frame->get_style();
+        $node = $frame->get_node();
         $border_box = $frame->get_border_box();
 
         $this->_set_opacity($frame->get_opacity($style->opacity));
@@ -38,7 +39,7 @@ class Image extends Block
         $src = $frame->get_image_url();
         $alt = "";
 
-        if (Cache::is_broken($src) && ($alt = $frame->get_node()->getAttribute("alt")) !== "") {
+        if (Cache::is_broken($src) && ($alt = $node->getAttribute("alt")) !== "") {
             $font = $style->font_family;
             $size = $style->font_size;
             $word_spacing = $style->word_spacing;
@@ -78,11 +79,7 @@ class Image extends Block
             }
         }
 
-        $id = $frame->get_node()->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
-
+        $this->addNamedDest($node);
         $this->debugBlockLayout($frame, "blue");
     }
 }

--- a/src/Renderer/Inline.php
+++ b/src/Renderer/Inline.php
@@ -7,7 +7,6 @@
 namespace Dompdf\Renderer;
 
 use Dompdf\Frame;
-use Dompdf\Helpers;
 
 /**
  * Renders inline frames
@@ -23,6 +22,7 @@ class Inline extends AbstractRenderer
         }
 
         $style = $frame->get_style();
+        $node = $frame->get_node();
         $dompdf = $this->_dompdf;
 
         $this->_set_opacity($frame->get_opacity($style->opacity));
@@ -55,31 +55,8 @@ class Inline extends AbstractRenderer
         $this->_render_border($frame, $border_box);
         $this->_render_outline($frame, $border_box);
 
-        $node = $frame->get_node();
-        $id = $node->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
-
-        // Only two levels of links frames
-        $is_link_node = $node->nodeName === "a";
-        if ($is_link_node) {
-            if (($name = $node->getAttribute("name"))) {
-                $this->_canvas->add_named_dest($name);
-            }
-        }
-
-        if ($frame->get_parent() && $frame->get_parent()->get_node()->nodeName === "a") {
-            $link_node = $frame->get_parent()->get_node();
-        }
-
-        // Handle anchors & links
-        if ($is_link_node) {
-            if ($href = $node->getAttribute("href")) {
-                $href = Helpers::build_url($dompdf->getProtocol(), $dompdf->getBaseHost(), $dompdf->getBasePath(), $href) ?? $href;
-                $this->_canvas->add_link($href, $x, $y, $w, $h);
-            }
-        }
+        $this->addNamedDest($node);
+        $this->addHyperlink($node, $border_box);
     }
 
     protected function get_child_size(Frame $frame, bool $do_debug_layout_line): array

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -215,10 +215,5 @@ class ListBullet extends AbstractRenderer
                     break;
             }
         }
-
-        $id = $frame->get_node()->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
     }
 }

--- a/src/Renderer/TableCell.php
+++ b/src/Renderer/TableCell.php
@@ -17,15 +17,15 @@ use Dompdf\FrameDecorator\Table;
  */
 class TableCell extends Block
 {
-
     /**
      * @param Frame $frame
      */
     function render(Frame $frame)
     {
         $style = $frame->get_style();
+        $node = $frame->get_node();
 
-        if (trim($frame->get_node()->nodeValue) === "" && $style->empty_cells === "hide") {
+        if (trim($node->nodeValue) === "" && $style->empty_cells === "hide") {
             return;
         }
 
@@ -62,10 +62,8 @@ class TableCell extends Block
             $this->_render_outline($frame, $border_box);
         }
 
-        $id = $frame->get_node()->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
+        $this->addNamedDest($node);
+        $this->addHyperlink($node, $border_box);
 
         // $this->debugBlockLayout($frame, "red", false);
     }

--- a/src/Renderer/TableCell.php
+++ b/src/Renderer/TableCell.php
@@ -64,8 +64,7 @@ class TableCell extends Block
 
         $this->addNamedDest($node);
         $this->addHyperlink($node, $border_box);
-
-        // $this->debugBlockLayout($frame, "red", false);
+        $this->debugBlockLayout($frame, "red", false);
     }
 
     /**

--- a/src/Renderer/TableRow.php
+++ b/src/Renderer/TableRow.php
@@ -11,7 +11,7 @@ use Dompdf\Frame;
 /**
  * @package dompdf
  */
-class TableRowGroup extends Block
+class TableRow extends Block
 {
     /**
      * @param Frame $frame

--- a/src/Renderer/TableRowGroup.php
+++ b/src/Renderer/TableRowGroup.php
@@ -22,6 +22,7 @@ class TableRowGroup extends Block
     function render(Frame $frame)
     {
         $style = $frame->get_style();
+        $node = $frame->get_node();
 
         $this->_set_opacity($frame->get_opacity($style->opacity));
 
@@ -30,11 +31,8 @@ class TableRowGroup extends Block
         $this->_render_border($frame, $border_box);
         $this->_render_outline($frame, $border_box);
 
-        $id = $frame->get_node()->getAttribute("id");
-        if (strlen($id) > 0) {
-            $this->_canvas->add_named_dest($id);
-        }
-
+        $this->addNamedDest($node);
+        $this->addHyperlink($node, $border_box);
         $this->debugBlockLayout($frame, "red");
     }
 }

--- a/src/Renderer/Text.php
+++ b/src/Renderer/Text.php
@@ -51,7 +51,7 @@ class Text extends AbstractRenderer
 
         $this->_set_opacity($frame->get_opacity($style->opacity));
 
-        list($x, $y) = $frame->get_position();
+        [$x, $y] = $frame->get_position();
         $cb = $frame->get_containing_block();
 
         $ml = $style->margin_left;
@@ -150,9 +150,12 @@ class Text extends AbstractRenderer
             $this->_canvas->line($x1, $deco_y, $x2, $deco_y, $color, $line_thickness);
         }
 
-        if ($this->_dompdf->getOptions()->getDebugLayout() && $this->_dompdf->getOptions()->getDebugLayoutLines()) {
-            $text_width = $this->_dompdf->getFontMetrics()->getTextWidth($text, $font, $size, $word_spacing, $letter_spacing);
-            $this->_debug_layout([$x, $y, $text_width, $frame_font_size], "orange", [0.5, 0.5]);
+        $options = $this->_dompdf->getOptions();
+
+        if ($options->getDebugLayout() && $options->getDebugLayoutLines()) {
+            $fontMetrics = $this->_dompdf->getFontMetrics();
+            $textWidth = $fontMetrics->getTextWidth($text, $font, $size, $word_spacing, $letter_spacing);
+            $this->_debug_layout([$x, $y, $textWidth, $frame_font_size], "orange", [0.5, 0.5]);
         }
     }
 }


### PR DESCRIPTION
* **Small adjustments to table rendering**
	* Do not render borders for table row groups in the separated model. They should be ignored per spec [1]
	* Render outlines for table rows
	* Support table rows as named destinations and hyperlinks
	* Draw outlines for table cells instead of row groups when debugging layout

* **Renderer fixes for named destinations and hyperlinks**
	* Fix anchor elements with `name` attribute with display other than `inline`
	* Make hyperlinks with display `table-cell` and `table-row-group` work
	* List bullets cannot be named destinations

* **Image: Improve `alt` text handling**
	* Render image message below `alt` text
	* Exactly fit box if displaying `alt` text
	* Display `alt` text if it is `"0"`

[1] https://www.w3.org/TR/CSS21/tables.html#separated-borders