### PR TITLE
FIX artifact path validation

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1192,7 +1192,7 @@ class Options
     }
 
 
-    public function validateArtifactPath(string $path, string $option)
+    public function validateArtifactPath(?string $path, string $option)
     {
         $parsed_uri = parse_url($path);
         if ($parsed_uri === false || (array_key_exists("scheme", $parsed_uri) && strtolower($parsed_uri["scheme"]) === "phar")) {


### PR DESCRIPTION
### There Is A Small Problem

Instead Of: ~~public function validateArtifactPath(string $path, string $option)~~

We Should Use: `public function validateArtifactPath(?string $path, string $option)`

The `PATH` might be `NULL` in some cases.