### PR TITLE
More improvements to parsing property sections and values

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2580,7 +2580,7 @@ class Style
     protected function _compute_background_position(string $val)
     {
         $val = strtolower($val);
-        $parts = preg_split("/\s+/", $val);
+        $parts = $this->parse_property_value($val);
         $count = \count($parts);
         $x = null;
         $y = null;
@@ -2691,7 +2691,7 @@ class Style
             return $val;
         }
 
-        $parts = preg_split("/\s+/", $val);
+        $parts = $this->parse_property_value($val);
 
         if (\count($parts) > 2) {
             return null;

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2328,7 +2328,7 @@ class Style
 
         // Negative non-`calc` values are invalid
         if ($computed === null
-            || ($computed < 0 && strncmp($val, "calc(", 5) !== 0)
+            || ($computed < 0 && !preg_match("/^-?[_a-zA-Z]/", $val))
         ) {
             return null;
         }
@@ -2366,7 +2366,7 @@ class Style
 
         // Negative non-`calc` values are invalid
         if ($computed === null
-            || ($computed < 0 && strncmp($val, "calc(", 5) !== 0)
+            || ($computed < 0 && !preg_match("/^-?[_a-zA-Z]/", $val))
         ) {
             return null;
         }
@@ -2810,7 +2810,7 @@ class Style
 
                 // Negative non-`calc` values are invalid
                 if ($computed === null
-                    || ($computed < 0 && strncmp($val, "calc(", 5) !== 0)
+                    || ($computed < 0 && !preg_match("/^-?[_a-zA-Z]/", $val))
                 ) {
                     return null;
                 }
@@ -3051,7 +3051,7 @@ class Style
 
         // Negative non-`calc` values are invalid
         if ($computed === null
-            || ($computed < 0 && strncmp($val, "calc(", 5) !== 0)
+            || ($computed < 0 && !preg_match("/^-?[_a-zA-Z]/", $val))
         ) {
             return null;
         }

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1618,11 +1618,11 @@ EOL;
             print '[_parse_properties';
         }
 
