### PR TITLE
Add basic support for PDF/UA with Cpdf

### DIFF
--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -10,6 +10,8 @@ use Dompdf\Canvas;
 use Dompdf\Dompdf;
 use Dompdf\Helpers;
 use Dompdf\Image\Cache;
+use Dompdf\StructTree;
+use Dompdf\StructTree\DummyStructTree;
 
 /**
  * Image rendering interface
@@ -1009,6 +1011,10 @@ class GD implements Canvas
         return ob_get_clean();
     }
 
+    public function set_language(string $language): void
+    {
+    }
+
     /**
      * Outputs the image stream directly.
      *
@@ -1057,5 +1063,10 @@ class GD implements Canvas
         if ($this->_aa_factor != 1 && PHP_MAJOR_VERSION < 8) {
             imagedestroy($dst);
         }
+    }
+
+    public function get_struct_tree(): StructTree
+    {
+        return new DummyStructTree();
     }
 }

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -12,6 +12,8 @@ use Dompdf\Exception;
 use Dompdf\FontMetrics;
 use Dompdf\Helpers;
 use Dompdf\Image\Cache;
+use Dompdf\StructTree;
+use Dompdf\StructTree\DummyStructTree;
 
 /**
  * PDF rendering interface
@@ -1478,6 +1480,15 @@ class PDFLib implements Canvas
         }
 
         return $data;
+    }
+
+    public function set_language(string $language): void
+    {
+    }
+
+    public function get_struct_tree(): StructTree
+    {
+        return new DummyStructTree();
     }
 
     /**

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -484,4 +484,8 @@ interface Canvas
      * @return string
      */
     function output($options = []);
+
+    public function set_language(string $language): void;
+
+    public function get_struct_tree(): StructTree;
 }

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -787,6 +787,11 @@ class Dompdf
             $canvas->add_info("Title", trim($title->item(0)->nodeValue));
         }
 
