### PR TITLE
Rendering improvements

### DIFF
--- a/src/Cellmap.php
+++ b/src/Cellmap.php
@@ -722,6 +722,12 @@ class Cellmap
                 continue;
             }
 
+            // Column calculation for fixed-layout tables should ony use the first row's cells
+            // https://www.w3.org/TR/CSS2/tables.html#fixed-table-layout
+            if ($this->_fixed_layout && !in_array(0, $frame_info["rows"], true)) {
+                continue;
+            }
+
             $node = $frame->get_node();
             $colspan = max((int) $node->getAttribute("colspan"), 1);
             $first_col = $frame_info["columns"][0];
@@ -766,7 +772,7 @@ class Cellmap
             if ($frame_min > $min && $colspan === 1) {
                 // The frame needs more space.  Expand each sub-column
                 // FIXME try to avoid putting this dummy value when table-layout:fixed
-                $inc = ($this->is_layout_fixed() ? 10e-10 : ($frame_min - $min));
+                $inc = ($this->_fixed_layout ? 10e-10 : ($frame_min - $min));
                 for ($c = 0; $c < $colspan; $c++) {
                     $col =& $this->get_column($first_col + $c);
                     $col["min-width"] += $inc;
@@ -775,7 +781,7 @@ class Cellmap
 
             if ($frame_max > $max) {
                 // FIXME try to avoid putting this dummy value when table-layout:fixed
-                $inc = ($this->is_layout_fixed() ? 10e-10 : ($frame_max - $max) / $colspan);
+                $inc = ($this->_fixed_layout ? 10e-10 : ($frame_max - $max) / $colspan);
                 for ($c = 0; $c < $colspan; $c++) {
                     $col =& $this->get_column($first_col + $c);
                     $col["max-width"] += $inc;

--- a/src/FrameDecorator/AbstractFrameDecorator.php
+++ b/src/FrameDecorator/AbstractFrameDecorator.php
@@ -173,7 +173,13 @@ abstract class AbstractFrameDecorator extends Frame
             $node->removeAttribute("id");
         }
 
-        return Factory::decorate_frame($frame, $this->_dompdf, $this->_root);
+        $deco = Factory::decorate_frame($frame, $this->_dompdf, $this->_root);
+
+        if ($this instanceof Text) {
+            $deco->trailingWs = $this->trailingWs;
+        }
+
+        return $deco;
     }
 
     /**
@@ -196,6 +202,10 @@ abstract class AbstractFrameDecorator extends Frame
         }
 
         $deco = Factory::decorate_frame($frame, $this->_dompdf, $this->_root);
+
+        if ($this instanceof Text) {
+            $deco->trailingWs = $this->trailingWs;
+        }
 
         foreach ($this->get_children() as $child) {
             $deco->append_child($child->deep_copy());

--- a/src/FrameDecorator/Table.php
+++ b/src/FrameDecorator/Table.php
@@ -65,7 +65,8 @@ class Table extends AbstractFrameDecorator
         parent::__construct($frame, $dompdf);
         $this->_cellmap = new Cellmap($this);
 
-        if ($frame->get_style()->table_layout === "fixed") {
+        $style = $frame->get_style();
+        if ($style->table_layout === "fixed" && $style->width !== "auto") {
             $this->_cellmap->set_layout_fixed(true);
         }
 

--- a/src/FrameReflower/AbstractFrameReflower.php
+++ b/src/FrameReflower/AbstractFrameReflower.php
@@ -429,11 +429,13 @@ abstract class AbstractFrameReflower
             }
 
             // Skip children with absolute position
-            if ($iter->valid() && !$iter->current()->is_absolute()) {
+            if ($iter->valid()) {
                 /** @var AbstractFrameDecorator */
                 $child = $iter->current();
                 $child->get_reflower()->_set_content();
-                list($low[], $high[]) = $child->get_min_max_width();
+                if (!$iter->current()->is_absolute()) {
+                    list($low[], $high[]) = $child->get_min_max_width();
+                }
             }
         }
 

--- a/src/FrameReflower/Text.php
+++ b/src/FrameReflower/Text.php
@@ -51,14 +51,6 @@ class Text extends AbstractFrameReflower
     protected $_frame;
 
     /**
-     * Saves trailing whitespace trimmed after a line break, so it can be
-     * restored when needed.
-     *
-     * @var string|null
-     */
-    protected $trailingWs = null;
-
-    /**
      * @var FontMetrics
      */
     private $fontMetrics;
@@ -445,30 +437,12 @@ class Text extends AbstractFrameReflower
      */
     public function trim_trailing_ws(): void
     {
-        $frame = $this->_frame;
-        $text = $frame->get_text();
-        $trailing = mb_substr($text, -1, null, "UTF-8");
-
-        // White space is always collapsed to the standard space character
-        // currently, so only handle that for now
-        if ($trailing === " ") {
-            $this->trailingWs = $trailing;
-            $frame->set_text(mb_substr($text, 0, -1, "UTF-8"));
-            $frame->recalculate_width();
-        }
+        $this->_frame->trim_trailing_ws();
     }
 
     public function reset(): void
     {
         parent::reset();
-
-        // Restore trimmed trailing white space, as the frame will go through
-        // another reflow and line breaks might be different after a split
-        if ($this->trailingWs !== null) {
-            $text = $this->_frame->get_text();
-            $this->_frame->set_text($text . $this->trailingWs);
-            $this->trailingWs = null;
-        }
     }
 
     //........................................................................

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -250,6 +250,36 @@ class Helpers
     }
 
     /**
+     * Converts decimal numbers to base26 (hexavigesimal)
+     * represented in lower case letters.
+     *
+     * @param int|string $num
+     *
+     * @throws Exception
+     * @return string
+     */
+    public static function dec2base26($num): string
+    {
+        if (!is_numeric($num)) {
+            throw new Exception("dec2base26() requires a numeric argument.");
+        }
+
+        $num = intval($num);
+
+        if ($num <= 0) {
+            return (string) $num;
+        }
+
+        $ret = '';
+        while ($num > 0) {
+            $remainder = ($num - 1) % 26;
+            $ret = chr(97 + $remainder) . $ret;
+            $num = intval(($num - 1) / 26);
+        }
+        return $ret;
+    }
+
+    /**
      * Restrict a length to the given range.
      *
      * If min > max, the result is min.

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -514,7 +514,10 @@ abstract class AbstractRenderer
             }
 
             if ($img_w != $org_img_w || $img_h != $org_img_h) {
-                $newSrc = imagescale($src, $img_w, $img_h);
+                $newSrc = imagecreatetruecolor($img_w, $img_h);
+                imagealphablending($newSrc, false);
+                imagesavealpha($newSrc, true);
+                imagecopyresampled($newSrc, $src, 0, 0, 0, 0, $img_w, $img_h, imagesx($src), imagesy($src));
                 imagedestroy($src);
                 $src = $newSrc;
             }

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -93,12 +93,12 @@ class ListBullet extends AbstractRenderer
 
             case "upper-alpha":
             case "upper-latin":
-                $text = chr((($n - 1) % 26) + ord('A'));
+                $text = strtoupper(Helpers::dec2base26($n));
                 break;
 
             case "lower-alpha":
             case "lower-latin":
-                $text = chr((($n - 1) % 26) + ord('a'));
+                $text = Helpers::dec2base26($n);
                 break;
 
             case "upper-roman":


### PR DESCRIPTION
- Improves column width calculation for tables with fixed layout
- Uses resampling instead of scaling for background images
- Fully supports alpha list numbering
- Fixes potential loss of space between text nodes during reflow
- Fixes counter resolution when contained in elements with a content-defined width