-        // Split on non-escaped semicolons which are not followed by a single
-        // closing parenthesis, to support semicolons as part of `url()`.
-        // As a consequence, semicolons and closing parentheses should be
-        // escaped if used in a string
-        $properties = preg_split("/(?<!\\\\); (?! [^(]* (?<!\\\\)\) )/x", $str);
+        // Split on non-escaped semicolons which are not part of an unquoted
+        // `url()` declaration. Semicolons in strings are not detected here, and
+        // as a consequence, should be escaped if used in a string
+        $urlEnd = "(?> (\\\\[\"'()] | [^\"'()])* ) (?<!\\\\)\)";
+        $properties = preg_split("/(?<!\\\\); (?! $urlEnd )/x", $str);
         $style = new Style($this, Stylesheet::ORIG_AUTHOR);
 
         foreach ($properties as $prop) {

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -115,7 +115,7 @@ class Stylesheet
     /**
      * Array of currently defined styles
      *
-     * @var Style[][]
+     * @var array<string, Style[]>
      */
     private $_styles;
 
@@ -274,6 +274,16 @@ class Stylesheet
     function get_base_path()
     {
         return $this->_base_path;
+    }
+
+    /**
+     * Get all registered styles as an associative array, indexed by selector.
+     *
+     * @return array<string, Style[]>
+     */
+    public function get_styles(): array
+    {
+        return $this->_styles;
     }
 
     /**

--- a/tests/Css/ShorthandTest.php
+++ b/tests/Css/ShorthandTest.php
@@ -25,7 +25,11 @@ class ShorthandTest extends TestCase
             ["10% 5pt 25%", "10%", "5pt", "25%", "5pt"],
             ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
             // Exponential notation
-            ["1e2% 50e-1pt 2.5e+1%", "1e2%", "50e-1pt", "2.5e+1%", "50e-1pt"]
+            ["1e2% 50e-1pt 2.5e+1%", "1e2%", "50e-1pt", "2.5e+1%", "50e-1pt"],
+
+            // Calc
+            ["calc(50% - 10pt) 1%", "calc(50% - 10pt)", "1%", "calc(50% - 10pt)", "1%"],
+            ["calc( (5 * 1pt) + 0pt ) 5pt CALC((0pt + 5pt))5pt", "calc( (5 * 1pt) + 0pt )", "5pt", "CALC((0pt + 5pt))", "5pt"]
         ];
     }
 
@@ -110,6 +114,9 @@ class ShorthandTest extends TestCase
             ["medium 1.2rem", "medium", "1.2rem", "medium", "1.2rem"],
             ["thick 5pt 12pc", "thick", "5pt", "12pc", "5pt"],
             ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
+
+            // Calc
+            ["calc(1pc - 12pt)medium", "calc(1pc - 12pt)", "medium", "calc(1pc - 12pt)", "medium"]
         ];
     }
 
@@ -172,7 +179,7 @@ class ShorthandTest extends TestCase
         $this->borderTypeShorthandTest("color", $value, $top, $right, $bottom, $left);
     }
 
-    public static function borderShorthandProvider(): array
+    public static function borderOutlineShorthandProvider(): array
     {
         return [
             ["transparent", "medium", "none", "transparent"],
@@ -181,11 +188,31 @@ class ShorthandTest extends TestCase
             ["solid 5pt", "5pt", "solid", "currentcolor"],
             ["1pt solid red", "1pt", "solid", "red"],
             ["rgb(0, 0, 0) double 1rem", "1rem", "double", "rgb(0, 0, 0)"],
-            ["thin rgb(0 255 0 / 0.2) solid", "thin", "solid", "rgb(0 255 0 / 0.2)"]
+            ["thin rgb(0 255 0 / 0.2) solid", "thin", "solid", "rgb(0 255 0 / 0.2)"],
+
+            // Calc
+            ["dotted calc((5pt + 1em)/2) #FF0000", "calc((5pt + 1em)/2)", "dotted", "#ff0000"],
+            ["calc( 3pt - 1px ) outset", "calc( 3pt - 1px )", "outset", "currentcolor"],
+        ];
+    }
+
+    public static function borderShorthandProvider(): array
+    {
+        return [
+            ["blue 1mm hidden", "1mm", "hidden", "blue"]
+        ];
+    }
+
+    public static function outlineShorthandProvider(): array
+    {
+        return [
+            ["auto 5pt", "5pt", "auto", "currentcolor"],
+            ["thin #000000 auto", "thin", "auto", "#000000"]
         ];
     }
 
     /**
+     * @dataProvider borderOutlineShorthandProvider
      * @dataProvider borderShorthandProvider
      */
     public function testBorderShorthand(
@@ -206,20 +233,8 @@ class ShorthandTest extends TestCase
         }
     }
 
-    public static function outlineShorthandProvider(): array
-    {
-        return [
-            ["transparent", "medium", "none", "transparent"],
-            ["currentcolor 1pc", "1pc", "none", "currentcolor"],
-            ["thick inset", "thick", "inset", "currentcolor"],
-            ["auto 5pt", "5pt", "auto", "currentcolor"],
-            ["1pt solid red", "1pt", "solid", "red"],
-            ["rgb(0, 0, 0) double 1rem", "1rem", "double", "rgb(0, 0, 0)"],
-            ["thin rgb(0 255 0 / 0.2) auto", "thin", "auto", "rgb(0 255 0 / 0.2)"]
-        ];
-    }
-
     /**
+     * @dataProvider borderOutlineShorthandProvider
      * @dataProvider outlineShorthandProvider
      */
     public function testOutlineShorthand(
@@ -243,6 +258,9 @@ class ShorthandTest extends TestCase
             ["1rem 2rem", "1rem", "2rem", "1rem", "2rem"],
             ["10% 5pt 15%", "10%", "5pt", "15%", "5pt"],
             ["5mm 4mm 3mm 2mm", "5mm", "4mm", "3mm", "2mm"],
+
+            // Calc
+            ["calc(50% - 10pt) 1%", "calc(50% - 10pt)", "1%", "calc(50% - 10pt)", "1%"],
         ];
     }
 
