### PR TITLE
Simplify regex for parsing property sections

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2227,12 +2227,12 @@ class Style
     protected function parse_string(string $string): string
     {
         // Strip string quotes and escapes
-        $string = preg_replace('/^[\"\']|[\"\']$/', "", $string);
-        $string = str_replace(["\\\n", '\\"', "\\'"], ["", '"', "'"], $string);
+        $string = preg_replace('/^["\']|["\']$/', "", $string);
+        $string = preg_replace("/\\\\([^0-9a-fA-F])/", "\\1", $string);
 
-        // Convert escaped hex characters into ascii characters (e.g. \A => newline)
+        // Convert escaped hex characters (e.g. \A => newline)
         return preg_replace_callback(
-            "/\\\\([0-9a-fA-F]{0,6})/",
+            "/\\\\([0-9a-fA-F]{1,6})/",
             function ($matches) { return Helpers::unichr(hexdec($matches[1])); },
             $string
         ) ?? "";

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1612,14 +1612,15 @@ EOL;
      */
     private function _parse_properties($str)
     {
-        $properties = preg_split("/;(?=(?:[^\(]*\([^\)]*\))*(?![^\)]*\)))/", $str);
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();
 
-        if ($DEBUGCSS) {
-            print '[_parse_properties';
-        }
+        if ($DEBUGCSS) print '[_parse_properties';
 
-        // Create the style
+        // Split on non-escaped semicolons which are not followed by a single
+        // closing parenthesis, to support semicolons as part of `url()`.
+        // As a consequence, semicolons and closing parentheses should be
+        // escaped if used in a string
+        $properties = preg_split("/(?<!\\\\); (?! [^(]* (?<!\\\\)\) )/x", $str);
         $style = new Style($this, Stylesheet::ORIG_AUTHOR);
 
         foreach ($properties as $prop) {

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -826,6 +826,7 @@ class StyleTest extends TestCase
             ['"string"', [new StringPart("string")]],
             ["'string'", [new StringPart("string")]],
             ["\"'s't\\\"r'\"", [new StringPart("'s't\"r'")]],
+            ['"\(\A\5F\;_\A\)"', [new StringPart("(\n_;_\n)")]],
             ["'attr(title)'", [new StringPart("attr(title)")]],
             ['"url(\'image.png\')"', [new StringPart("url('image.png')")]],
 


### PR DESCRIPTION
The original pattern fails on nested parentheses. Instead of trying to be too clever, simplify the pattern so the rules are clearer. Allow semicolons and parentheses to be escaped, which allows dealing with the parser shortcomings more easily.

See https://github.com/dompdf/dompdf/pull/3314#discussion_r1387312858.