### PR TITLE
Address php8.4 deprecation of with type hinting on NULL

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -330,7 +330,7 @@ class Options
     /**
      * @param array $attributes
      */
-    public function __construct(array $attributes = null)
+    public function __construct(?array $attributes = null)
     {
         $rootDir = realpath(__DIR__ . "/../");
         $this->setChroot(array($rootDir));


### PR DESCRIPTION
This avoids the following php 8.4 deprecation 

Dompdf\Options::__construct(): Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead