### PR TITLE
Stop generated table frame reflow after paging

### DIFF
--- a/src/FrameReflower/TableRowGroup.php
+++ b/src/FrameReflower/TableRowGroup.php
@@ -36,6 +36,8 @@ class TableRowGroup extends AbstractFrameReflower
         /** @var TableRowGroupFrameDecorator */
         $frame = $this->_frame;
         $page = $frame->get_root();
+        $parent = $frame->get_parent();
+        $dompdf_generated = $parent->get_frame()->get_node()->nodeName === "dompdf_generated";
 
         // Counters and generated content
         $this->_set_content();
@@ -53,6 +55,10 @@ class TableRowGroup extends AbstractFrameReflower
             if ($page->is_full()) {
                 break;
             }
+        }
+
+        if ($page->is_full() && $dompdf_generated && $frame->get_parent() === null) {
+            return;
         }
 
         $table = TableFrameDecorator::find_parent_table($frame);


### PR DESCRIPTION
When a generated frame is paged it's children are removed from the frame. If the generated frame is styled `display: table` the first child will be a table row group. Since table child frames are always expected to be associated with a table this causes an exception.

When a table row group's parent frame is a generated frame and the frame no longer has a parent after paging Dompdf will halt further processing of the frame.

fixes #3334