### PR TITLE
Encode URI before passing to curl_init()

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1082,6 +1082,7 @@ class Helpers
                 }
 
             } elseif ($can_use_curl) {
+                $uri = self::encodeURI($uri);
                 $curl = curl_init($uri);
 
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
The file_get_contents code path encodes the URI via encodeURI(), but the cURL code path(since v3.1.1) does not. This causes images with spaces or other characters like special chars in their URL to fail.
This generates pdf files with empty images