@@ -276,7 +294,11 @@ class ShorthandTest extends TestCase
             ["url( \"$imagePath\" )", "url( \"$imagePath\" )"],
             ["rgba( 5, 5, 5, 1 )", "none", [0.0, 0.0], ["auto", "auto"], "repeat", "scroll", "rgba( 5, 5, 5, 1 )"],
             ["url(non-existing.png) top center no-repeat red fixed", "url(non-existing.png)", "top center", ["auto", "auto"], "no-repeat", "fixed", "red"],
-            ["url($imagePath) LEFT/200PT 30% RGB( 123 16 69/0.8 )no-REPEAT", "url($imagePath)", "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"]
+            ["url($imagePath) LEFT/200PT 30% RGB( 123 16 69/0.8 )no-REPEAT", "url($imagePath)", "left", "200pt 30%", "no-repeat", "scroll", "rgb( 123 16 69/0.8 )"],
+            ["url($imagePath) 10pt 10pt/200PT 30%", "url($imagePath)", "10pt 10pt", "200pt 30%"],
+
+            // Calc for position and size
+            ["url($imagePath) calc(100% - 20pt)/ calc(10% + 20pt)CALC(100%/3)", "url($imagePath)", "calc(100% - 20pt)", "calc(10% + 20pt) calc(100%/3)"],
         ];
     }
 
@@ -312,7 +334,10 @@ class ShorthandTest extends TestCase
             ["700   normal  ITALIC    15.5PT /2.1 'Courier',sans-serif", "italic", "normal", "700", "15.5pt", "2.1", "'courier',sans-serif"],
             ["normal normal small-caps 100.01% serif, sans-serif", "normal", "small-caps", 400, "100.01%", "normal", "serif,sans-serif"],
             ["normal normal normal xx-small/normal monospace", "normal", "normal", 400, "xx-small", "normal", "monospace"],
-            ["1 0 serif", "normal", "normal", "1", "0", "normal", "serif"]
+            ["1 0 serif", "normal", "normal", "1", "0", "normal", "serif"],
+
+            // TODO: Calc for font size and line height
+            // ["italic 700 calc(1rem + 0.5pt)/calc(10/3) sans-serif", "italic", "normal", "700", "calc(1rem + 0.5pt)", "calc(10/3)", "sans-serif"],
         ];
     }
 

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -839,6 +839,7 @@ class StyleTest extends TestCase
             ["url('image.png')", [new Url("image.png")]],
             ["url(\"'image.PNG'\")", [new Url("'image.PNG'")]],
             ["url(\"image(1).PNG\")", [new Url("image(1).PNG")]],
+            ["url(image\(1\).PNG)", [new Url("image(1).PNG")]],
             ["url(\"image\\\"1\\\".PNG\")", [new Url("image\"1\".PNG")]],
 
             // Counter/Counters
@@ -846,6 +847,7 @@ class StyleTest extends TestCase
             ["counter(UPPER, UPPER-roman)", [new Counter("UPPER", "upper-roman")]],
             ["counters(c, '')", [new Counters("c", "", "decimal")]],
             ["counters(c, '', decimal)", [new Counters("c", "", "decimal")]],
+            ["counters(c, ')', decimal)", [new Counters("c", ")", "decimal")]],
             ["counters(UPPER, 'UPPER', lower-ROMAN)", [new Counters("UPPER", "UPPER", "lower-roman")]],
 
             // Quotes

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -250,6 +250,10 @@ class StyleTest extends TestCase
             ["23% 50pt", ["23%", 50.0]],
             ["50pt 23%", [50.0, "23%"]],
 
+            // Calc values
+            ["calc(-75% + 100pt)", ["calc(-75% + 100pt)", "50%"]],
+            ["calc(33% * 3 + 1%) calc(20pt + 30pt)", ["calc(33% * 3 + 1%)", 50.0]],
+
             // Case and whitespace variations
             ["LEFT", [0.0, "50%"]],
             ["TOP    Right", ["100%", 0.0]],
