### PR TITLE
issues 2311 text-align-last property inclusion

### DIFF
--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -547,7 +547,8 @@ class Style
         "white_space" => true,
         "widows" => true,
         "word_break" => true,
-        "word_spacing" => true
+        "word_spacing" => true,
+        "text_align_last" => true
     ];
 
     /**
@@ -914,6 +915,9 @@ class Style
 
             // vendor-prefixed properties
             $d["_dompdf_keep"] = "";
+
+            //add css text align last property
+            $d["text_align_last"] = "";
 
             // Compute dependent props from dependency map
             foreach (self::$_dependency_map as $props) {


### PR DESCRIPTION
**Description:**
This pull request implements the text-align-last css property.

**Changes Made:**
I created a protected function **_text_align_last()** in src/FrameReflow/Block.php file.
In the justify case (that is what i needed) i m doing a continue if not last line with
**if ($line->br || $i !== $last_line_index) { 
     **continue;**
}**
In reflow() function called this new function with **$this->_text_align_last();**

**Testing:**
Tested in in localhost with PHP Version 8.0.25 and works greatly.

**Related Issues:**
doing issue reported in github repository (https://github.com/dompdf/dompdf/issues/2311).