### PR TITLE
Updates to canvas adapter usage and Cpdf implementation

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -5017,7 +5017,6 @@ EOT;
         $debug = !$options['compress'];
         $tmp = ltrim($this->output($debug));
 
-        header("Cache-Control: private");
         header("Content-Type: application/pdf");
         header("Content-Length: " . mb_strlen($tmp, "8bit"));
 

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1627,9 +1627,6 @@ EOT;
                             break;
                     }
                 }
-
-                // pass values down to cid to gid map
-                $this->o_fontGIDtoCIDMap($o['info']['cidToGidMap'], 'add', $options);
                 break;
 
             case 'out':

--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -1837,17 +1837,6 @@ EOT;
                     ]
                 ];
                 break;
-            case 'Title':
-            case 'Author':
-            case 'Subject':
-            case 'Keywords':
-            case 'Creator':
-            case 'Producer':
-            case 'CreationDate':
-            case 'ModDate':
-            case 'Trapped':
-                $this->objects[$id]['info'][$action] = $options;
-                break;
 
             case 'out':
                 $encrypted = $this->encrypted;
@@ -1876,6 +1865,22 @@ EOT;
                 $res .= ">>\nendobj";
 
                 return $res;
+
+            case 'Title':
+            case 'Author':
+            case 'Subject':
+            case 'Keywords':
+            case 'Creator':
+            case 'Producer':
+            case 'CreationDate':
+            case 'ModDate':
+            case 'Trapped':
+            default:
+                $val = "$options";
+                if (strlen($val) > 0) {
+                    $this->objects[$id]['info'][$action] = $val;
+                    break;
+                }
         }
 
         return null;

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -971,7 +971,6 @@ class CPDF implements Canvas
         $debug = !$options['compress'];
         $tmp = ltrim($this->_pdf->output($debug));
 
-        header("Cache-Control: private");
         header("Content-Type: application/pdf");
         header("Content-Length: " . mb_strlen($tmp, "8bit"));
 

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -983,7 +983,6 @@ class GD implements Canvas
                 break;
         }
 
-        header("Cache-Control: private");
         header("Content-Type: $contentType");
 
         $filename = str_replace(["\n", "'"], "", basename($filename, ".$type")) . $extension;

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1409,7 +1409,6 @@ class PDFLib implements Canvas
             $size = filesize($this->_file);
         }
 
-        header("Cache-Control: private");
         header("Content-Type: application/pdf");
         header("Content-Length: " . $size);
 


### PR DESCRIPTION
- Address loss of options due to canvas adapter re-initialization. Due to a lack of functionality in the Cpdf class, a change to the page size after instantiation requires re-instantiation. Depending on when options were set, they may not be used during rendering. This change modifies options handling so that the adapter is re-initialized when the options are changed.
- Remove cache-control headers
- Allows custom document information when using the Cpdf adapter