### PR TITLE
Workaround for float reflows limit

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -772,6 +772,8 @@ class Dompdf
 
         $canvas = $this->canvas;
 
+        LineBox::reset_float_reflow_limit(); // FIXME smelly hack
+
         $root_frame = $this->tree->get_root();
         $root = Factory::decorate_root($root_frame, $this);
         foreach ($this->tree as $frame) {

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -92,6 +92,11 @@ class LineBox
     public $inline = false;
 
     /**
+     * @var int
+     */
+    public static $max_float_reflows = 10000;
+
+    /**
      * FIXME smelly hack, used by the get_float_offsets method.
      *
      * @var int
@@ -164,7 +169,7 @@ class LineBox
      */
     public static function reset_float_reflow_limit(): void
     {
-        self::$float_offset_anti_infinite_loop = 10000;
+        self::$float_offset_anti_infinite_loop = self::$max_float_reflows;
     }
 
     public function get_float_offsets(): void

--- a/src/LineBox.php
+++ b/src/LineBox.php
@@ -92,6 +92,13 @@ class LineBox
     public $inline = false;
 
     /**
+     * FIXME smelly hack, used by the get_float_offsets method.
+     *
+     * @var int
+     */
+    private static $float_offset_anti_infinite_loop = 10000;
+
+    /**
      * @param Block $frame the Block containing this line
      * @param float $y
      */
@@ -152,10 +159,16 @@ class LineBox
         return $childs;
     }
 
+    /**
+     * Resets the anti-infinite-loop counter for the get_float_offsets method.
+     */
+    public static function reset_float_reflow_limit(): void
+    {
+        self::$float_offset_anti_infinite_loop = 10000;
+    }
+
     public function get_float_offsets(): void
     {
-        static $anti_infinite_loop = 10000; // FIXME smelly hack
-
         $reflower = $this->_block_frame->get_reflower();
 
         if (!$reflower) {
@@ -201,7 +214,7 @@ class LineBox
             }
 
             // If the child is still shifted by the floating element
-            if ($anti_infinite_loop-- > 0 &&
+            if (self::$float_offset_anti_infinite_loop-- > 0 &&
                 $floating_frame->get_position("y") + $floating_frame->get_margin_height() >= $this->y &&
                 $block->get_position("x") + $block->get_margin_width() >= $floating_frame->get_position("x")
             ) {


### PR DESCRIPTION
As discussed in #3713, related to #620.

Before someone can come up with a real fix (or a proof that this loop-prevention is not needed anymore), this PR resets the static reflows counter on every render.

By the way, users experiencing problems when rendering very large documents can override this limit externally to any absurd value that may suit their needs, for example:
```php
\Dompdf\LineBox::$max_float_reflows = PHP_INT_MAX;
```