### PR TITLE
Improve PHP 8.5 compatibility

### DIFF
--- a/lib/Cpdf.php
+++ b/lib/Cpdf.php
@@ -6049,7 +6049,9 @@ EOT;
             // Cast to 8bit+palette
             $imgalpha_ = @imagecreatefrompng($tempfile_alpha);
             imagecopy($imgalpha, $imgalpha_, 0, 0, 0, 0, $wpx, $hpx);
-            imagedestroy($imgalpha_);
+            if (PHP_MAJOR_VERSION < 8) {
+                imagedestroy($imgalpha_);
+            }
             imagepng($imgalpha, $tempfile_alpha);
 
             // Make opaque image
@@ -6104,7 +6106,9 @@ EOT;
                 // Cast to 8bit+palette
                 $imgalpha_ = @imagecreatefrompng($tempfile_alpha);
                 imagecopy($imgalpha, $imgalpha_, 0, 0, 0, 0, $wpx, $hpx);
-                imagedestroy($imgalpha_);
+                if (PHP_MAJOR_VERSION < 8) {
+                    imagedestroy($imgalpha_);
+                }
                 imagepng($imgalpha, $tempfile_alpha);
             } else {
                 $tempfile_alpha = null;
@@ -6158,7 +6162,9 @@ EOT;
             // extract image without alpha channel
             $imgplain = imagecreatetruecolor($wpx, $hpx);
             imagecopy($imgplain, $img, 0, 0, 0, 0, $wpx, $hpx);
-            imagedestroy($img);
+            if (PHP_MAJOR_VERSION < 8) {
+                imagedestroy($img);
+            }
 
             imagepng($imgalpha, $tempfile_alpha);
             imagepng($imgplain, $tempfile_plain);
@@ -6169,13 +6175,17 @@ EOT;
         // embed mask image
         if ($tempfile_alpha) {
             $this->addImagePng($imgalpha, $tempfile_alpha, $x, $y, $w, $h, true);
-            imagedestroy($imgalpha);
+            if (PHP_MAJOR_VERSION < 8) {
+                imagedestroy($imgalpha);
+            }
             $this->imageCache[] = $tempfile_alpha;
         }
 
         // embed image, masked with previously embedded mask
         $this->addImagePng($imgplain, $tempfile_plain, $x, $y, $w, $h, false, ($tempfile_alpha !== null));
-        imagedestroy($imgplain);
+        if (PHP_MAJOR_VERSION < 8) {
+            imagedestroy($imgplain);
+        }
         $this->imageCache[] = $tempfile_plain;
     }
 
@@ -6260,11 +6270,13 @@ EOT;
             }
 
             imagecopy($img, $imgtmp, 0, 0, 0, 0, $sx, $sy);
-            imagedestroy($imgtmp);
+            if (PHP_MAJOR_VERSION < 8) {
+                imagedestroy($imgtmp);
+            }
         }
         $this->addImagePng($img, $file, $x, $y, $w, $h);
 
-        if ($img) {
+        if ($img && PHP_MAJOR_VERSION < 8) {
             imagedestroy($img);
         }
     }

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -620,7 +620,9 @@ class CPDF implements Canvas
                 $filename = "$tmp_name.png";
 
                 imagepng($im, $filename);
-                imagedestroy($im);
+                if (PHP_MAJOR_VERSION < 8) {
+                    imagedestroy($im);
+                }
             } else {
                 $filename = null;
             }

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -1055,7 +1055,7 @@ class GD implements Canvas
                 break;
         }
 
-        if ($this->_aa_factor != 1) {
+        if ($this->_aa_factor != 1 && PHP_MAJOR_VERSION < 8) {
             imagedestroy($dst);
         }
     }

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1100,7 +1100,9 @@ class PDFLib implements Canvas
                 $filename = "$tmp_name.png";
 
                 imagepng($im, $filename);
-                imagedestroy($im);
+                if (PHP_MAJOR_VERSION < 8) {
+                    imagedestroy($im);
+                }
             } else {
                 $filename = null;
             }

--- a/src/Css/AttributeTranslator.php
+++ b/src/Css/AttributeTranslator.php
@@ -503,7 +503,7 @@ class AttributeTranslator
             $width = "100%";
         }
 
-        $remainder = 100 - (double)rtrim($width, "% ");
+        $remainder = 100 - (float)rtrim($width, "% ");
 
         switch ($value) {
             case "left":

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1020,6 +1020,7 @@ class Helpers
 
         try {
             if ($is_local_path || ini_get('allow_url_fopen') && !$can_use_curl) {
+                $http_response_header = null;
                 if ($is_local_path === false) {
                     $uri = Helpers::encodeURI($uri);
                 }
@@ -1031,7 +1032,9 @@ class Helpers
                 if ($result !== false) {
                     $content = $result;
                 }
-                if (isset($http_response_header)) {
+                if (version_compare(PHP_VERSION, "8.4.0", ">=")) {
+                    $headers = \http_get_last_response_headers();
+                } elseif (isset($http_response_header)) {
                     $headers = $http_response_header;
                 }
 
@@ -1101,7 +1104,10 @@ class Helpers
                             break;
                     }
                 }
-                curl_close($curl);
+
+                if (PHP_MAJOR_VERSION < 8) {
+                    curl_close($curl);
+                }
             }
         } finally {
             restore_error_handler();

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -515,7 +515,9 @@ abstract class AbstractRenderer
 
             if ($img_w != $org_img_w || $img_h != $org_img_h) {
                 $newSrc = imagescale($src, $img_w, $img_h);
-                imagedestroy($src);
+                if (PHP_MAJOR_VERSION < 8) {
+                    imagedestroy($src);
+                }
                 $src = $newSrc;
             }
 
@@ -622,7 +624,9 @@ abstract class AbstractRenderer
                 print 'Unknown repeat!';
             }
 
-            imagedestroy($src);
+            if (PHP_MAJOR_VERSION < 8) {
+                imagedestroy($src);
+            }
 
             if ($cpdfFromGd && $this->_canvas instanceof CPDF) {
                 // Skip writing temp file as the GD object is added directly
@@ -633,7 +637,9 @@ abstract class AbstractRenderer
                 $tmpFile = "$tmpName.png";
 
                 imagepng($bg, $tmpFile);
-                imagedestroy($bg);
+                if (PHP_MAJOR_VERSION < 8) {
+                    imagedestroy($bg);
+                }
 
                 Cache::addTempImage($img, $tmpFile, $key);
             }
@@ -654,7 +660,7 @@ abstract class AbstractRenderer
             // Note: CPDF_Adapter image converts y position
             $this->_canvas->get_cpdf()->addImagePng($bg, $cpdfKey, $x, $this->_canvas->get_height() - $y - $height, $width, $height);
 
-            if (isset($bg)) {
+            if (isset($bg) && PHP_MAJOR_VERSION < 8) {
                 imagedestroy($bg);
             }
         } else {


### PR DESCRIPTION
- only use imagedestroy with PHP < 8
- only use curl_close with PHP < 8
- use http_get_last_response_headers with PHP >= 8.4
- use canonical types for casts

addresses #3644