### PR TITLE
Implements render_progress event with PhpUnit tests

### DIFF
--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -241,6 +241,32 @@ class DompdfTest extends TestCase
         $this->assertSame(2, $called);
     }
 
+    public function testRenderProgressCallback(): void
+    {
+        $called = 0;
+
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "render_progress",
+                "f" => function ($percentage, $framesRendered, $framesTotal, $frame, $canvas, $fontMetrics) use (&$called) {
+                    $called++;
+                    $this->assertIsNumeric($percentage);
+                    $this->assertIsInt($framesRendered);
+                    $this->assertIsInt($framesTotal);
+                    $this->assertInstanceOf(Frame::class, $frame);
+                    $this->assertInstanceOf(Canvas::class, $canvas);
+                    $this->assertInstanceOf(FontMetrics::class, $fontMetrics);
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml("<html><body><p>Page 1</p><p style='page-break-before: always;'>Page 2</p></body></html>");
+        $dompdf->render();
+
+        $this->assertGreaterThanOrEqual(1, $called);
+    }
+
     public static function customCanvasProvider(): array
     {
         return [


### PR DESCRIPTION
This PR solves issue #3450, providing a new callback event to watch the `render_progress` and return the percentage for every stage of a frame being rendered.

```php
use Dompdf\Dompdf;

$dompdf = new Dompdf();

$dompdf->setCallbacks([
    'render_progress' => [
        'event' => 'render_progress',
        'f' => function (float $percentage, int $renderedFrames, int $totalFrames) {
            var_dump($percentage, $renderedFrames, $totalFrames);
        }
    ]
]);

$dompdf->loadHtml('<h1>Hello world</h1>');
$dompdf->setPaper('A4', 'portrait');
$dompdf->render();
```

The idea is to, before rendering, count all the frames recursively in the tree and store that value. Then, every time a frame is rendered, increment a counter to compare how many frames have been rendered and how many are left to render, so we can calculate the progress percentage. All the counting and storage are being done inside the scope of the `$dompdf->render()` method execution, inside the `$renderProgressData` variable.

To avoid changes to the `Dompdf` class callbacks property style (array of `['event' => array(fn(), fn()...)]`), we override the callback function of `render_progress` events only to receive `$renderProgressData` as a pointer. When a new frame is rendered, we can access `$renderProgressData` by passing a new array with the `data` and the original closure function as `f`, without the need to expose a variable globally or as a public property on the `Dompdf` class. Now we can track the changes using the private scope of the closure function.