### PR TITLE
feat: enable compressed response encoding for cURL requests

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1086,6 +1086,7 @@ class Helpers
 
                 curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
                 curl_setopt($curl, CURLOPT_HEADER, true);
+                curl_setopt($curl, CURLOPT_ENCODING, '');
                 if ($offset > 0) {
                     curl_setopt($curl, CURLOPT_RESUME_FROM, $offset);
                 }


### PR DESCRIPTION
## Summary

Enable compressed response encoding for cURL requests by setting `CURLOPT_ENCODING` to an empty string `''`, which sends an `Accept-Encoding` header with all supported encodings (gzip, deflate, br). This improves download performance for remote resources.

## Changes

- Added `curl_setopt($curl, CURLOPT_ENCODING, '')` in `Helpers::fileGetContent` to advertise support for compressed responses

## Files Changed

- `src/Helpers.php` — Modified (1 insertion)

## Testing

Needs testing — verify that remote resource fetching still works correctly with compressed responses enabled.

## Related Issues

None