@@ -281,6 +285,52 @@ class StyleTest extends TestCase
 
         $style->set_prop("background_position", $value);
         $this->assertSame($expected, $style->background_position);
+    }
+    public static function backgroundSizeProvider(): array
+    {
+        return [
+            // Keywords
+            ["cover", "cover"],
+            ["contain", "contain"],
+
+            // One value
+            ["100%", ["100%", "auto"]],
+            ["200pt", [200.0, "auto"]],
+
+            // Two values
+            ["100% auto", ["100%", "auto"]],
+            ["200pt auto", [200.0, "auto"]],
+            ["auto 100%", ["auto", "100%"]],
+            ["auto 200pt", ["auto", 200.0]],
+            ["10% 200pt", ["10%", 200.0]],
+
+            // Calc values
+            ["calc(-75% + 100pt) auto", ["calc(-75% + 100pt)", "auto"]],
+            ["calc(33% * 3 + 1%) calc(20pt + 30pt)", ["calc(33% * 3 + 1%)", 50.0]],
+
+            // Case and whitespace variations
+            ["CoveR", "cover"],
+            ["AUTO    23PT", ["auto", 23.0]],
+            ["CALC(20PT*3)23PT", [60.0, 23.0]],
+
+            // Invalid values
+            ["none", ["auto", "auto"]],
+            ["auto", ["auto", "auto"]],
+            ["cover contain", ["auto", "auto"]]
+        ];
+    }
+
+    /**
+     * @dataProvider backgroundSizeProvider
+     */
+    public function testBackgroundSize(string $value, $expected): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $style = new Style($sheet);
+
+        $style->set_prop("background_size", $value);
+        $this->assertSame($expected, $style->background_size);
     }
 
     public static function fontWeightProvider(): array

--- a/tests/Css/StylesheetTest.php
+++ b/tests/Css/StylesheetTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Dompdf\Tests\Css;
+
+use Dompdf\Css\Style;
+use Dompdf\Dompdf;
+use Dompdf\Css\Stylesheet;
+use Dompdf\Tests\TestCase;
+
+class StylesheetTest extends TestCase
+{
+    public static function parseCssProvider(): array
+    {
+        return [
+            // TODO: Heredocs can be nicely indented starting with PHP 7.3
+            "closing parenthesis in string" => [
+                <<<CSS
+li::before {
+    counter-increment: c;
+    content: ")";
+}
+CSS
+,
+                [
+                    "li::before" => [[
+                        "counter_increment" => "c",
+                        "content" => '")"'
+                    ]]
+                ]
+            ],
+            "semicolon in url" => [
+                <<<CSS
+div {
+    background-image: url(image;\(12\).png);
+}
+CSS
+,
+                [
+                    "div" => [[
+                        "background_image" => "url(image;\(12\).png)"
+                    ]]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * The expected styles define the selectors to check. For each selector, the
+     * styles have to match the defined properties in their specified values.
+     *
+     * @dataProvider parseCssProvider
+     */
+    public function testParseCss(string $css, array $expected): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $sheet->load_css($css);
+
+        $styles = $sheet->get_styles();
+        $actual = [];
+
+        foreach ($expected as $selector => $expectedStyles) {
+            $this->assertArrayHasKey($selector, $styles);
+            $this->assertSameSize($expectedStyles, $styles[$selector]);
+
+            $actual[$selector] = array_map(function (array $props, Style $style) {
+                $propNames = array_keys($props);
+                $values = array_map(function (string $prop) use ($style) {
+                    return $style->get_specified($prop);
+                }, $propNames);
+
+                return array_combine($propNames, $values);
+            }, $expectedStyles, $styles[$selector]);
+        }
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
* **Support nested parentheses during property-value parsing**
This allows nested parentheses to work within shorthands and also prepares for nested math functions
* **Fix `calc` support for `background_position` and `background_size`**
* **Further adjust regex for parsing property sections**
Fixes closing parentheses as part of a string, such as `content:")";`

Fixes #2195