### PR TITLE
FIX: Escape encrypted strings

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1404,7 +1404,7 @@ class Cpdf
 
                 if ($this->encrypted) {
                     $this->encryptInit($id);
-                    $ordering = $this->ARC4($ordering);
+                    $ordering = $this->filterText($this->ARC4($ordering), false, false);
                     $registry = $this->filterText($this->ARC4($registry), false, false);
                 }
 
@@ -1673,8 +1673,8 @@ EOT;
 
                 if ($this->encrypted) {
                     $this->encryptInit($id);
-                    $ordering = $this->ARC4($ordering);
-                    $registry = $this->ARC4($registry);
+                    $ordering = $this->filterText($this->ARC4($ordering), false, false);
+                    $registry = $this->filterText($this->ARC4($registry), false, false);
                 }
 
 
@@ -2816,7 +2816,7 @@ EOT;
 
                 $date = "D:" . substr_replace(date('YmdHisO'), '\'', -2, 0) . '\'';
                 if ($encrypted) {
-                    $date = $this->ARC4($date);
+                    $date = $this->filterText($this->ARC4($date), false, false);
                 }
 
                 $res .= "/M ($date)\n";
@@ -2992,6 +2992,8 @@ EOT;
                             $filename = $entry['filename'];
                         }
 
+                        $filename = $this->filterText($filename, false, false);
+
                         $res .= "($filename) " . $entry['dict_reference'] . " 0 R ";
                     }
 
@@ -3068,7 +3070,7 @@ EOT;
 
                 if ($this->encrypted) {
                     $this->encryptInit($id);
-                    $checksum = $this->ARC4($checksum);
+                    $checksum = $this->filterText($this->ARC4($checksum), false, false);
                     $file_content_compressed = $this->ARC4($file_content_compressed);
                 }
                 $file_size_compressed = mb_strlen($file_content_compressed, '8bit');


### PR DESCRIPTION
Hey,

We are using this package to generate encrypted documents and it works fine for some time now. Lately we found 1 case where opening it in Adobe Reader displays blank pages, but it still looks fine in Google Chrome for example.
Checking the PDF with `qpdf` gave the following warnings:
```
WARNING: filename.pdf (object 11 0, offset 4423): unknown token while reading object; treating as string
WARNING: filename.pdf (object 11 0, offset 4424): unexpected )
WARNING: filename.pdf (object 11 0, offset 4392): expected dictionary key but found non-name object; inserting key /QPDFFake1
WARNING: filename.pdf (object 11 0, offset 4392): expected dictionary key but found non-name object; inserting key /QPDFFake2
WARNING: filename.pdf (object 30 0, offset 52569): unknown token while reading object; treating as string
WARNING: filename.pdf (object 30 0, offset 52581): unknown token while reading object; treating as string
WARNING: filename.pdf (object 30 0, offset 52585): treating unexpected brace token as null
WARNING: filename.pdf (object 30 0, offset 52586): unknown token while reading object; treating as string
WARNING: filename.pdf (object 30 0, offset 52591): unknown token while reading object; treating as string
WARNING: filename.pdf (object 30 0, offset 52605): unknown token while reading object; treating as string
WARNING: filename.pdf (object 30 0, offset 52605): too many errors; giving up on reading object
WARNING: filename.pdf (object 30 0, offset 52608): expected endobj
```

Checking the mentioned objects(11 and 30) we have noticed that not all encrypted strings are escaped properly:
Both objects are the same unencrypted:
```
11 0 obj
<</Registry (Adobe)
/Ordering (UCS)
/Supplement 0
>>
endobj
```
The encrypted version:
```
11 0 obj
<</Registry (��N�)
/Ordering (�)�)
/Supplement 0
>>
endobj
```
```
30 0 obj
<</Registry (�+R%)
/Ordering (�()
/Supplement 0
>>
endobj
```

The problem is that the `/Ordering` string value contains `0x29` and `0x28` which are the opening and closing parenthesis. Some readers fail to handle it and they doesn't render the document properly.

After checking the whole file I've found a couple places where the `filterText` call was missing and added them where it seemed necessary to escape these strings properly.