+        $language = $this->dom->getElementsByTagName('html');
+        if ($language->length && $language[0]->getAttribute('lang')) {
+            $canvas->set_language($language[0]->getAttribute('lang'));
+        }
+
         $metas = $this->dom->getElementsByTagName("meta");
         $labels = [
             "author" => "Author",

--- a/src/Options.php
+++ b/src/Options.php
@@ -235,6 +235,12 @@ class Options
     private $isPdfAEnabled = false;
 
     /**
+     * Same as $isPdfAEnabled but for PDF/UA.
+     * @var bool
+     */
+    private $isPdfUAEnabled = false;
+
+    /**
      * Enable inline JavaScript
      *
      * If this setting is set to true then DOMPDF will automatically insert
@@ -399,6 +405,8 @@ class Options
                 $methodForCall = "setIsRemoteEnabled";
             } elseif ($methodForMatch === 'enablePdfA') {
                 $methodForCall = "setIsPdfAEnabled";
+            } elseif ($methodForMatch === 'enablePdfUA') {
+                $methodForCall = "setIsPdfUAEnabled";
             } elseif ($methodForMatch === 'enableJavascript') {
                 $methodForCall = "setIsJavascriptEnabled";
             } elseif ($methodForMatch === 'enableHtml5Parser') {
@@ -430,6 +438,8 @@ class Options
             $methodForCall = "getIsRemoteEnabled";
         } elseif ($methodForMatch === 'enablePdfA') {
             $methodForCall = "getIsPdfAEnabled";
+        } elseif ($methodForMatch === 'enablePdfUA') {
+            $methodForCall = "getIsPdfUAEnabled";
         } elseif ($methodForMatch === 'enableJavascript') {
             $methodForCall = "getIsJavascriptEnabled";
         } elseif ($methodForMatch === 'enableHtml5Parser') {
@@ -1071,6 +1081,22 @@ class Options
     public function isPdfAEnabled()
     {
         return $this->getIsPdfAEnabled();
+    }
+
+    public function setIsPdfUAEnabled(bool $isPdfUAEnabled): self
+    {
+        $this->isPdfUAEnabled = $isPdfUAEnabled;
+        return $this;
+    }
+
+    public function getIsPdfUAEnabled(): bool
+    {
+        return $this->isPdfUAEnabled;
+    }
+
+    public function isPdfUAEnabled(): bool
+    {
+        return $this->getIsPdfUAEnabled();
     }
 
     /**

--- a/src/Renderer/AbstractRenderer.php
+++ b/src/Renderer/AbstractRenderer.php
@@ -63,6 +63,7 @@ abstract class AbstractRenderer
      */
     protected function _render_background(Frame $frame, array $border_box): void
     {
+        $this->_canvas->get_struct_tree()->inArtifact();
         $style = $frame->get_style();
         $color = $style->background_color;
         $image = $style->background_image;
@@ -97,6 +98,7 @@ abstract class AbstractRenderer
      */
     protected function _render_border(Frame $frame, array $border_box, string $corner_style = "bevel"): void
     {
+        $this->_canvas->get_struct_tree()->inArtifact();
         $style = $frame->get_style();
         $bp = $style->get_border_properties();
         [$x, $y, $w, $h] = $border_box;
@@ -183,6 +185,7 @@ abstract class AbstractRenderer
      */
     protected function _render_outline(Frame $frame, array $border_box, string $corner_style = "bevel"): void
     {
+        $this->_canvas->get_struct_tree()->inArtifact();
         $style = $frame->get_style();
 
         $width = $style->outline_width;

--- a/src/Renderer/Image.php
+++ b/src/Renderer/Image.php
@@ -60,6 +60,7 @@ class Image extends Block
                 $this->_canvas->clipping_roundrectangle($x, $y, $w, $h, $tl, $tr, $br, $bl);
             }
 
+            $this->_canvas->get_struct_tree()->render($frame->get_node());
             $this->_canvas->image($src, $x, $y, $w, $h, $style->image_resolution);
 
             if ($style->has_border_radius()) {

--- a/src/Renderer/Text.php
+++ b/src/Renderer/Text.php
@@ -72,6 +72,8 @@ class Text extends AbstractRenderer
           $text
         );*/
 
+        $this->_canvas->get_struct_tree()->render($frame->get_node());
+
         $this->_canvas->text($x, $y, $text,
             $font, $size,
             $style->color, $word_spacing, $letter_spacing);

--- a/src/StructTree.php
+++ b/src/StructTree.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dompdf;
+
+use DOMNode;
+
+interface StructTree
+{
+    public function render(DOMNode $node): void;
+    public function inArtifact(): void;
+}

--- a/src/StructTree/CPDFStructTree.php
+++ b/src/StructTree/CPDFStructTree.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dompdf\StructTree;
+
+use Dompdf\StructTree;
+use Dompdf\Adapter\CPDF;
+use SplObjectStorage;
+use DOMNode;
+use DOMDocument;
+
+class CPDFStructTree implements StructTree
+{
+    /** @var CPDF */
+    private $canvas;
+
+    /**
+     * Keys are the headline level.
+     * Values are the outline id.
+     * Key 0 must be the outline root id of the PDF.
+     *
+     * @var array<int, int>
+     */
+    private $headlineParents;
+
+    /**
+     * The values are the struct tree ID's.
+     *
+     * @var SplObjectStorage<DOMNode, int>
+     */
+    private $structTree;
+
+    /**
+     * Last marked struct tree ID (the direct parent of the marked content block).
+     *
+     * @var ?int
+     */
+    private $activeStructElement = null;
+
+    private const HTML2PDF_TAGS = [
+        'Strong' => 'Span',
+        'Article' => 'Art',
+        'Img' => 'Span',
+        'Tbody' => 'TBody',
+        'Thead' => 'THead',
+        'Td' => 'TD',
+        'Tr' => 'TR',
+        'Th' => 'TH',
+        'Em' => 'Span',
+        'I' => 'Span',
+    ];
+
+    private const HTML2PDF_TH_SCOPES = [
+        'col' => 'Column',
+        'row' => 'Row',
+    ];
+
+    /**
+     * Placeholder for the struct tree root.
+     * The value is just used as a unique identifier, the object itself is never used.
+     * To always have the same root in a document this must only be assigned once.
+     *
+     * @var ?DOMNode
+     *
+     */
+    private static $structDummyRoot = null;
+
+    public function __construct(CPDF $canvas)
+    {
+        $this->canvas = $canvas;
+        $this->structTree = new SplObjectStorage();
+        self::$structDummyRoot = self::$structDummyRoot ?? new DOMDocument();
+        $this->headlineParents = [0 => $this->canvas->addOutlineRoot()];
+    }
+
+    public function inArtifact(): void
+    {
+        $this->canvas->inArtifact();
+    }
+
+    /**
+     * Add struct tree, outline and (structure) content marks based on $node's path.
+     */
+    public function render(DOMNode $node): void
+    {
+        [$path, $headTagNr] = $this->path($node);
+        $this->renderStructTree($path);
+        if ($headTagNr !== null && isset($node->data) && $node->data) {
+            $this->renderOutline($headTagNr, $node->data);
+        }
+    }
+
+    /**
+     * Add the struct element tree to the PDF according to $path.
+     * The values of $path (used as IDs) are used to keep track if a node has been closed.
+     * Additionally special attributes are like <th scope="col"></th> are kept to the corresponding PDF attributes.
+     *
+     * The leaf of $path is used as a struct element and as a marked structured content.
+     *
+     * @param array<string, DOMNode> $path
+     */
+    private function renderStructTree(array $path): void
+    {
+        $parent = $this->canvas->addStructTreeRoot();
+        $parentTag = null;
+        foreach ($path as $tag => $node) {
+            if (!isset($this->structTree[$node])) {
+                $this->structTree[$node] = $this->canvas->addStructElement($tag, $parent);
+                if ($tag === 'TH' && isset(self::HTML2PDF_TH_SCOPES[$node->getAttribute('scope')])) {
+                    $this->canvas->addAttribute($this->structTree[$node], ['O' => 'Table', 'Scope' => self::HTML2PDF_TH_SCOPES[$node->getAttribute('scope')]]);
+                }
+            }
+
+            $parent = $this->structTree[$node];
+            $parentTag = $tag;
+        }
+
+        if (!in_array($parent, [null, $this->activeStructElement], true)) {
+            $this->canvas->inMarkedStructureContent($parentTag, $parent, $this->markedContentPropsOfNode($path[$parentTag]));
+            $this->activeStructElement = $parent;
+        }
+    }
+
+    /**
+     * Keeps track of $node's headlines.
+     * Based on the headline level a corresponding outline is added to the PDF.
+     *
+     * @Example
+     * $this->renderOutline(1, 'hej');
+     * $this->renderOutline(2, 'ho');
+     * $this->renderOutline(3, 'hu');
+     * $this->renderOutline(2, 'ha');
+     * $this->renderOutline(1, 'hi');
+     *
+     * Will result in an outline like:
+     * - hej
+     *  - ho
+     *    - hu
+     *  - ha
+     * - hi
+     */
+    private function renderOutline(int $headTagNr, string $title): void
+    {
+        // Remove all tags greater as $headTagNr (as they are no parent).
+        if ($headTagNr <= max(array_keys($this->headlineParents))) {
+            $this->headlineParents = array_filter($this->headlineParents, function($nr)use($headTagNr){
+                return $headTagNr > $nr;
+            }, ARRAY_FILTER_USE_KEY);
+        }
+
+        // Find next parent if nrs are skipped (like: <html><h1></h1><h5></h5></html>)
+        for ($i = $headTagNr - 1; !array_key_exists($i, $this->headlineParents); $i--) {
+        }
+
+        $parent = $this->headlineParents[$i];
+        $outlineId = $this->canvas->addOutline($title, $parent);
+        $this->headlineParents[$headTagNr] = $outlineId;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function markedContentPropsOfNode(DOMNode $node): array
+    {
+        $props = [];
+
+        if (!strcasecmp($node->nodeName ?? '', 'img') && $node->getAttribute('alt')) {
+            $props['Alt'] = $node->getAttribute('alt');
+        }
+
+        return $props;
+    }
+
+    /**
+     * Returns the document path from the HTML body to $node in PDF tag names in $this->path($node)[0].
+     * Tag replacements from HTML to PDF are done as well.
+     * Returns the closest (to $node->get_node()) headline tag in $this->path($node)[1].
+     *
+     * A HTML path of the node like:
+     * body > div > article > p > strong
+     * is returned as:
+     * Document > Div > Art > P > Span
+     * In the form of:
+     * [['Document' => self::$structDummyRoot, 'Div' => $divNode, 'Art' => $articeNode, 'P' => $pNode, 'Span' => $strongNode], null]
+     * And for headlines:
+     * Given HTML Path:
+     * div > article > h2
+     * [['Document' => self::$structDummyRoot, 'Div' => $divNode, 'Art' => $articeNode, 'H2' => $h2Node], 'H2']
+     *
+     * Document must always be the root of the struct element tree, so it is always added.
+     *
+     * @return array{0: array<string, DOMNode>, 1: ?int}
+     */
+    private function path(DOMNode $node): array
+    {
+        $path = [];
+        $headTagNr = null;
+        do {
+            if (isset($node->tagName)) {
+                $tagName = $this->niceTagName($node->tagName);
+                $path[$tagName] = $node;
+                if (preg_match('/H([1-9])/', $tagName, $matches)) {
+                    $headTagNr = (int) $matches[1];
+                }
+            }
+            $node = $node->parentNode;
+        }while ($node && strcasecmp($node->tagName, 'body'));
+
+        $path['Document'] = self::$structDummyRoot;
+
+        return [array_reverse($path), $headTagNr];
+    }
+
+    /**
+     * Rename HTML tag names to PDF tag names.
+     */
+    private function niceTagName(string $tagName): string
+    {
+        $tagName = ucfirst(strtolower($tagName));
+        return self::HTML2PDF_TAGS[$tagName] ?? $tagName;
+    }
+}

--- a/src/StructTree/DummyStructTree.php
+++ b/src/StructTree/DummyStructTree.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dompdf\StructTree;
+
+use Dompdf\StructTree;
+use DOMNode;
+
+class DummyStructTree implements StructTree
+{
+    public function render(DOMNode $node): void
+    {
+    }
+
+    public function inArtifact(): void
+    {
+    }
+}

--- a/tests/StructTree/CPDFStructTreeTest.php
+++ b/tests/StructTree/CPDFStructTreeTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dompdf\Tests\StructTree;
+
+use Dompdf\StructTree\CPDFStructTree;
+use Dompdf\Tests\TestCase;
+use Dompdf\Adapter\CPDF;
+use DOMNode;
+use DOMDocument;
+
+class CPDFStructTreeTest extends TestCase
+{
+    public function testConstruct(): void
+    {
+        $this->assertInstanceOf(CPDFStructTree::class, new CPDFStructTree(
+            $this->getMockBuilder(CPDF::class)->disableOriginalConstructor()->getMock()
+        ));
+    }
+
+    public function testRenderWithPath(): void
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->loadHTML('<html><body><div><p>hej</p><div></body></html>');
+        $p = $doc->getElementsByTagName('p')[0];
+
+        $canvas = $this->getMockBuilder(CPDF::class)->disableOriginalConstructor()->getMock();
+
+        $canvas->expects(self::once())->method('addOutlineRoot');
+        $canvas->expects(self::once())->method('addStructTreeRoot')->willReturn(123);
+        $canvas->expects(self::exactly(3))->method('addStructElement')->willReturnCallback(function($tag, $parent){
+            $map = ['Document' => [123, 456], 'Div' => [456, 789], 'P' => [789, 111]];
+            $this->assertSame($map[$tag][0], $parent);
+            return $map[$tag][1];
+        });
+        $canvas->expects(self::once())->method('inMarkedStructureContent')->with('P', 111, []);
+
+        $instance = new CPDFStructTree($canvas);
+        $instance->render($p);
+    }
+
+    public function testRenderOutline(): void
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->loadHTML('<html><body><h1>first</h1><h3>sec</h3><div><h1>third</h1></div></body></html>');
+        $p = $doc->getElementsByTagName('p')[0];
+        $outline = [
+            ['first', 987, 765],
+            ['sec', 765, 543],
+            ['third', 987, 321],
+        ];
+
+        $canvas = $this->getMockBuilder(CPDF::class)->disableOriginalConstructor()->getMock();
+
+        $canvas->expects(self::once())->method('addOutlineRoot')->willReturn(987);
+        $canvas->expects(self::exactly(3))->method('addOutline')->willReturnCallback(function($title, $parent) use (&$outline){
+            $expected = array_shift($outline);
+            $this->assertSame($title, $expected[0]);
+            $this->assertSame($parent, $expected[1]);
+            return $expected[2];
+        });
+
+        $instance = new CPDFStructTree($canvas);
+        $instance->render($doc->getElementsByTagName('h1')[0]->firstChild);
+        $instance->render($doc->getElementsByTagName('h3')[0]->firstChild);
+        $instance->render($doc->getElementsByTagName('h1')[1]->firstChild);
+    }
+}


### PR DESCRIPTION
Hi,
this PR adds basic functionality to generate PDF/UA compatible PDF's.

# Changes made in Cpdf

## Add new `$pdfua` toggle (similar to `$pdfa`)

Many things that are required for PDF/A are also required for PDF/UA (e.g. embedded fonts) but I still need to check if they are _all_ required (e.g. color profile).
For now I have simply required the same as for PDF/A to be on the safe side.

## Add Lang & MarkInfo

Document language can be set.

If a struct tree is used the document is also marked as `tagged` (required for PDF/UA).

## Struct tree

Adds new `structTreeRoot` and `structElement` types and corresponding methods to be able to build a tree describing the documents structure.

## Outline

The existing outline code did not work correctly in my tests,
so I modified it and added methods to be able to create an outline tree.

The outline item will link to the currently rendered page, maybe the target should be made explicit.
I may add other link targets in the future too.

## Marked Content

To simplify marking content (and as all content must be marked anyway for PDF/UA), consumer code only opens marked contents and closing is done automatically.

Marking structure content requires the struct tree, so that the generated MCID is always added to the correct places in the struct tree.

# Changes made in Dompdf

## Add pdfua option

New property in the `Option` class.

## Add language

Document language is set based on the `html` `lang` attribute.
This is left empty for canvas implementations other than CPDF.

## `StructTree` Interface

Adds a new interface which the `Canvas` returns.
If PDF/UA is enabled `Dompdf\Adapter\CPDF` returns a `Dompdf\StructTree\CPDFStructTree` instance.

Building the struct tree, outline & marking all structure content is done in the `CPDFStructTree` class.

Creating the outline is currently very basic. Headlines with further children are not properly handled

All other `Canvas` implementations return a dummy class.

## Renderers

Backgrounds, borders and outlines are marked as artifacts.

### Text
When rendering text (or images) the corresponding node's path is used to build the struct tree and outline.
As this happens after the document reflow, the HTML tree and therefore the struct tree contains the modified version instead of the original.
But this has made the implementation much simpler, as for example MCID's with different pages in the same direct parent struct element are not possible (and therefore don't need to be implemented).

HTML tag and HTML attribute mappings to fitting PDF tags and attributes are not complete.
These will be extended in the future (also attributes to mark whole nodes as artifacts too).

### Images
I set the PDF/UA XML tag to PDF/UA-2 instead of PDF/UA-1 because images are tagged as `Span` instead of `Figure`.

According to this https://pdfa.org/tagging-images-in-pdfua-1-and-pdfua-2/ PDF/UA-1 contains some ambiguities on how images should be handled, PDF/UA-2 seems to resolve this issue.

The PAC checker doesn't care if the document is set to PDF/UA-1 or PDF/UA-2...
When set to `Figure` **and** with an `alt` attribute the PAC checker also returns some errors which don't make sense for accessibility so...

So it might be incorrect how images are tagged or that the document is tagged as PDF/UA-2 instead of 1.

# Other

~~I'm currently using several php7.4 features.~~
~~Should this be made php7.1 compatible or is php7.4 also ok?~~

This should be PHP7.1 compatible.

Currently this is one big commit,
if you want I can separate the Cpdf and Dompdf part into multiple commits or PRs.

## PDF/A-3a

I originally aimed for PDF/A-3a support but the PAC checker only accepts PDF/UA documents and I couldn't find any better source to validate generated PDF's.
I suspect that most of PDF/UA will be required for PDF/A-3a, so maybe it's enough to just change the metadata info to PDF/A-3a ^^
