### PR TITLE
Check existence of VERSION file

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -356,7 +356,7 @@ class Options
 
         $ver = "";
         $versionFile = realpath(__DIR__ . '/../VERSION');
-        if (($version = file_get_contents($versionFile)) !== false) {
+        if (file_exists($versionFile) && ($version = file_get_contents($versionFile)) !== false) {
             $version = trim($version);
             if ($version !== '$Format:<%h>$') {
                 $ver = "/$version";


### PR DESCRIPTION
If "VERSION" file is missing, there is error "Path must not be empty", so we must check, if file is existing.

PHP 8.5 environment

Why can VERSION file be missing in some specific situations?
Someone wants a minimalist version and removes all unnecessary files and leaves only functional things.