### PR TITLE
Add ::marker pseudo-element support

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -127,6 +127,15 @@ class Stylesheet
     private $_styles;
 
     /**
+     * Styles matched against ::marker pseudo-elements, indexed by originating
+     * frame id and specificity. The actual marker frame is created after the
+     * stylesheet cascade has run, so these styles are applied later by Factory.
+     *
+     * @var array
+     */
+    private $_marker_styles = [];
+
+    /**
      * Array of embedded files (dataURIs) found in the parsed CSS
      *
      * @var array<string>
@@ -261,7 +270,7 @@ class Stylesheet
     }
 
     /**
-     * Return the base protocol for this stylesheet
+     * Return the base protocol
      *
      * @return string
      */
@@ -271,7 +280,7 @@ class Stylesheet
     }
 
     /**
-     * Return the base host for this stylesheet
+     * Return the base host
      *
      * @return string
      */
@@ -281,7 +290,7 @@ class Stylesheet
     }
 
     /**
-     * Return the base path for this stylesheet
+     * Return the base path
      *
      * @return string
      */
@@ -298,6 +307,31 @@ class Stylesheet
     public function get_styles(): array
     {
         return $this->_styles;
+    }
+
+    /**
+     * Return ::marker styles for a frame in cascade order.
+     *
+     * @param mixed $frame_id
+     * @return Style[]
+     */
+    public function get_marker_styles($frame_id): array
+    {
+        if (!isset($this->_marker_styles[$frame_id])) {
+            return [];
+        }
+
+        $styles = $this->_marker_styles[$frame_id];
+        ksort($styles);
+
+        $result = [];
+        foreach ($styles as $specificity_styles) {
+            foreach ($specificity_styles as $style) {
+                $result[] = $style;
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -423,7 +457,7 @@ class Stylesheet
      * @param int    $origin
      *    - Stylesheet::ORIG_UA: user agent style sheet
      *    - Stylesheet::ORIG_USER: user style sheet
-     *    - Stylesheet::ORIG_AUTHOR: author style sheet
+     *    - Stylesheet::ORIG_AUTHOR: author normal style sheet
      *
      * @return int
      */
@@ -485,7 +519,7 @@ class Stylesheet
         // Initial query, always expanded to // below (non-absolute)
         $query = "/";
 
-        // Will contain :before and :after
+        // Will contain supported pseudo-elements
         $pseudo_elements = [];
 
         // Parse the selector
@@ -756,6 +790,14 @@ class Stylesheet
                             }
                             break;
 
+                        // https://www.w3.org/TR/css-pseudo-4/#marker-pseudo
+                        // The actual marker frame is created after CSS has been
+                        // applied, so keep the XPath on the originating element.
+                        case "marker":
+                        case ":marker":
+                            $pseudo_elements["marker"] = true;
+                            break;
+
                         // Invalid or unsupported pseudo-class or pseudo-element
                         default:
                             return null;
@@ -961,6 +1003,7 @@ class Stylesheet
         // FIXME: this is not particularly robust...
 
         $styles = [];
+        $this->_marker_styles = [];
         $xp = new DOMXPath($tree->get_dom());
         $DEBUGCSS = $this->_dompdf->getOptions()->getDebugCss();
 
@@ -1050,6 +1093,8 @@ class Stylesheet
                 continue;
             }
 
+            $is_marker = isset($query["pseudo_elements"]["marker"]);
+
             foreach ($selector_styles as $style) {
                 $spec = $this->specificity($selector, $style->get_origin());
 
@@ -1061,8 +1106,14 @@ class Stylesheet
 
                     $id = $node->getAttribute("frame_id");
 
-                    // Assign the current style to the scratch array
-                    $styles[$id][$spec][] = $style;
+                    // Marker frames are created later by Frame\Factory. Keep
+                    // these declarations separate so they do not style the li.
+                    if ($is_marker) {
+                        $this->_marker_styles[$id][$spec][] = $style;
+                    } else {
+                        // Assign the current style to the scratch array
+                        $styles[$id][$spec][] = $style;
+                    }
                 }
             }
         }
