### PR TITLE
Optimize `font_supports_text` to only check a single character

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -782,37 +782,21 @@ class CPDF implements Canvas
         }
     }
 
-    public function font_supports_text(string $font, string $text): bool
+    public function font_supports_char(string $font, string $char): bool
     {
-        if ($text === "") {
+        if ($char === "") {
             return true;
         }
 
         $is_font_subsetting = $this->_dompdf->getOptions()->getIsFontSubsettingEnabled();
         $this->_pdf->selectFont($font, '', false, $is_font_subsetting);
-        if (!array_key_exists($font, $this->_pdf->fonts)) {
+        if (!\array_key_exists($font, $this->_pdf->fonts)) {
             return false;
         }
         $font_info = $this->_pdf->fonts[$font];
+        $char_code = Helpers::uniord($char, "UTF-8");
 
-        if (function_exists("mb_str_split")) {
-            $chars = array_unique(mb_str_split($text, 1, "UTF-8"), SORT_STRING);
-        } else {
-            $chars = array_unique(preg_split("//u", $text, -1, PREG_SPLIT_NO_EMPTY), SORT_STRING);
-        }
-        $char_codes = array_map(
-            function($char) {
-                return Helpers::uniord($char, "UTF-8");
-            },
-            $chars
-        );
-
-        foreach ($char_codes as $char_code) {
-            if (!array_key_exists($char_code, $font_info['C'])) {
-                return false;
-            }
-        }
-        return true;
+        return \array_key_exists($char_code, $font_info['C']);
     }
 
     /**

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -798,32 +798,16 @@ class GD implements Canvas
         return $unicodeCharMapTables[$font] = $char_map;
     }
 
-    public function font_supports_text(string $font, string $text): bool
+    public function font_supports_char(string $font, string $char): bool
     {
-        if ($text === "") {
+        if ($char === "") {
             return true;
         }
 
-        if (function_exists("mb_str_split")) {
-            $chars = array_unique(mb_str_split($text, 1, "UTF-8"), SORT_STRING);
-        } else {
-            $chars = array_unique(preg_split("//u", $text, -1, PREG_SPLIT_NO_EMPTY), SORT_STRING);
-        }
-        $char_codes = array_map(
-            function($char) {
-                return Helpers::uniord($char, "UTF-8");
-            },
-            $chars
-        );
-
+        $char_code = Helpers::uniord($char, "UTF-8");
         $char_map = $this->getCharMap($font);
 
-        foreach ($char_codes as $char_code) {
-            if (!array_key_exists($char_code, $char_map)) {
-                return false;
-            }
-        }
-        return true;
+        return \array_key_exists($char_code, $char_map);
     }
 
     public function get_text_width($text, $font, $size, $word_spacing = 0.0, $char_spacing = 0.0)

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -366,14 +366,14 @@ interface Canvas
     public function add_info(string $label, string $value): void;
 
     /**
-     * Determines if the font supports the characters in the specified text
+     * Determines if the font supports the given character
      *
      * @param string $font The font file to use
-     * @param string $text The string of characters to check
+     * @param string $char The character to check
      *
      * @return bool
      */
-    function font_supports_text(string $font, string $text): bool;
+    function font_supports_char(string $font, string $char): bool;
 
     /**
      * Calculates text size, in points

--- a/src/FontMetrics.php
+++ b/src/FontMetrics.php
@@ -367,7 +367,7 @@ class FontMetrics
             }
             $mapped_font = null;
             foreach ($fonts as $font) {
-                if ($this->canvas->font_supports_text($font, $char)) {
+                if ($this->canvas->font_supports_char($font, $char)) {
                     $mapped_font = $font;
                     break;
                 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -612,11 +612,11 @@ class Helpers
             return mb_ord($c, $encoding);
         }
 
-        if ($encoding != "UTF-8") {
-            $c = mb_convert_encoding($c, $encoding);
+        if ($encoding != "UTF-8" && $encoding !== null) {
+            $c = mb_convert_encoding($c, "UTF-8", $encoding);
         }
 
-        $length = mb_strlen($c, '8bit');
+        $length = mb_strlen(mb_substr($c, 0, 1), '8bit');
         $ord = false;
         $bytes = [];
         $numbytes = 1;


### PR DESCRIPTION
We discussed this simplification during review of #3155, the method is only used in that way.

The performance impact is measurable with the test document from #3302. Here are average render times for that test case running on my machine (100 iterations with several repeats to account for outliers):

branch/tag | time
--- | ---
2.0.3 | 110.40 ms
master | 137.07 ms
font-fallback-perf-2 | 126.50 ms

Running the tests with other documents, the impact seems to be generally much less, up to being barely noticeable. I still think it is worth it.

I would just change the existing implementation and rename the method, but we could also keep `font_supports_text` in addition to `font_supports_char`. Thus marking as draft for now.