### PR TITLE
Minor updates for the 3.1.0 release

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -86,7 +86,7 @@ class Cpdf
      * @var string The default font metrics file to use if no other font has been loaded.
      * The path to the directory containing the font metrics should be included
      */
-    public $defaultFont = './fonts/Helvetica.afm';
+    public $defaultFont = __DIR__ . '/fonts/Helvetica.afm';
 
     /**
      * @string A record of the current font

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -2530,27 +2530,6 @@ class Style
     /*==============================*/
 
     /**
-     * Parses a CSS string containing quotes and escaped hex characters.
-     *
-     * @param string $string The string to parse.
-     *
-     * @return string
-     */
-    protected function parse_string(string $string): string
-    {
-        // Strip string quotes and escapes
-        $string = preg_replace('/^["\']|["\']$/', "", $string);
-        $string = preg_replace("/\\\\([^0-9a-fA-F])/", "\\1", $string);
-
-        // Convert escaped hex characters (e.g. \A => newline)
-        return preg_replace_callback(
-            "/\\\\([0-9a-fA-F]{1,6})/",
-            function ($matches) { return Helpers::unichr(hexdec($matches[1])); },
-            $string
-        ) ?? "";
-    }
-
-    /**
      * Parse a property value into its components.
      *
      * @param string $value
@@ -4119,7 +4098,7 @@ class Style
                 return null;
             }
 
-            $quotes[] = $this->parse_string($value);
+            $quotes[] = $this->_stylesheet->parse_string($value);
         }
 
         if ($quotes === [] || \count($quotes) % 2 !== 0) {
@@ -4151,7 +4130,7 @@ class Style
         foreach ($components as $value) {
             // String
             if (strncmp($value, '"', 1) === 0 || strncmp($value, "'", 1) === 0) {
-                $parts[] = new StringPart($this->parse_string($value));
+                $parts[] = new StringPart($this->_stylesheet->parse_string($value));
                 continue;
             }
 
@@ -4225,7 +4204,7 @@ class Style
                 }
 
                 $name = $matches[1];
-                $string = $this->parse_string($matches[2]);
+                $string = $this->_stylesheet->parse_string($matches[2]);
                 $type = isset($matches[3]) ? strtolower($matches[3]) : "decimal";
 
                 if (!$this->isValidCounterName($name)
@@ -4239,7 +4218,7 @@ class Style
 
             // url()
             elseif ($function === "url") {
-                $url = $this->parse_string($arguments);
+                $url = $this->_stylesheet->parse_string($arguments);
                 $parts[] = new Url($url);
             }
 

--- a/src/Css/Style.php
+++ b/src/Css/Style.php
@@ -1347,6 +1347,9 @@ class Style
             } elseif (\in_array($part, $ops, true)) {
                 $rightValue = array_pop($stack);
                 $leftValue = array_pop($stack);
+                if ($rightValue === null || $leftValue === null) {
+                    return null;
+                }
                 switch ($part) {
                     case '*':
                         $stack[] = $leftValue * $rightValue;

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -62,6 +62,13 @@ class Stylesheet
     const PATTERN_CSS_STRING = '(?<CSS_STRING>(?<CSS_STRING_QUOTE>[\'"])(?<CSS_STRING_VALUE>.*?)(?<!\\\\)\g{CSS_STRING_QUOTE})';
 
     /**
+     * RegEx pattern representing the CSS var() function
+     *
+     * @var string
+     */
+    const PATTERN_CSS_VAR_FN = "var\((([^()]|(?R))*)\)";
+
+    /**
      * RegEx pattern representing the CSS url() function
      *
      * @var string
@@ -1004,7 +1011,12 @@ class Stylesheet
                         // https://www.w3.org/TR/CSS21/generate.html#content
                         // https://www.w3.org/TR/CSS21/generate.html#undisplayed-counters
                         if ($content === "normal" || $content === "none") {
-                            continue;
+                            $specified = $style->get_specified("content");
+                            if (!\preg_match("/". self::PATTERN_CSS_VAR_FN . "/", $specified)) {
+                                continue;
+                            } else {
+                                $content = [];
+                            }
                         }
 
                         // https://www.w3.org/TR/css-content-3/#content-property

--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -506,6 +506,7 @@ class Stylesheet
 
             // Eat characters up to the next delimiter
             $tok = "";
+            $escape = false;
             $in_attr = false;
             $in_func = false;
 
@@ -513,7 +514,13 @@ class Stylesheet
                 $c = $selector[$i];
                 $c_prev = $selector[$i - 1];
 
-                if (!$in_func && !$in_attr && in_array($c, $delimiters, true) && !($c === $c_prev && $c === ":")) {
+                if ($c_prev === "\\" && !$escape) {
+                    $escape = true;
+                } elseif ($escape === true) {
+                    $escape = false;
+                }
+
+                if (!$escape && !$in_func && !$in_attr && in_array($c, $delimiters, true) && !($c === $c_prev && $c === ":")) {
                     break;
                 }
 
@@ -526,15 +533,17 @@ class Stylesheet
 
                 $tok .= $selector[$i++];
 
-                if ($in_attr && $c === "]") {
+                if (!$escape && $in_attr && $c === "]") {
                     $in_attr = false;
                     break;
                 }
-                if ($in_func && $c === ")") {
+                if (!$escape && $in_func && $c === ")") {
                     $in_func = false;
                     break;
                 }
             }
+            $tok = $this->parse_string($tok);
+    
 
             switch ($s) {
 
@@ -1681,7 +1690,7 @@ EOL;
         $properties[] = $str;
         $style = new Style($this, Stylesheet::ORIG_AUTHOR);
         foreach ($properties as $prop) {
-            $prop = str_replace("\\;", ";", trim($prop));
+            $prop = trim($prop);
             if ($prop === "") {
                 continue;
             }
@@ -1778,6 +1787,28 @@ EOL;
         if ($DEBUGCSS) {
             print "_parse_sections]\n";
         }
+    }
+
+    /**
+     * Parses a CSS string containing quotes and escaped hex characters.
+     * https://www.w3.org/TR/CSS21/syndata.html#characters
+     *
+     * @param string $string The string to parse.
+     *
+     * @return string
+     */
+    public function parse_string(string $string): string
+    {
+        // Strip string quotes and escapes
+        $string = preg_replace('/^["\']|["\']$/', "", $string);
+        $string = preg_replace("/\\\\([^0-9a-fA-F])/", "\\1", $string);
+
+        // Convert escaped hex characters (e.g. \A => newline)
+        return preg_replace_callback(
+            "/\\\\([0-9a-fA-F]{1,6})\s?/",
+            function ($matches) { return Helpers::unichr(hexdec($matches[1])); },
+            $string
+        ) ?? "";
     }
 
     /**

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -498,14 +498,14 @@ abstract class AbstractFrameReflower
      *
      * @return string The resulting string
      */
