### PR TITLE
allow searching files in chroot options directories

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -1458,7 +1458,8 @@ EOL;
                 $this->_protocol,
                 $this->_base_host,
                 $this->_base_path,
-                $url
+                $url,
+                $this->_dompdf->getOptions()->getChroot()
             );
             if ($path === null) {
                 $path = "none";
@@ -1787,7 +1788,7 @@ EOL;
     {
         $options = $this->_dompdf->getOptions();
         $rootDir = realpath($options->getRootDir());
-        return Helpers::build_url("file://", "", $rootDir, $rootDir . self::DEFAULT_STYLESHEET);
+        return Helpers::build_url("file://", "", $rootDir, $rootDir . self::DEFAULT_STYLESHEET, $options->getChroot());
     }
 
     /**

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -346,7 +346,7 @@ class Dompdf
             [$this->protocol, $this->baseHost, $this->basePath] = Helpers::explode_url($file);
         }
         $protocol = strtolower($this->protocol);
-        $uri = Helpers::build_url($this->protocol, $this->baseHost, $this->basePath, $file);
+        $uri = Helpers::build_url($this->protocol, $this->baseHost, $this->basePath, $file, $this->options->getChroot());
 
         $allowed_protocols = $this->options->getAllowedProtocols();
         if (!array_key_exists($protocol, $allowed_protocols)) {
@@ -613,7 +613,7 @@ class Dompdf
                         }
 
                         $url = $tag->getAttribute("href");
-                        $url = Helpers::build_url($this->protocol, $this->baseHost, $this->basePath, $url);
+                        $url = Helpers::build_url($this->protocol, $this->baseHost, $this->basePath, $url, $this->options->getChroot());
 
                         if ($url !== null) {
                             $this->css->load_css_file($url, Stylesheet::ORIG_AUTHOR);

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -59,7 +59,7 @@ class Helpers
      * Vice versa, on using the local file system path of a file, make sure that the slash
      * is appended (o.k. also for Windows)
      */
-    public static function build_url($protocol, $host, $base_path, $url)
+    public static function build_url($protocol, $host, $base_path, $url, $chrootDirs = [])
     {
         $protocol = mb_strtolower($protocol);
         if (empty($protocol)) {
@@ -113,13 +113,26 @@ class Helpers
             $ret = preg_replace('/\?(.*)$/', "", $ret);
 
             $filepath = realpath($ret);
-            if ($filepath === false) {
-                return null;
+            if ($filepath !== false) {
+                $ret = "$protocol$filepath$res";
+
+                return $ret;
             }
 
-            $ret = "$protocol$filepath$res";
+            if ($url[0] == '/' && !empty($chrootDirs)) {
+                foreach ($chrootDirs as $dir) {
+                    $ret = realpath($dir) . '/' . $url;
+                    $ret = preg_replace('/\?(.*)$/', "", $ret);
 
-            return $ret;
+                    if ($filepath = realpath($ret)) {
+                        $ret = "$protocol$filepath$res";
+
+                        return $ret;
+                    }
+                }
+            }
+
+            return null;
         }
 
         $ret = $protocol;

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -121,7 +121,7 @@ class Helpers
 
             if ($url[0] == '/' && !empty($chrootDirs)) {
                 foreach ($chrootDirs as $dir) {
-                    $ret = realpath($dir) . '/' . $url;
+                    $ret = realpath($dir) . $url;
                     $ret = preg_replace('/\?(.*)$/', "", $ret);
 
                     if ($filepath = realpath($ret)) {

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -43,21 +43,18 @@ class Helpers
     }
 
     /**
-     * builds a full url given a protocol, hostname, base path and url
+     * Builds a full url given a protocol, hostname, base path and URL.
+     *
+     * When the URL provided is a local file reference from the root of the filesystem
+     * (i.e., beginning with a "/") and the file does not resolve to a valid path,
+     * the path is validated against the chroot paths (if provided).
      *
      * @param string $protocol
      * @param string $host
      * @param string $base_path
      * @param string $url
+     * @param array  $chrootDirs array of strings representing the chroot paths
      * @return string
-     *
-     * Initially the trailing slash of $base_path was optional, and conditionally appended.
-     * However on dynamically created sites, where the page is given as url parameter,
-     * the base path might not end with an url.
-     * Therefore do not append a slash, and **require** the $base_url to ending in a slash
-     * when needed.
-     * Vice versa, on using the local file system path of a file, make sure that the slash
-     * is appended (o.k. also for Windows)
      */
     public static function build_url($protocol, $host, $base_path, $url, $chrootDirs = [])
     {

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -68,7 +68,7 @@ class Cache
         $message = null;
         
         try {
-            $full_url = Helpers::build_url($protocol, $host, $base_path, $url);
+            $full_url = Helpers::build_url($protocol, $host, $base_path, $url, $options->getChroot());
 
             if ($full_url === null) {
                 throw new ImageException("Unable to parse image URL $url.", E_WARNING);
@@ -154,7 +154,7 @@ class Cache
                                     continue;
                                 }
 
-                                $inner_full_url = Helpers::build_url($parsed_url["protocol"], $parsed_url["host"], $parsed_url["path"], $url);
+                                $inner_full_url = Helpers::build_url($parsed_url["protocol"], $parsed_url["host"], $parsed_url["path"], $url, $options->getChroot());
                                 if (empty($inner_full_url)) {
                                     continue;
                                 }

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -1270,7 +1270,8 @@ abstract class AbstractRenderer
                 $dompdf->getProtocol(),
                 $dompdf->getBaseHost(),
                 $dompdf->getBasePath(),
-                $href
+                $href,
+                $dompdf->getOptions()->getChroot()
             ) ?? $href;
             $this->_canvas->add_link($href, $x, $y, $w, $h);
         }


### PR DESCRIPTION
with chroot option set to ['/dir/dir1', /dir/dir2'] files will be search there too, 

ex : <link src='/css/file.css'> wiil be search in basePath AND in /dir/dir1/css/file.css or /dir/dir2/css/file.css