### PR TITLE
Update FrameListIterator.php return types to be compatible with Iterator

### DIFF
--- a/src/Frame/FrameListIterator.php
+++ b/src/Frame/FrameListIterator.php
@@ -1,11 +1,9 @@
 <?php
-
 /**
  * @package dompdf
  * @link    https://github.com/dompdf/dompdf
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
-
 namespace Dompdf\Frame;
 
 use Iterator;

--- a/src/Frame/FrameListIterator.php
+++ b/src/Frame/FrameListIterator.php
@@ -1,9 +1,11 @@
 <?php
+
 /**
  * @package dompdf
  * @link    https://github.com/dompdf/dompdf
  * @license http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
+
 namespace Dompdf\Frame;
 
 use Iterator;
@@ -64,17 +66,17 @@ class FrameListIterator implements Iterator
     }
 
     /**
-     * @return int
+     * @return mixed
      */
-    public function key(): int
+    public function key(): mixed
     {
         return $this->num;
     }
 
     /**
-     * @return Frame|null
+     * @return mixed
      */
-    public function current(): ?Frame
+    public function current(): mixed
     {
         return $this->cur;
     }


### PR DESCRIPTION
I have encountered the following warning when using the FrameListIterator class on PHP 8.1 using Dompdf version 2.0.4:

```Return type of Dompdf\Frame\FrameListIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice```

The return type of `FrameListIterator::key()` is currently `int`. According to [php.net](https://www.php.net/manual/en/class.iterator.php), it should be `mixed` in order to be compatible.

The same is the case with `FrameListIterator::current()`, having a return type of `?Frame` when it should be `mixed` in order to be compatible.