-    protected function resolve_content(): string
+    protected function resolve_content(): ?string
     {
         $frame = $this->_frame;
         $style = $frame->get_style();
         $content = $style->content;
 
         if ($content === "normal" || $content === "none") {
-            return "";
+            return null;
         }
 
         $quotes = $style->quotes;
@@ -586,7 +586,7 @@ abstract class AbstractFrameReflower
         if ($frame->get_node()->nodeName === "dompdf_generated") {
             $content = $this->resolve_content();
 
-            if ($content !== "") {
+            if ($content !== null) {
                 $node = $frame->get_node()->ownerDocument->createTextNode($content);
 
                 $new_style = $style->get_stylesheet()->create_style();

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -113,7 +113,16 @@ abstract class AbstractFrameReflower
                     break;
                 }
             case "fixed":
-                $initial_cb = $frame->get_root()->get_first_child()->get_containing_block();
+                $root = $frame->get_root();
+                $parent = $frame->get_parent();
+                do {
+                    $parents_parent = $parent->get_parent();
+                    if ($parents_parent == $root) {
+                        break;
+                    }
+                    $parent = $parents_parent;
+                } while ($parent);
+                $initial_cb = $parent->get_containing_block();
                 $frame->set_containing_block($initial_cb["x"], $initial_cb["y"], $initial_cb["w"], $initial_cb["h"]);
                 break;
             default:

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -277,8 +277,13 @@ class Helpers
      */
     public static function parse_data_uri($data_uri)
     {
-        if (!preg_match('/^data:(?P<mime>[a-z0-9\/+-.]+)(;charset=(?P<charset>[a-z0-9-])+)?(?P<base64>;base64)?\,(?P<data>.*)?/is', $data_uri, $match)) {
-            return false;
+        $expression = '/^data:(?P<mime>[a-z0-9\/+-.]+)(;charset=(?P<charset>[a-z0-9-])+)?(?P<base64>;base64)?\,(?P<data>.*)?/is';
+        if (!preg_match($expression, $data_uri, $match)) {
+            $parts = explode(",", $data_uri);
+            $parts[0] = preg_replace('/\\s/', '', $parts[0]);
+            if (preg_match('/\\s/', $data_uri) && !preg_match($expression, implode(",", $parts), $match)) {
+                return false;
+            }
         }
 
         $match['data'] = rawurldecode($match['data']);

--- a/tests/Css/SelectorTest.php
+++ b/tests/Css/SelectorTest.php
@@ -742,6 +742,12 @@ class SelectorTest extends TestCase
                 '[title*=""]',
                 '<body><div title="multiple tokens"></div><div title=""></div></body>'
             ],
+
+            // escaped selector characteres
+            "escaped classname characters" => [
+                '.w-\[var\(--sidebar-width\)\]',
+                '<body><div class="w-\[var\(--sidebar-width\)\]"></div></body>'
+            ]
         ];
     }
 
@@ -792,9 +798,6 @@ class SelectorTest extends TestCase
     public static function selectorInvalidProvider(): array
     {
         return [
-            // Valid but unsupported selector syntax
-            [".w-\[var\(--sidebar-width\)\]"],
-
             // Invalid selectors
             [":unknown"],
             ["p:unknown"],

--- a/tests/Css/StyleTest.php
+++ b/tests/Css/StyleTest.php
@@ -202,6 +202,37 @@ class StyleTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public static function widthProvider(): array
+    {
+        return [
+            [[ "width" => "100pt" ], 1000.0, 100.0],
+            [[ "width" => "calc(100% + 100%)", "font-size: 12pt;" ], 1000.0, 2000.0],
+            [[ "width" => "calc(100% + var(--expand-by))", "--expand-by" => "100pt"], 1000.0, 1100.0],
+            [[ "width" => "calc(100% + var(--invalid))"], 1000.0, "auto"]
+        ];
+    }
+    
+    /**
+     * @dataProvider widthProvider
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('widthProvider')]
+    public function testSetWidth(array $properties, ?float $ref_size, $expected, ?int $precision = null): void
+    {
+        $dompdf = new Dompdf();
+        $sheet = new Stylesheet($dompdf);
+        $s = new Style($sheet);
+
+        foreach ($properties as $prop => $value) {
+            $s->set_prop($prop, $value);
+        }
+        $result = $s->length_in_pt($s->width, $ref_size);
+        if ($precision !== null) {
+            $result = round($result, $precision);
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
     public static function cssImageBasicProvider(): array
     {
         return [


### PR DESCRIPTION
- Fixes body element retrieval for fixed-position elements
- Fixes potentially invalid font reference in Cpdf
- Updates conditional pseudo-element (::before/::after) generation and rendering
- Halts CSS calculations when operands are missing
- Adds support for CSS selectors with escaped characters