### PR TITLE
Fix open_basedir restriction issue in selectFont

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3530,7 +3530,7 @@ EOT;
      * @throws FontNotFoundException
      */
     function selectFont($fontName, $encoding = '', $set = true, $isSubsetting = true)
-    {   
+    {
         $fontName = (string) $fontName;
         $ext = substr($fontName, -4);
         if ($ext === '.afm' || $ext === '.ufm') {

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3532,7 +3532,7 @@ EOT;
     function selectFont($fontName, $encoding = '', $set = true, $isSubsetting = true)
     {   
         $fontName = (string) $fontName;
-        $ext = substr("$fontName", -4);
+        $ext = substr($fontName, -4);
         if ($ext === '.afm' || $ext === '.ufm') {
             $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
         }

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3530,17 +3530,17 @@ EOT;
      * @throws FontNotFoundException
      */
     function selectFont($fontName, $encoding = '', $set = true, $isSubsetting = true)
-    {
+    {   
+        $fontName = (string) $fontName;
+        $ext = substr("$fontName", -4);
+        if ($ext === '.afm' || $ext === '.ufm') {
+            $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
+        }
         if ($fontName === null || $fontName === '') {
             return $this->currentFontNum;
         }
 
-        $ext = substr($fontName, -4);
-        if ($ext === '.afm' || $ext === '.ufm') {
-            $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
-        }
-
-        if ($fontName && !isset($this->fonts[$fontName]) ) {
+        if (!isset($this->fonts[$fontName])) {
             $this->addMessage("selectFont: selecting - $fontName - $encoding, $set");
 
             // load the file

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3540,7 +3540,7 @@ EOT;
             $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
         }
 
-        if (!isset($this->fonts[$fontName])) {
+        if (!isset($this->fonts[$fontName]) && $fontName !== '' ) {
             $this->addMessage("selectFont: selecting - $fontName - $encoding, $set");
 
             // load the file

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3540,7 +3540,7 @@ EOT;
             $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
         }
 
-        if (!isset($this->fonts[$fontName]) && $fontName !== '' ) {
+        if ($fontName && !isset($this->fonts[$fontName]) ) {
             $this->addMessage("selectFont: selecting - $fontName - $encoding, $set");
 
             // load the file

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -3536,7 +3536,7 @@ EOT;
         if ($ext === '.afm' || $ext === '.ufm') {
             $fontName = substr($fontName, 0, mb_strlen($fontName) - 4);
         }
-        if ($fontName === null || $fontName === '') {
+        if ($fontName === '') {
             return $this->currentFontNum;
         }
 


### PR DESCRIPTION
**Title:**
Fix open_basedir restriction issue in selectFont

**Description:**
This pull request addresses an issue related to the `open_basedir` restriction in the `selectFont` function. The problem arises when attempting to load a font with an empty name (`$fontName === ''`), resulting in an error. The solution involves adding a simple condition to check if the font name is not empty before proceeding with font loading.

**Changes Made:**
- Added a condition to check if `$fontName` is not empty before attempting to load the font in the `selectFont` function.

**Testing:**
- Tested the changes locally to ensure that the `open_basedir` restriction issue is resolved.
- Verified that the modification does not introduce new issues or impact existing functionality.
- Tested and confirmed compatibility with PHP version 8.2.15.

**Additional Context:**
- The issue was identified during generation of pdf  .
- This fix improves the robustness of the code by handling edge cases where an empty font name is provided.

**Related Issues:**
- Fixes issue reported in the laravel-dompdf repository ([#1032](https://github.com/barryvdh/laravel-dompdf/issues/1032)).



**Contributor Agreement:**
I confirm that I have read and agreed to the terms of the dompdf opensource project .

