### PR TITLE
Guard against a missing VERSION file in the Dompdf constructor

### DIFF
--- a/src/Dompdf.php
+++ b/src/Dompdf.php
@@ -259,7 +259,7 @@ class Dompdf
         }
 
         $versionFile = realpath(__DIR__ . '/../VERSION');
-        if (($version = file_get_contents($versionFile)) !== false) {
+        if (file_exists($versionFile) && ($version = file_get_contents($versionFile)) !== false) {
             $version = trim($version);
             if ($version !== '$Format:<%h>$') {
                 $this->version = sprintf('dompdf %s', $version);


### PR DESCRIPTION
The `Dompdf` constructor reads the `VERSION` file like this:

```php
$versionFile = realpath(__DIR__ . "/../VERSION");
if (($version = file_get_contents($versionFile)) !== false) {
```

`realpath()` returns `false` when the file is not there, so `file_get_contents()` is called with `false`. On PHP 8 that emits a `Path cannot be empty` warning, and since PHP 8.1 passing `false` where a string is expected is deprecated as well.

The file can legitimately be missing when dompdf is bundled without it, for example when it is vendored into a distributed package and the build step drops files that are not needed at runtime.

`Options.php` already got the same guard in #3701, but the constructor in `Dompdf.php` was missed at the time. This applies the identical `file_exists()` check so both places behave the same way.

No behaviour change when the file is present.