@@ -1484,7 +1535,7 @@ EOL;
         if ($val === null || $val === "" || strcasecmp($val, "none") === 0) {
             $path = "none";
         } elseif (preg_match($pattern, $val, $matches)) {
-            // Resolve the url now in the context of the current stylesheet
+            // Resolve the url now in the context of the stylesheet.
             $url = $matches["CSS_URL_FN_VALUE"];
             switch ($matches["CSS_URL_FN_QUOTE"]) {
                 case "\"":
@@ -1545,7 +1596,7 @@ EOL;
     /**
      * parse @import at-rule
      *
-     * @param string $url the url of the imported CSS file
+     * @param string $url the imported CSS file
      */
     private function _parse_import($url, $import_media_query)
     {

--- a/src/Frame/Factory.php
+++ b/src/Frame/Factory.php
@@ -138,7 +138,8 @@ class Factory
                     $positioner = "ListBullet";
                 }
 
-                if ($style->list_style_image !== "none") {
+                // Explicit ::marker content replaces list-style-image.
+                if ($style->list_style_image !== "none" && $style->content === "normal") {
                     $decorator = "ListBulletImage";
                 } else {
                     $decorator = "ListBullet";
@@ -234,8 +235,11 @@ class Factory
             }
 
             $new_style = $dompdf->getCss()->create_style();
-            $new_style->set_prop("display", "-dompdf-list-bullet");
+            foreach ($dompdf->getCss()->get_marker_styles($frame->get_id()) as $marker_style) {
+                $new_style->merge($marker_style);
+            }
             $new_style->inherit($style);
+            $new_style->set_prop("display", "-dompdf-list-bullet");
             $b_f->set_style($new_style);
 
             $deco->prepend_child(Factory::decorate_frame($b_f, $dompdf, $root));
@@ -247,7 +251,7 @@ class Factory
     /**
      * Creates Positioners
      *
-     * @param string $type Type of positioner to use
+     * @param string $type Type of positioner
      *
      * @return AbstractPositioner
      */

--- a/src/FrameDecorator/ListBullet.php
+++ b/src/FrameDecorator/ListBullet.php
@@ -48,6 +48,21 @@ class ListBullet extends AbstractFrameDecorator
     }
 
     /**
+     * Whether the marker generates visible content.
+     */
+    private function is_marker_visible(): bool
+    {
+        $style = $this->get_style();
+        $content = $style->content;
+
+        if ($content === "none") {
+            return false;
+        }
+
+        return $content !== "normal" || $style->list_style_type !== "none";
+    }
+
+    /**
      * Get the width of the bullet symbol.
      *
      * @return float
@@ -56,7 +71,7 @@ class ListBullet extends AbstractFrameDecorator
     {
         $style = $this->_frame->get_style();
 
-        if ($style->list_style_type === "none") {
+        if (!$this->is_marker_visible()) {
             return 0.0;
         }
 
@@ -72,7 +87,7 @@ class ListBullet extends AbstractFrameDecorator
     {
         $style = $this->_frame->get_style();
 
-        if ($style->list_style_type === "none") {
+        if (!$this->is_marker_visible()) {
             return 0.0;
         }
 
@@ -86,7 +101,7 @@ class ListBullet extends AbstractFrameDecorator
     {
         $style = $this->get_style();
 
-        if ($style->list_style_type === "none") {
+        if (!$this->is_marker_visible()) {
             return 0.0;
         }
 
@@ -102,7 +117,7 @@ class ListBullet extends AbstractFrameDecorator
     {
         $style = $this->get_style();
 
-        if ($style->list_style_type === "none") {
+        if (!$this->is_marker_visible()) {
             return 0.0;
         }
 

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -138,6 +138,61 @@ class ListBullet extends AbstractRenderer
     }
 
     /**
+     * Resolve the automatic list-item counter chain for counters(list-item).
+     *
+     * Each list-item owns a generated bullet frame carrying the counter value
+     * assigned by Frame\Factory. Walking ancestor list-items therefore gives
+     * us the complete outer-to-inner counter chain without introducing a
+     * separate CSS counter implementation for list-item.
+     *
+     * @return string[]
+     */
+    private function get_list_item_counter_values(Frame $frame, string $style): array
+    {
+        $values = [];
+        $current = $frame->get_parent();
+
+        while ($current) {
+            $node = $current->get_node();
+
+            if ($node->nodeName === "li") {
+                $bullet = $current->get_first_child();
+
+                if ($bullet) {
+                    $bullet_node = $bullet->get_node();
+
+                    if ($bullet_node->nodeName === "bullet" && $bullet_node->hasAttribute("dompdf-counter")) {
+                        $pad = null;
+
+                        if ($style === "decimal-leading-zero") {
+                            $list = $current->get_parent();
+                            if ($list) {
+                                $count = $list->get_node()->getAttribute("dompdf-children-count");
+                                if ($count !== "") {
+                                    $pad = strlen($count);
+                                }
+                            }
+                        }
+
+                        array_unshift(
+                            $values,
+                            $this->make_counter_value(
+                                (int) $bullet_node->getAttribute("dompdf-counter"),
+                                $style,
+                                $pad
+                            )
+                        );
+                    }
+                }
+            }
+
+            $current = $current->get_parent();
+        }
+
+        return $values;
+    }
+
+    /**
      * Resolve explicit `content` on the ::marker pseudo-element.
      *
      * `counter(list-item)` is backed by dompdf's existing list counter, which
@@ -210,9 +265,15 @@ class ListBullet extends AbstractRenderer
 
             elseif ($val instanceof Counters) {
                 if ($val->name === "list-item") {
-                    // The automatic list-item counter is maintained separately
-                    // from CSS counters. For now expose the current list item.
-                    $text .= $this->make_counter_value($index, $val->style);
+                    $values = $this->get_list_item_counter_values($frame, $val->style);
+
+                    // Keep the current marker usable even if the frame tree is
+                    // incomplete (for example during a split/reflow edge case).
+                    if ($values === []) {
+                        $values[] = $this->make_counter_value($index, $val->style);
+                    }
+
+                    $text .= implode($val->string, $values);
                 } else {
                     $p = $frame->lookup_counter_frame($val->name, true);
                     $tmp = [];

--- a/src/Renderer/ListBullet.php
+++ b/src/Renderer/ListBullet.php
@@ -6,6 +6,14 @@
  */
 namespace Dompdf\Renderer;
 
+use Dompdf\Css\Content\Attr;
+use Dompdf\Css\Content\CloseQuote;
+use Dompdf\Css\Content\Counter;
+use Dompdf\Css\Content\Counters;
+use Dompdf\Css\Content\NoCloseQuote;
+use Dompdf\Css\Content\NoOpenQuote;
+use Dompdf\Css\Content\OpenQuote;
+use Dompdf\Css\Content\StringPart;
 use Dompdf\Helpers;
 use Dompdf\Frame;
 use Dompdf\FrameDecorator\ListBullet as ListBulletFrameDecorator;
@@ -76,7 +84,7 @@ class ListBullet extends AbstractRenderer
      *
      * @return string
      */
-    private function make_counter(int $n, string $type, ?int $pad = null): string
+    private function make_counter_value(int $n, string $type, ?int $pad = null): string
     {
         $text = "";
 
@@ -87,7 +95,7 @@ class ListBullet extends AbstractRenderer
                 if ($pad) {
                     $text = str_pad($n, $pad, "0", STR_PAD_LEFT);
                 } else {
-                    $text = $n;
+                    $text = (string) $n;
                 }
                 break;
 
@@ -114,7 +122,141 @@ class ListBullet extends AbstractRenderer
                 break;
         }
 
-        return "$text.";
+        return $text;
+    }
+
+    /**
+     * @param int      $n
+     * @param string   $type
+     * @param int|null $pad
+     *
+     * @return string
+     */
+    private function make_counter(int $n, string $type, ?int $pad = null): string
+    {
+        return $this->make_counter_value($n, $type, $pad) . ".";
+    }
+
+    /**
+     * Resolve explicit `content` on the ::marker pseudo-element.
+     *
+     * `counter(list-item)` is backed by dompdf's existing list counter, which
+     * already accounts for `start` and `value` attributes.
+     */
+    private function resolve_marker_content(Frame $frame, int $index): ?string
+    {
+        $style = $frame->get_style();
+        $content = $style->content;
+
+        if ($content === "normal") {
+            return null;
+        }
+
+        if ($content === "none") {
+            return "";
+        }
+
+        $quotes = $style->quotes;
+        $text = "";
+
+        foreach ($content as $val) {
+            if ($val instanceof StringPart) {
+                $text .= $val->string;
+            }
+
+            elseif ($val instanceof OpenQuote) {
+                if ($quotes !== "none" && isset($quotes[0][0])) {
+                    $text .= $quotes[0][0];
+                }
+            }
+
+            elseif ($val instanceof CloseQuote) {
+                if ($quotes !== "none" && isset($quotes[0][1])) {
+                    $text .= $quotes[0][1];
+                }
+            }
+
+            elseif ($val instanceof NoOpenQuote || $val instanceof NoCloseQuote) {
+                // Quote depth is not tracked by dompdf yet.
+            }
+
+            elseif ($val instanceof Attr) {
+                $parent = $frame->get_parent();
+                if ($parent) {
+                    $text .= $parent->get_node()->getAttribute($val->attribute);
+                }
+            }
+
+            elseif ($val instanceof Counter) {
+                if ($val->name === "list-item") {
+                    $pad = null;
+                    if ($val->style === "decimal-leading-zero") {
+                        $li = $frame->get_parent();
+                        if ($li && $li->get_parent()) {
+                            $count = $li->get_parent()->get_node()->getAttribute("dompdf-children-count");
+                            if ($count !== "") {
+                                $pad = strlen($count);
+                            }
+                        }
+                    }
+                    $text .= $this->make_counter_value($index, $val->style, $pad);
+                } else {
+                    $p = $frame->lookup_counter_frame($val->name, true);
+                    if ($p) {
+                        $text .= $p->counter_value($val->name, $val->style);
+                    }
+                }
+            }
+
+            elseif ($val instanceof Counters) {
+                if ($val->name === "list-item") {
+                    // The automatic list-item counter is maintained separately
+                    // from CSS counters. For now expose the current list item.
+                    $text .= $this->make_counter_value($index, $val->style);
+                } else {
+                    $p = $frame->lookup_counter_frame($val->name, true);
+                    $tmp = [];
+                    while ($p) {
+                        array_unshift($tmp, $p->counter_value($val->name, $val->style));
+                        $p = $p->lookup_counter_frame($val->name);
+                    }
+                    $text .= implode($val->string, $tmp);
+                }
+            }
+        }
+
+        return $text;
+    }
+
+    private function render_text_marker(Frame $frame, string $text): void
+    {
+        $style = $frame->get_style();
+        $font_family = $style->font_family;
+        $font_size = $style->font_size;
+        $word_spacing = $style->word_spacing;
+        $letter_spacing = $style->letter_spacing;
+        $text_width = $this->_dompdf->getFontMetrics()->getTextWidth(
+            $text,
+            $font_family,
+            $font_size,
+            $word_spacing,
+            $letter_spacing
+        );
+
+        [$x, $y] = $frame->get_position();
+        // Correct for static frame width applied by positioner
+        $x += $frame->get_width() - $text_width;
+
+        $this->_canvas->text(
+            $x,
+            $y,
+            $text,
+            $font_family,
+            $font_size,
+            $style->color,
+            $word_spacing,
+            $letter_spacing
+        );
     }
 
     /**
@@ -129,6 +271,19 @@ class ListBullet extends AbstractRenderer
 
         // Don't render bullets twice if the list item was split
         if ($li->is_split_off) {
+            return;
+        }
+
+        $node = $frame->get_node();
+        $index = $node->hasAttribute("dompdf-counter")
+            ? (int) $node->getAttribute("dompdf-counter")
+            : 0;
+
+        $marker_content = $this->resolve_marker_content($frame, $index);
+        if ($marker_content !== null) {
+            if ($marker_content !== "") {
+                $this->render_text_marker($frame, $marker_content);
+            }
             return;
         }
 
@@ -183,26 +338,12 @@ class ListBullet extends AbstractRenderer
                         $pad = strlen($li->get_parent()->get_node()->getAttribute("dompdf-children-count"));
                     }
 
-                    $node = $frame->get_node();
-
                     if (!$node->hasAttribute("dompdf-counter")) {
                         return;
                     }
 
-                    $index = (int) $node->getAttribute("dompdf-counter");
                     $text = $this->make_counter($index, $bullet_style, $pad);
-
-                    $word_spacing = $style->word_spacing;
-                    $letter_spacing = $style->letter_spacing;
-                    $text_width = $this->_dompdf->getFontMetrics()->getTextWidth($text, $font_family, $font_size, $word_spacing, $letter_spacing);
-
-                    [$x, $y] = $frame->get_position();
-                    // Correct for static frame width applied by positioner
-                    $x += $frame->get_width() - $text_width;
-
-                    $this->_canvas->text($x, $y, $text,
-                        $font_family, $font_size,
-                        $style->color, $word_spacing, $letter_spacing);
+                    $this->render_text_marker($frame, $text);
                     break;
 
                 case "none":

--- a/tests/MarkerPseudoElementTest.php
+++ b/tests/MarkerPseudoElementTest.php
@@ -2,9 +2,12 @@
 namespace Dompdf\Tests;
 
 use Dompdf\Css\Content\Counter;
+use Dompdf\Css\Content\Counters;
 use Dompdf\Css\Content\StringPart;
 use Dompdf\Dompdf;
 use Dompdf\FrameDecorator\AbstractFrameDecorator;
+use Dompdf\Renderer\ListBullet as ListBulletRenderer;
+use ReflectionMethod;
 
 final class MarkerPseudoElementTest extends TestCase
 {
@@ -70,5 +73,75 @@ HTML
             $this->assertInstanceOf(StringPart::class, $marker["content"][2]);
             $this->assertSame(") ", $marker["content"][2]->string);
         }
+    }
+
+    public function testNestedListItemCountersAreResolved(): void
+    {
+        $markers = [];
+
+        $dompdf = new Dompdf();
+        $renderer = new ListBulletRenderer($dompdf);
+        $resolver = new ReflectionMethod(ListBulletRenderer::class, "resolve_marker_content");
+        $resolver->setAccessible(true);
+
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function (AbstractFrameDecorator $frame) use (&$markers, $renderer, $resolver): void {
+                    $node = $frame->get_node();
+                    if ($node->nodeName !== "bullet") {
+                        return;
+                    }
+
+                    $content = $frame->get_style()->content;
+                    if (!is_array($content) || !isset($content[0]) || !$content[0] instanceof Counters) {
+                        return;
+                    }
+
+                    $index = $node->hasAttribute("dompdf-counter")
+                        ? (int) $node->getAttribute("dompdf-counter")
+                        : 0;
+
+                    $markers[] = $resolver->invoke($renderer, $frame, $index);
+                },
+            ],
+        ]);
+
+        $dompdf->loadHtml(<<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+ol.legal-list {
+    list-style: none;
+}
+
+ol.legal-list > li::marker {
+    content: counters(list-item, ".") " ";
+}
+</style>
+</head>
+<body>
+<ol class="legal-list">
+    <li>Outer
+        <ol class="legal-list">
+            <li>First</li>
+            <li>Second</li>
+            <li>Third</li>
+        </ol>
+    </li>
+</ol>
+</body>
+</html>
+HTML
+        );
+        $dompdf->render();
+
+        $this->assertSame([
+            "1 ",
+            "1.1 ",
+            "1.2 ",
+            "1.3 ",
+        ], $markers);
     }
 }

--- a/tests/MarkerPseudoElementTest.php
+++ b/tests/MarkerPseudoElementTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Dompdf\Tests;
+
+use Dompdf\Css\Content\Counter;
+use Dompdf\Css\Content\StringPart;
+use Dompdf\Dompdf;
+use Dompdf\FrameDecorator\AbstractFrameDecorator;
+
+final class MarkerPseudoElementTest extends TestCase
+{
+    public function testMarkerStylesAreAppliedToListBullet(): void
+    {
+        $markers = [];
+
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function (AbstractFrameDecorator $frame) use (&$markers): void {
+                    if ($frame->get_node()->nodeName !== "bullet") {
+                        return;
+                    }
+
+                    $style = $frame->get_style();
+                    $markers[] = [
+                        "font_weight" => $style->get_specified("font_weight"),
+                        "content" => $style->content,
+                    ];
+                },
+            ],
+        ]);
+
+        $dompdf->loadHtml(<<<HTML
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+ol.parenthesized-list {
+    list-style: none;
+}
+
+ol.parenthesized-list > li::marker {
+    content: "(" counter(list-item) ") ";
+    font-weight: bold;
+}
+</style>
+</head>
+<body>
+<ol class="parenthesized-list">
+    <li>First</li>
+    <li>Second</li>
+</ol>
+</body>
+</html>
+HTML
+        );
+        $dompdf->render();
+
+        $this->assertCount(2, $markers);
+
+        foreach ($markers as $marker) {
+            $this->assertSame("bold", $marker["font_weight"]);
+            $this->assertIsArray($marker["content"]);
+            $this->assertCount(3, $marker["content"]);
+            $this->assertInstanceOf(StringPart::class, $marker["content"][0]);
+            $this->assertSame("(", $marker["content"][0]->string);
+            $this->assertInstanceOf(Counter::class, $marker["content"][1]);
+            $this->assertSame("list-item", $marker["content"][1]->name);
+            $this->assertSame("decimal", $marker["content"][1]->style);
+            $this->assertInstanceOf(StringPart::class, $marker["content"][2]);
+            $this->assertSame(") ", $marker["content"][2]->string);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for the `::marker` pseudo-element on list items.

It allows marker styling and generated marker content such as:

```css
ol.parenthesized-list {
    list-style: none;
}

ol.parenthesized-list > li::marker {
    content: "(" counter(list-item) ") ";
    font-weight: bold;
}
```

which renders markers like:

```text
(1)
(2)
(3)
```

It also supports nested automatic list-item counters using `counters(list-item, ".")`, for example:

```css
ol.legal-list {
    list-style: none;
}

ol.legal-list > li::marker {
    content: counters(list-item, ".") " ";
}
```

which produces hierarchical markers such as:

```text
1
1.1
1.2
1.2.1
2
```

## Implementation

* Parses and stores styles matched by `::marker` separately from the originating list item.
* Applies marker declarations when Dompdf creates the internal list-bullet frame.
* Supports explicit marker `content`, including strings, `counter()`, `counters()`, `attr()`, and quote content parts already represented by Dompdf's generated-content model.
* Uses Dompdf's existing automatic list counter for `counter(list-item)`, preserving existing `<ol start>` and `<li value>` handling.
* Resolves nested `counters(list-item, ...)` by walking ancestor list items and collecting their generated list counters.
* Keeps existing `list-style-type` rendering unchanged when no explicit marker content is specified.
* Explicit `::marker` content takes precedence over `list-style-image`.

## Tests

Adds regression coverage for:

* applying `::marker` styles and generated content to list bullets;
* `counter(list-item)` marker content;
* nested `counters(list-item, ".")` output such as `1.1`, `1.2`, etc.
