### PR TITLE
Added support for AVIF images on PHP>=8.1

### DIFF
--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -657,6 +657,8 @@ class CPDF implements Canvas
 
             case "webp":
             /** @noinspection PhpMissingBreakStatementInspection */
+            case "avif":
+            /** @noinspection PhpMissingBreakStatementInspection */
             case "gif":
             /** @noinspection PhpMissingBreakStatementInspection */
             case "bmp":

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -1131,6 +1131,7 @@ class PDFLib implements Canvas
 
         if (!isset($this->_imgs[$img])) {
             switch (strtolower($img_type)) {
+                case "avif":
                 case "webp":
                     $img = $this->_convert_to_png($img, $img_type);
                     if ($img === null) {

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -809,10 +809,13 @@ class Helpers
             IMAGETYPE_GIF  => "gif",
             IMAGETYPE_BMP  => "bmp",
             IMAGETYPE_PNG  => "png",
-            IMAGETYPE_WEBP => "webp"
+            IMAGETYPE_WEBP => "webp",
         ];
         if (defined('IMAGETYPE_SVG')) {
             $types[IMAGETYPE_SVG] = "svg";
+        }
+        if (defined('IMAGETYPE_AVIF')) {
+            $types[IMAGETYPE_AVIF] = "avif";
         }
 
         if (isset($cache[$filename])) {

--- a/src/Image/Cache.php
+++ b/src/Image/Cache.php
@@ -130,7 +130,7 @@ class Cache
 
             list($width, $height, $type) = Helpers::dompdf_getimagesize($resolved_url, $options->getHttpContext());
 
-            if (($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg","webp"], true)) === false) {
+            if (($width && $height && in_array($type, ["gif", "png", "jpeg", "bmp", "svg", "webp", "avif"], true)) === false) {
                 throw new ImageException("Image type unknown", E_WARNING);
             }
 

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -497,6 +497,15 @@ abstract class AbstractRenderer
                     $src = @imagecreatefromwebp($img);
                     break;
 
+                case "avif":
+                    // Conditional while targeting PHP < 8.1 where function may not exist
+                    if (function_exists('imagecreatefromavif')) {
+                        $src = @imagecreatefromavif($img);
+                    } else {
+                        $src = null;
+                    }
+                    break;
+
                 case "gif":
                     $src = @imagecreatefromgif($img);
                     break;


### PR DESCRIPTION
As raised/requested in #3600.

_Feel free to just close or take-over this PR if it'd be less work for you to implement yourself in the future, I don't want to consume more of your time than necessary._ 

I generally looked at all areas related to webp, and added avif support in a similar manner, being careful to consider the lack of support on older PHP versions.

I manually tested using both `CPDF` and `GD` back-ends, which appeared to work fine in rendering my AVIF image.
I did not test against `PDFLib`, but looking at the logic, I'm hoping that what I've implemented should be fine (falling through to webp case which performs a PHP-side conversion to PNG).
I also tested via PHP 7.1, to ensure the implementation does not result in errors (upon just rendering the "not-found" placeholder).

I wasn't sure if there were useful PHPUnit tests I could add here, I couldn't find existing tests that cover specific image formats, but I'd be happy to add some upon light direction if needed.

Here's example test code that I was using for development:

<details><summary>Code Here</summary>
<p>

```php
<?php

use Dompdf\Dompdf;
use Dompdf\Options;

require __DIR__ . '/vendor/autoload.php';

$options = new Options();
$options->setChroot(__DIR__);
//$options->setPdfBackend('GD');

$dompdf = new Dompdf($options);
$dompdf->loadHtml('<html><body><p>Hello <img src="cat.avif">  world!</p></body></html>', "UTF-8");

$dompdf->render();
$pdf = $dompdf->output();

file_put_contents('test.pdf', $pdf);
```

</p>
</details> 

Here's a small AVIF file of mine which I was also using to test, for convenience. I've uploaded in a ZIP since GitHub does not allow avif image uploads:

[cat.zip](https://github.com/user-attachments/files/24390021/cat.zip)
