### PR TITLE
Adding enum `PageOrientation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $dompdf = new Dompdf();
 $dompdf->loadHtml('hello world');
 
 // (Optional) Setup the paper size and orientation
-$dompdf->setPaper('A4', 'landscape');
+$dompdf->setPaper('A4', PageOrientation::Landscape);
 
 // Render the HTML as PDF
 $dompdf->render();

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "ext-gd": "*",
         "ext-json": "*",
         "ext-zip": "*",
+        "phpstan/phpstan": "*",
         "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
         "squizlabs/php_codesniffer": "^3.5",
         "mockery/mockery": "^1.3",

--- a/src/Adapter/CPDF.php
+++ b/src/Adapter/CPDF.php
@@ -14,6 +14,7 @@ use Dompdf\Exception;
 use Dompdf\FontMetrics;
 use Dompdf\Helpers;
 use Dompdf\Image\Cache;
+use Dompdf\PageOrientation;
 use FontLib\Exception\FontNotFoundException;
 
 /**
@@ -155,7 +156,7 @@ class CPDF implements Canvas
      */
     protected $_current_opacity = 1;
 
-    public function __construct($paper = "letter", string $orientation = "portrait", ?Dompdf $dompdf = null)
+    public function __construct($paper = "letter", PageOrientation $orientation = PageOrientation::Portrait, ?Dompdf $dompdf = null)
     {
         if (is_array($paper)) {
             $size = array_map("floatval", $paper);
@@ -164,7 +165,7 @@ class CPDF implements Canvas
             $size = self::$PAPER_SIZES[$paper] ?? self::$PAPER_SIZES["letter"];
         }
 
-        if (strtolower($orientation) === "landscape") {
+        if (PageOrientation::Landscape === $orientation) {
             [$size[2], $size[3]] = [$size[3], $size[2]];
         }
 

--- a/src/Adapter/GD.php
+++ b/src/Adapter/GD.php
@@ -10,6 +10,7 @@ use Dompdf\Canvas;
 use Dompdf\Dompdf;
 use Dompdf\Helpers;
 use Dompdf\Image\Cache;
+use Dompdf\PageOrientation;
 
 /**
  * Image rendering interface
@@ -135,7 +136,7 @@ class GD implements Canvas
      * @param float          $aa_factor   Anti-aliasing factor, 1 for no AA
      * @param array          $bg_color    Image background color: array(r,g,b,a), 0 <= r,g,b,a <= 1
      */
-    public function __construct($paper = "letter", string $orientation = "portrait", ?Dompdf $dompdf = null, float $aa_factor = 1.0, array $bg_color = [1, 1, 1, 0])
+    public function __construct($paper = "letter", PageOrientation $orientation = PageOrientation::Portrait, ?Dompdf $dompdf = null, float $aa_factor = 1.0, array $bg_color = [1, 1, 1, 0])
     {
         if (is_array($paper)) {
             $size = array_map("floatval", $paper);
@@ -144,7 +145,7 @@ class GD implements Canvas
             $size = CPDF::$PAPER_SIZES[$paper] ?? CPDF::$PAPER_SIZES["letter"];
         }
 
-        if (strtolower($orientation) === "landscape") {
+        if (PageOrientation::Landscape === $orientation) {
             [$size[2], $size[3]] = [$size[3], $size[2]];
         }
 

--- a/src/Adapter/PDFLib.php
+++ b/src/Adapter/PDFLib.php
@@ -12,6 +12,7 @@ use Dompdf\Exception;
 use Dompdf\FontMetrics;
 use Dompdf\Helpers;
 use Dompdf\Image\Cache;
+use Dompdf\PageOrientation;
 
 /**
  * PDF rendering interface
@@ -187,7 +188,7 @@ class PDFLib implements Canvas
      */
     protected $_pages;
 
-    public function __construct($paper = "letter", string $orientation = "portrait", ?Dompdf $dompdf = null)
+    public function __construct($paper = "letter", PageOrientation $orientation = PageOrientation::Portrait, ?Dompdf $dompdf = null)
     {
         if (is_array($paper)) {
             $size = array_map("floatval", $paper);
@@ -196,7 +197,7 @@ class PDFLib implements Canvas
             $size = self::$PAPER_SIZES[$paper] ?? self::$PAPER_SIZES["letter"];
         }
 
-        if (strtolower($orientation) === "landscape") {
+        if (PageOrientation::Landscape === $orientation) {
             [$size[2], $size[3]] = [$size[3], $size[2]];
         }
 

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -6,7 +6,7 @@
  */
 namespace Dompdf;
 
-use PageOrientation;
+use Dompdf\PageOrientation;
 
 /**
  * Main rendering interface

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -6,6 +6,8 @@
  */
 namespace Dompdf;
 
+use PageOrientation;
+
 /**
  * Main rendering interface
  *
@@ -22,12 +24,12 @@ namespace Dompdf;
 interface Canvas
 {
     /**
-     * @param string|float[] $paper       The paper size to use as either a standard paper size (see {@link Dompdf\Adapter\CPDF::$PAPER_SIZES})
-     *                                    or an array of the form `[x1, y1, x2, y2]` (typically `[0, 0, width, height]`).
-     * @param string         $orientation The paper orientation, either `portrait` or `landscape`.
-     * @param Dompdf|null    $dompdf      The Dompdf instance.
+     * @param string|float[]  $paper       The paper size to use as either a standard paper size (see {@link Dompdf\Adapter\CPDF::$PAPER_SIZES})
+     *                                     or an array of the form `[x1, y1, x2, y2]` (typically `[0, 0, width, height]`).
+     * @param PageOrientation $orientation The paper orientation, either portrait or landscape.
+     * @param Dompdf|null     $dompdf      The Dompdf instance.
      */
-    public function __construct($paper = "letter", string $orientation = "portrait", ?Dompdf $dompdf = null);
+    public function __construct($paper = "letter", PageOrientation $orientation = PageOrientation::Portrait, ?Dompdf $dompdf = null);
 
     /**
      * @return Dompdf

--- a/src/CanvasFactory.php
+++ b/src/CanvasFactory.php
@@ -6,7 +6,7 @@
  */
 namespace Dompdf;
 
-use PageOrientation;
+use Dompdf\PageOrientation;
 
 /**
  * Create canvas instances

--- a/src/CanvasFactory.php
+++ b/src/CanvasFactory.php
@@ -6,6 +6,8 @@
  */
 namespace Dompdf;
 
+use PageOrientation;
+
 /**
  * Create canvas instances
  *
@@ -31,7 +33,7 @@ class CanvasFactory
      *
      * @return Canvas
      */
-    static function get_instance(Dompdf $dompdf, $paper, string $orientation, ?string $class = null)
+    static function get_instance(Dompdf $dompdf, $paper, PageOrientation $orientation, ?string $class = null)
     {
         $backend = strtolower($dompdf->getOptions()->getPdfBackend());
 

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -66,6 +66,9 @@ use Masterminds\HTML5;
  */
 class Dompdf
 {
+    public const ORIENTATION_PORTRAIT = 'portrait';
+    public const ORIENTATION_LANDSCAPE = 'landscape';
+
     /**
      * Version string for dompdf
      *
@@ -1021,7 +1024,7 @@ class Dompdf
      * @param string $orientation 'portrait' or 'landscape'
      * @return $this
      */
-    public function setPaper($size, string $orientation = "portrait"): self
+    public function setPaper($size, string $orientation = self::ORIENTATION_PORTRAIT): self
     {
         $current_size = $this->getPaperSize();
         $this->paperSize = $size;

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -16,6 +16,7 @@ use Dompdf\Image\Cache;
 use Dompdf\Css\Stylesheet;
 use Dompdf\Helpers;
 use Masterminds\HTML5;
+use PageOrientation;
 
 /**
  * Dompdf - PHP5 HTML to PDF renderer
@@ -66,9 +67,6 @@ use Masterminds\HTML5;
  */
 class Dompdf
 {
-    public const ORIENTATION_PORTRAIT = 'portrait';
-    public const ORIENTATION_LANDSCAPE = 'landscape';
-
     /**
      * Version string for dompdf
      *
@@ -112,11 +110,11 @@ class Dompdf
     private $paperSize;
 
     /**
-     * Paper orientation ('portrait' or 'landscape')
+     * Paper orientation (portrait or landscape)
      *
-     * @var string
+     * @var PageOrientation
      */
-    private $paperOrientation = "portrait";
+    private $paperOrientation = PageOrientation::Portrait;
 
     /**
      * Callbacks on new page and new element
@@ -1024,7 +1022,7 @@ class Dompdf
      * @param string $orientation 'portrait' or 'landscape'
      * @return $this
      */
-    public function setPaper($size, string $orientation = self::ORIENTATION_PORTRAIT): self
+    public function setPaper($size, PageOrientation $orientation = PageOrientation::Portrait): self
     {
         $current_size = $this->getPaperSize();
         $this->paperSize = $size;

--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -16,7 +16,7 @@ use Dompdf\Image\Cache;
 use Dompdf\Css\Stylesheet;
 use Dompdf\Helpers;
 use Masterminds\HTML5;
-use PageOrientation;
+use Dompdf\PageOrientation;
 
 /**
  * Dompdf - PHP5 HTML to PDF renderer
@@ -1007,10 +1007,10 @@ class Dompdf
 
     /**
      * @param string $size
-     * @param string $orientation
+     * @param PageOrientation $orientation
      * @deprecated
      */
-    public function set_paper($size, $orientation = "portrait")
+    public function set_paper($size, $orientation = PageOrientation::Portrait)
     {
         $this->setPaper($size, $orientation);
     }
@@ -1019,7 +1019,7 @@ class Dompdf
      * Sets the paper size & orientation
      *
      * @param string|float[] $size 'letter', 'legal', 'A4', etc. {@link Dompdf\Adapter\CPDF::$PAPER_SIZES}
-     * @param string $orientation 'portrait' or 'landscape'
+     * @param PageOrientation $orientation portrait or landscape
      * @return $this
      */
     public function setPaper($size, PageOrientation $orientation = PageOrientation::Portrait): self
@@ -1054,7 +1054,7 @@ class Dompdf
             $size = CPDF::$PAPER_SIZES[$paper] ?? CPDF::$PAPER_SIZES["letter"];
         }
 
-        if (strtolower($orientation) === "landscape") {
+        if (PageOrientation::Landscape === $orientation) {
             [$size[2], $size[3]] = [$size[3], $size[2]];
         }
 
@@ -1064,9 +1064,9 @@ class Dompdf
     /**
      * Gets the paper orientation
      *
-     * @return string Either "portrait" or "landscape"
+     * @return PageOrientation Either portrait or landscape
      */
-    public function getPaperOrientation(): string
+    public function getPaperOrientation(): PageOrientation
     {
         return $this->paperOrientation;
     }
@@ -1305,7 +1305,7 @@ class Dompdf
         $canvasWidth = $this->canvas->get_width();
         $canvasHeight = $this->canvas->get_height();
         $this->paperSize = [0, 0, $canvasWidth, $canvasHeight];
-        $this->paperOrientation = "portrait";
+        $this->paperOrientation = PageOrientation::Portrait;
         return $this;
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -6,6 +6,8 @@
  */
 namespace Dompdf;
 
+use PageOrientation;
+
 class Options
 {
     /**
@@ -120,9 +122,9 @@ class Options
      *
      * The orientation of the page (portrait or landscape).
      *
-     * @var string
+     * @var PageOrientation
      */
-    private $defaultPaperOrientation = "portrait";
+    private $defaultPaperOrientation = PageOrientation::Portrait;
 
     /**
      * The default font family

--- a/src/Options.php
+++ b/src/Options.php
@@ -6,7 +6,7 @@
  */
 namespace Dompdf;
 
-use PageOrientation;
+use Dompdf\PageOrientation;
 
 class Options
 {
@@ -791,7 +791,7 @@ class Options
      * @param string $defaultPaperOrientation
      * @return $this
      */
-    public function setDefaultPaperOrientation(string $defaultPaperOrientation): self
+    public function setDefaultPaperOrientation(PageOrientation $defaultPaperOrientation): self
     {
         $this->defaultPaperOrientation = $defaultPaperOrientation;
         return $this;
@@ -808,7 +808,7 @@ class Options
     /**
      * @return string
      */
-    public function getDefaultPaperOrientation(): string
+    public function getDefaultPaperOrientation(): PageOrientation
     {
         return $this->defaultPaperOrientation;
     }

--- a/src/PageOrientation.php
+++ b/src/PageOrientation.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace Dompdf;
+
 enum PageOrientation
 {
     case Portrait;

--- a/src/PageOrientation.php
+++ b/src/PageOrientation.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+enum PageOrientation
+{
+    case Portrait;
+    case Landscape;
+}

--- a/tests/Canvas/CPDFTest.php
+++ b/tests/Canvas/CPDFTest.php
@@ -6,6 +6,7 @@ use Dompdf\Canvas;
 use Dompdf\Dompdf;
 use Dompdf\FontMetrics;
 use Dompdf\Tests\TestCase;
+use Dompdf\PageOrientation;
 use DateTime;
 
 class CPDFTest extends TestCase
@@ -16,7 +17,7 @@ class CPDFTest extends TestCase
         $imagePath = "$basePath/_files/red-dot.png";
 
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
         $canvas->new_page();
         $canvas->image($imagePath, 0, 0, 5, 5);
         $output = $canvas->output();
@@ -29,7 +30,7 @@ class CPDFTest extends TestCase
         $called = 0;
 
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
         $canvas->new_page();
 
         $canvas->page_script(function (
@@ -59,7 +60,7 @@ class CPDFTest extends TestCase
     public function testPageText(): void
     {
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
         $canvas->new_page();
 
         $font = $dompdf->getFontMetrics()->getFont("Helvetica");
@@ -72,7 +73,7 @@ class CPDFTest extends TestCase
     public function testPageLine(): void
     {
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
         $canvas->new_page();
 
         $canvas->page_line(0, 0, 200, 200, [0, 0, 0], 1);
@@ -147,7 +148,7 @@ class CPDFTest extends TestCase
     public function testFontSupportsChar(string $font, string $char, bool $expected): void
     {
         $dompdf = new Dompdf();
-        $canvas = new CPDF("letter", "portrait", $dompdf);
+        $canvas = new CPDF("letter", PageOrientation::Portrait, $dompdf);
         $fontFile = $dompdf->getFontMetrics()->getFont($font);
 
         $this->assertSame($expected, $canvas->font_supports_char($fontFile, $char));
@@ -156,7 +157,7 @@ class CPDFTest extends TestCase
     public function testGetXmpMetadata(): void
     {
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
 
         $canvas->get_cpdf()->addInfo('CreationDate', 'aa20250208195048');
         $canvas->get_cpdf()->addInfo('ModDate', 'aa20250208195048Z');
@@ -192,7 +193,7 @@ class CPDFTest extends TestCase
     public function testSetAdditionalXmpRdf(): void
     {
         $dompdf = new Dompdf();
-        $canvas = new CPDF([0, 0, 200, 200], "portrait", $dompdf);
+        $canvas = new CPDF([0, 0, 200, 200], PageOrientation::Portrait, $dompdf);
 
         $canvas->get_cpdf()->addInfo('CreationDate', 'aa20250208195048');
         $canvas->get_cpdf()->addInfo('ModDate', 'aa20250208195048Z');

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -11,6 +11,7 @@ use Dompdf\Frame;
 use Dompdf\Frame\FrameTree;
 use Dompdf\Options;
 use Dompdf\Tests\TestCase;
+use Dompdf\PageOrientation;
 
 class DompdfTest extends TestCase
 {
@@ -246,10 +247,10 @@ class DompdfTest extends TestCase
     public static function customCanvasProvider(): array
     {
         return [
-            ["A4", "portrait", true, "auto"],
-            ["A5", "landscape", true, "A5 landscape"],
-            ["A5", "landscape", false, "A5 landscape"],
-            [[0, 0, 300, 400], "portrait", true, "300pt 400pt"]
+            ["A4", PageOrientation::Portrait, true, "auto"],
+            ["A5", PageOrientation::Landscape, true, "A5 landscape"],
+            ["A5", PageOrientation::Portrait::Landscape, false, "A5 landscape"],
+            [[0, 0, 300, 400], PageOrientation::Portrait, true, "300pt 400pt"]
         ];
     }
 
@@ -262,7 +263,7 @@ class DompdfTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('customCanvasProvider')]
     public function testCustomCanvas(
         $size,
-        string $orientation,
+        PageOrientation $orientation,
         bool $setPaper,
         string $cssSize
     ): void {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -3,6 +3,7 @@ namespace Dompdf\Tests;
 
 use Dompdf\Options;
 use Dompdf\Tests\TestCase;
+use Dompdf\PageOrientation;
 
 class OptionsTest extends TestCase
 {
@@ -50,7 +51,7 @@ class OptionsTest extends TestCase
             'logOutputFile' => 'test5',
             'defaultMediaType' => 'test6',
             'defaultPaperSize' => 'test7',
-            'defaultPaperOrientation' => 'landscape',
+            'defaultPaperOrientation' => PageOrientation::Landscape,
             'defaultFont' => 'test8',
             'dpi' => 300,
             'fontHeightRatio' => 1.2,
@@ -80,7 +81,7 @@ class OptionsTest extends TestCase
         $this->assertEquals('test5', $option->getLogOutputFile());
         $this->assertEquals('test6', $option->getDefaultMediaType());
         $this->assertEquals('test7', $option->getDefaultPaperSize());
-        $this->assertEquals('landscape', $option->getDefaultPaperOrientation());
+        $this->assertEquals(PageOrientation::Landscape, $option->getDefaultPaperOrientation());
         $this->assertEquals('test8', $option->getDefaultFont());
         $this->assertEquals(300, $option->getDpi());
         $this->assertEquals(1.2, $option->getFontHeightRatio());
@@ -119,7 +120,7 @@ class OptionsTest extends TestCase
             'log_output_file' => 'test5',
             'default_media_type' => 'test6',
             'default_paper_size' => 'test7',
-            'default_paper_orientation' => 'landscape',
+            'default_paper_orientation' => PageOrientation::Landscape,
             'default_font' => 'test8',
             'dpi' => 300,
             'font_height_ratio' => 1.2,
@@ -149,7 +150,7 @@ class OptionsTest extends TestCase
         $this->assertEquals('test5', $option->getLogOutputFile());
         $this->assertEquals('test6', $option->getDefaultMediaType());
         $this->assertEquals('test7', $option->getDefaultPaperSize());
-        $this->assertEquals('landscape', $option->getDefaultPaperOrientation());
+        $this->assertEquals(PageOrientation::Landscape, $option->getDefaultPaperOrientation());
         $this->assertEquals('test8', $option->getDefaultFont());
         $this->assertEquals(300, $option->getDpi());
         $this->assertEquals(1.2, $option->getFontHeightRatio());
@@ -183,7 +184,7 @@ class OptionsTest extends TestCase
             'logOutputFile' => 'test5',
             'defaultMediaType' => 'test6',
             'defaultPaperSize' => 'test7',
-            'defaultPaperOrientation' => 'landscape',
+            'defaultPaperOrientation' => PageOrientation::Landscape,
             'defaultFont' => 'test8',
             'dpi' => 300,
             'fontHeightRatio' => 1.2,
@@ -214,7 +215,7 @@ class OptionsTest extends TestCase
         $this->assertEquals('test5', $option->get('logOutputFile'));
         $this->assertEquals('test6', $option->get('defaultMediaType'));
         $this->assertEquals('test7', $option->get('defaultPaperSize'));
-        $this->assertEquals('landscape', $option->get('defaultPaperOrientation'));
+        $this->assertEquals(PageOrientation::Landscape, $option->get('defaultPaperOrientation'));
         $this->assertEquals('test8', $option->get('defaultFont'));
         $this->assertEquals(300, $option->get('dpi'));
         $this->assertEquals(1.2, $option->get('fontHeightRatio'));
@@ -248,7 +249,7 @@ class OptionsTest extends TestCase
             'log_output_file' => 'test5',
             'default_media_type' => 'test6',
             'default_paper_size' => 'test7',
-            'default_paper_orientation' => 'landscape',
+            'default_paper_orientation' => PageOrientation::Landscape,
             'default_font' => 'test8',
             'dpi' => 300,
             'font_height_ratio' => 1.2,
@@ -279,7 +280,7 @@ class OptionsTest extends TestCase
         $this->assertEquals('test5', $option->get('log_output_file'));
         $this->assertEquals('test6', $option->get('default_media_type'));
         $this->assertEquals('test7', $option->get('default_paper_size'));
-        $this->assertEquals('landscape', $option->get('default_paper_orientation'));
+        $this->assertEquals(PageOrientation::Landscape, $option->get('default_paper_orientation'));
         $this->assertEquals('test8', $option->get('default_font'));
         $this->assertEquals(300, $option->get('dpi'));
         $this->assertEquals(1.2, $option->get('font_height_ratio'));


### PR DESCRIPTION
What about adding those `const`s instead of using strings everywhere?

A dedicated file `enum Orientation` would be even better, but a BC break ;-)