### PR TITLE
Updates from 2.0.x releases not yet applied to master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*",
         "masterminds/html5": "^2.0",
         "phenx/php-font-lib": ">=0.5.4 <1.0.0",
-        "phenx/php-svg-lib": ">=0.3.3 <1.0.0"
+        "phenx/php-svg-lib": ">=0.5.2 <1.0.0"
     },
     "require-dev": {
         "ext-gd": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          failOnSkipped="true">

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -467,12 +467,17 @@ class GD implements Canvas
         imagesetthickness($this->get_image(), $width);
 
         if ($c === IMG_COLOR_STYLED) {
-            imagepolygon($this->get_image(), [
+            $points = [
                 $x1, $y1,
                 $x1 + $w, $y1,
                 $x1 + $w, $y1 + $h,
                 $x1, $y1 + $h
-            ], $c);
+            ];
+            if (version_compare(PHP_VERSION, "8.1.0", "<")) {
+                imagepolygon($this->get_image(), $points, count($points)/2, $c);
+            } else {
+                imagepolygon($this->get_image(), $points, $c);
+            }
         } else {
             imagerectangle($this->get_image(), $x1, $y1, $x1 + $w, $y1 + $h, $c);
         }
@@ -570,9 +575,17 @@ class GD implements Canvas
         imagesetthickness($this->get_image(), isset($width) ? $width : 0);
 
         if ($fill) {
-            imagefilledpolygon($this->get_image(), $points, $c);
+            if (version_compare(PHP_VERSION, "8.1.0", "<")) {
+                imagefilledpolygon($this->get_image(), $points, count($points)/2, $c);
+            } else {
+                imagefilledpolygon($this->get_image(), $points, $c);
+            }
         } else {
-            imagepolygon($this->get_image(), $points, $c);
+            if (version_compare(PHP_VERSION, "8.1.0", "<")) {
+                imagepolygon($this->get_image(), $points, count($points)/2, $c);
+            } else {
+                imagepolygon($this->get_image(), $points, $c);
+            }
         }
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -1194,6 +1194,9 @@ class Options
 
     public function validateArtifactPath(?string $path, string $option)
     {
+        if ($path === null) {
+            return true;
+        }
         $parsed_uri = parse_url($path);
         if ($parsed_uri === false || (array_key_exists("scheme", $parsed_uri) && strtolower($parsed_uri["scheme"]) === "phar")) {
             return false;

--- a/src/Options.php
+++ b/src/Options.php
@@ -1192,7 +1192,7 @@ class Options
     }
 
 
-    public function validateArtifactPath(string $path, string $option)
+    public function validateArtifactPath(?string $path, string $option)
     {
         $parsed_uri = parse_url($path);
         if ($parsed_uri === false || (array_key_exists("scheme", $parsed_uri) && strtolower($parsed_uri["scheme"]) === "phar")) {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -174,5 +174,9 @@ class OptionsTest extends TestCase
         $log_path = sys_get_temp_dir() . "/log.html";
         $options->setLogOutputFile($log_path);
         $this->assertEquals($log_path, $options->getLogOutputFile());
+
+        $log_path = null;
+        $options->setLogOutputFile($log_path);
+        $this->assertEquals($log_path, $options->getLogOutputFile());
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -162,4 +162,17 @@ class OptionsTest extends TestCase
         [$validation_result] = $allowedProtocols["http://"]["rules"][0]("http://en.wikipedia.org/");
         $this->assertTrue($validation_result);
     }
+
+    public function testArtifactPathValidation()
+    {
+        $options = new Options();
+
+        $log_path = $options->getLogOutputFile();
+        $options->setLogOutputFile("phar://test.phar/log.html");
+        $this->assertEquals($log_path, $options->getLogOutputFile());
+
+        $log_path = sys_get_temp_dir() . "/log.html";
+        $options->setLogOutputFile($log_path);
+        $this->assertEquals($log_path, $options->getLogOutputFile());
+    }
 }


### PR DESCRIPTION
- Addresses a PHP compatibility issue in the GD back end
- Adds Options class support for validating artifact paths. The default validation does not accept paths that utilize the PHAR protocol.
- Bumps the minimum version of SvgLib to 0.5.2.