### PR TITLE
Fix checking for character support with core fonts

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -788,15 +788,58 @@ class CPDF implements Canvas
             return true;
         }
 
-        $is_font_subsetting = $this->_dompdf->getOptions()->getIsFontSubsettingEnabled();
-        $this->_pdf->selectFont($font, '', false, $is_font_subsetting);
+        $subsetting = $this->_dompdf->getOptions()->getIsFontSubsettingEnabled();
+        $this->_pdf->selectFont($font, '', false, $subsetting);
         if (!\array_key_exists($font, $this->_pdf->fonts)) {
             return false;
         }
-        $font_info = $this->_pdf->fonts[$font];
-        $char_code = Helpers::uniord($char, "UTF-8");
+        $fontInfo = $this->_pdf->fonts[$font];
+        $charCode = Helpers::uniord($char, "UTF-8");
 
-        return \array_key_exists($char_code, $font_info['C']);
+        if (!$fontInfo["isUnicode"]) {
+            // The core fonts use Windows ANSI encoding. The char map uses the
+            // position of the character in the encoding's mapping table in this
+            // case, not the Unicode code point, which is different for the
+            // characters outside ISO-8859-1 (positions 0x80-0x9F)
+            // https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT
+            $mapping = [
+                0x20AC => 0x80,
+                0x201A => 0x82,
+                0x0192 => 0x83,
+                0x201E => 0x84,
+                0x2026 => 0x85,
+                0x2020 => 0x86,
+                0x2021 => 0x87,
+                0x02C6 => 0x88,
+                0x2030 => 0x89,
+                0x0160 => 0x8A,
+                0x2039 => 0x8B,
+                0x0152 => 0x8C,
+                0x017D => 0x8E,
+                0x2018 => 0x91,
+                0x2019 => 0x92,
+                0x201C => 0x93,
+                0x201D => 0x94,
+                0x2022 => 0x95,
+                0x2013 => 0x96,
+                0x2014 => 0x97,
+                0x02DC => 0x98,
+                0x2122 => 0x99,
+                0x0161 => 0x9A,
+                0x203A => 0x9B,
+                0x0153 => 0x9C,
+                0x017E => 0x9E,
+                0x0178 => 0x9F
+            ];
+
+            $charCode = $mapping[$charCode] ?? $charCode;
+
+            if ($charCode > 0xFF) {
+                return false;
+            }
+        }
+
+        return \array_key_exists($charCode, $fontInfo["C"]);
     }
 
     /**

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -804,10 +804,11 @@ class GD implements Canvas
             return true;
         }
 
-        $char_code = Helpers::uniord($char, "UTF-8");
-        $char_map = $this->getCharMap($font);
+        $font = $this->get_ttf_file($font);
+        $charMap = $this->getCharMap($font);
+        $charCode = Helpers::uniord($char, "UTF-8");
 
-        return \array_key_exists($char_code, $char_map);
+        return \array_key_exists($charCode, $charMap);
     }
 
     public function get_text_width($text, $font, $size, $word_spacing = 0.0, $char_spacing = 0.0)

--- a/tests/Canvas/CPDFTest.php
+++ b/tests/Canvas/CPDFTest.php
@@ -66,4 +66,75 @@ class CPDFTest extends TestCase
         $output = $canvas->output();
         $this->assertNotSame("", $output);
     }
+
+    public static function fontSupportsCharProvider(): array
+    {
+        return [
+            // Core fonts
+            // ASCII and ISO-8859-1
+            ["Helvetica", "A", true],
+            ["Helvetica", "{", true],
+            ["Helvetica", "Æ", true],
+            ["Helvetica", "÷", true],
+
+            // Part of Windows-1252, but not ISO-8859-1
+            ["Helvetica", "€", true],
+            ["Helvetica", "‚", true],
+            ["Helvetica", "ƒ", true],
+            ["Helvetica", "„", true],
+            ["Helvetica", "…", true],
+            ["Helvetica", "†", true],
+            ["Helvetica", "‡", true],
+            ["Helvetica", "ˆ", true],
+            ["Helvetica", "‰", true],
+            ["Helvetica", "Š", true],
+            ["Helvetica", "‹", true],
+            ["Helvetica", "Œ", true],
+            ["Helvetica", "Ž", true],
+            ["Helvetica", "‘", true],
+            ["Helvetica", "’", true],
+            ["Helvetica", "“", true],
+            ["Helvetica", "”", true],
+            ["Helvetica", "•", true],
+            ["Helvetica", "–", true],
+            ["Helvetica", "—", true],
+            ["Helvetica", "˜", true],
+            ["Helvetica", "™", true],
+            ["Helvetica", "š", true],
+            ["Helvetica", "›", true],
+            ["Helvetica", "œ", true],
+            ["Helvetica", "ž", true],
+            ["Helvetica", "Ÿ", true],
+            ["Helvetica", "ÿ", true],
+
+            // Unicode outside Windows-1252
+            ["Helvetica", "Ā", false],
+            ["Helvetica", "↦", false],
+            ["Helvetica", "∉", false],
+            ["Helvetica", "能", false],
+
+            // DejaVu
+            ["DejaVu Sans", "A", true],
+            ["DejaVu Sans", "{", true],
+            ["DejaVu Sans", "Æ", true],
+            ["DejaVu Sans", "÷", true],
+            ["DejaVu Sans", "Œ", true],
+            ["DejaVu Sans", "—", true],
+            ["DejaVu Sans", "↦", true],
+            ["DejaVu Sans", "∉", true],
+            ["DejaVu Sans", "能", false],
+        ];
+    }
+
+    /**
+     * @dataProvider fontSupportsCharProvider
+     */
+    public function testFontSupportsChar(string $font, string $char, bool $expected): void
+    {
+        $dompdf = new Dompdf();
+        $canvas = new CPDF("letter", "portrait", $dompdf);
+        $fontFile = $dompdf->getFontMetrics()->getFont($font);
+
+        $this->assertSame($expected, $canvas->font_supports_char($fontFile, $char));
+    }
 }


### PR DESCRIPTION
Avoids unnecessarily splitting text frames when using one of the core fonts and characters which are included in Windows ANSI encoding, but not in ISO-8859-1, such as typographical quotation marks, or the en dash.

See https://en.wikipedia.org/wiki/Windows-1252

Changing the substitution character via `mb_substitute_character` is kind of awkward, but I haven’t found a better way (comparing to the current one is even more complicated).