### PR TITLE
add Hebrew support

### DIFF
--- a/src/Renderer/Text.php
+++ b/src/Renderer/Text.php
@@ -71,7 +71,27 @@ class Text extends AbstractRenderer
           array($this->_canvas->get_page_number()),
           $text
         );*/
+        if ( strtolower( $style -> direction ) == 'rtl' && preg_match( "/\p{Hebrew}/u", $text ) ){
 
+            preg_match_all('/./us', $text, $ar);
+        
+            // reverse the whole line
+            $text = join('',array_reverse($ar[0]));
+        
+            // flip english back to ltr
+            $words = explode( ' ', $text );
+            foreach( $words as $i => $word ):
+                if( !preg_match( "/\p{Hebrew}/u", $word ) ):
+                    $words[$i] = implode( '', array_reverse( str_split( $word ) ) );
+                endif;
+                if( $word === "–"){
+                    $words[$i] = "-";
+                }
+            endforeach;
+        
+            $text = implode( ' ', $words );
+        }
+        
         $this->_canvas->text($x, $y, $text,
             $font, $size,
             $style->color, $word_spacing, $letter_spacing);


### PR DESCRIPTION
Following the discussion in [stack overflow,](https://stackoverflow.com/questions/21201257/arabic-fonts-display-in-reverse-order-in-dompdf) can you please add this code?

Also opened an issue https://github.com/dompdf/dompdf/issues/3419

Test instruction:
render to pdf the following code:
```html
<div style="font-family:firefly, DejaVu Sans, sans-serif;direction:rtl;text-align:right">בדיקה– 123</div>
```

With this PR, Check you get in the pdf the following result:

> בדיקה- 123

Without this PR the letters would appear in the reversed order.