### PR TITLE
xml_set_*_handler() deprecation fix for PHP 8.4

### DIFF
--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -168,7 +168,7 @@ class Cache
                             }
                         }
                     },
-                    false
+                    function () {}
                 );
         
                 if (($fp = fopen($resolved_url, "r")) !== false) {

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -168,7 +168,7 @@ class Cache
                             }
                         }
                     },
-                    function () {}
+                    null
                 );
         
                 if (($fp = fopen($resolved_url, "r")) !== false) {


### PR DESCRIPTION
With the release of PHP 8.4, the xml_set_*_handler() function arguments must be callable or null. Otherwise is a deprecated warning thrown:

_Passing non-callable strings is deprecated since 8.4_

The message is a bit misleading as dompdf uses `false` as end handler and not a string.