### PR TITLE
Add :has() pseudo-class support

### DIFF
--- a/src/Css/Stylesheet.php
+++ b/src/Css/Stylesheet.php
@@ -59,7 +59,7 @@ class Stylesheet
      *
      * @var string
      */
-    const PATTERN_CSS_STRING = '(?<CSS_STRING>(?<CSS_STRING_QUOTE>[\'"])(?<CSS_STRING_VALUE>.*?)(?<!\\\\)\g{CSS_STRING_QUOTE})';
+    const PATTERN_CSS_STRING = '(?<CSS_STRING>(?<CSS_STRING_QUOTE>[\'\"])(?<CSS_STRING_VALUE>.*?)(?<!\\\\)\g{CSS_STRING_QUOTE})';
 
     /**
      * RegEx pattern representing the CSS var() function
@@ -73,14 +73,14 @@ class Stylesheet
      *
      * @var string
      */
-    const PATTERN_CSS_URL_FN = '(?<CSS_URL_FN>url\(\s*(?<CSS_URL_FN_QUOTE>[\'"]?)(?<CSS_URL_FN_VALUE>.*?)(?(CSS_URL_FN_QUOTE)(?<!\\\\)\g{CSS_URL_FN_QUOTE})\s*\))';
+    const PATTERN_CSS_URL_FN = '(?<CSS_URL_FN>url\(\s*(?<CSS_URL_FN_QUOTE>[\'\"]?)(?<CSS_URL_FN_VALUE>.*?)(?(CSS_URL_FN_QUOTE)(?<!\\\\)\g{CSS_URL_FN_QUOTE})\s*\))';
 
     /**
      * RegEx pattern representing the CSS local() function
      *
      * @var string
      */
-    const PATTERN_CSS_LOCAL_FN = '(?<CSS_LOCAL_FN>local\(\s*(?<CSS_LOCAL_FN_QUOTE>[\'"]?)(?<CSS_LOCAL_FN_VALUE>.*?)(?(CSS_LOCAL_FN_QUOTE)(?<!\\\\)\g{CSS_LOCAL_FN_QUOTE})\s*\))';
+    const PATTERN_CSS_LOCAL_FN = '(?<CSS_LOCAL_FN>local\(\s*(?<CSS_LOCAL_FN_QUOTE>[\'\"]?)(?<CSS_LOCAL_FN_VALUE>.*?)(?(CSS_LOCAL_FN_QUOTE)(?<!\\\\)\g{CSS_LOCAL_FN_QUOTE})\s*\))';
 
     /**
      * RegEx pattern representing a CSS media query
@@ -436,7 +436,8 @@ class Stylesheet
         $c = min(mb_substr_count($selector, ".") +
             mb_substr_count($selector, "[") +
             mb_substr_count($selector, ":") -
-            2 * mb_substr_count($selector, "::"), 255);
+            2 * mb_substr_count($selector, "::") -
+            mb_substr_count(strtolower($selector), ":has("), 255);
 
         $d = min(mb_substr_count($selector, " ") +
             mb_substr_count($selector, ">") +
@@ -465,6 +466,156 @@ class Stylesheet
         }
 
         return self::$_stylesheet_origins[$origin] + (($a << 24) | ($b << 16) | ($c << 8) | ($d));
+    }
+
+    /**
+     * Extract the argument and closing parenthesis position of a functional
+     * pseudo-class starting at the given opening parenthesis.
+     *
+     * @return array{0: string, 1: int}|null
+     */
+    private function functionalPseudoArgument(string $selector, int $openParen): ?array
+    {
+        if (!isset($selector[$openParen]) || $selector[$openParen] !== "(") {
+            return null;
+        }
+
+        $depth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($selector);
+
+        for ($pos = $openParen; $pos < $length; ++$pos) {
+            $char = $selector[$pos];
+
+            if ($escaped) {
+                $escaped = false;
+                continue;
+            }
+
+            if ($char === "\\") {
+                $escaped = true;
+                continue;
+            }
+
+            if ($quote !== null) {
+                if ($char === $quote) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($char === "\"" || $char === "'") {
+                $quote = $char;
+                continue;
+            }
+
+            if ($char === "(") {
+                ++$depth;
+                continue;
+            }
+
+            if ($char === ")") {
+                --$depth;
+                if ($depth === 0) {
+                    return [substr($selector, $openParen + 1, $pos - $openParen - 1), $pos];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Split a selector list on top-level commas.
+     *
+     * @return string[]
+     */
+    private function splitSelectorList(string $selectorList): array
+    {
+        $selectors = [];
+        $start = 0;
+        $parenDepth = 0;
+        $bracketDepth = 0;
+        $quote = null;
+        $escaped = false;
+        $length = strlen($selectorList);
+
+        for ($pos = 0; $pos < $length; ++$pos) {
+            $char = $selectorList[$pos];
+
+            if ($escaped) {
+                $escaped = false;
+                continue;
+            }
+
+            if ($char === "\\") {
+                $escaped = true;
+                continue;
+            }
+
+            if ($quote !== null) {
+                if ($char === $quote) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($char === "\"" || $char === "'") {
+                $quote = $char;
+                continue;
+            }
+
+            if ($char === "(") {
+                ++$parenDepth;
+            } elseif ($char === ")") {
+                --$parenDepth;
+            } elseif ($char === "[") {
+                ++$bracketDepth;
+            } elseif ($char === "]") {
+                --$bracketDepth;
+            } elseif ($char === "," && $parenDepth === 0 && $bracketDepth === 0) {
+                $selectors[] = trim(substr($selectorList, $start, $pos - $start));
+                $start = $pos + 1;
+            }
+        }
+
+        $selectors[] = trim(substr($selectorList, $start));
+
+        return array_values(array_filter($selectors, static function (string $selector): bool {
+            return $selector !== "";
+        }));
+    }
+
+    /**
+     * Convert a selector relative to the :has() anchor into an XPath expression
+     * evaluated from the candidate element.
+     */
+    private function relativeSelectorToXpath(string $selector): ?string
+    {
+        $selector = trim($selector);
+        if ($selector === "" || stripos($selector, ":has(") !== false) {
+            // Nested :has() is not allowed by Selectors Level 4.
+            return null;
+        }
+
+        $anchor = "dompdf_has_scope";
+        $first = $selector[0];
+        $anchoredSelector = in_array($first, [">", "+", "~"], true)
+            ? $anchor . $first . ltrim(substr($selector, 1))
+            : $anchor . " " . $selector;
+
+        $result = $this->selectorToXpath($anchoredSelector);
+        if ($result === null || $result["pseudo_elements"] !== []) {
+            return null;
+        }
+
+        $prefix = "//descendant::$anchor";
+        if (strpos($result["query"], $prefix) !== 0) {
+            return null;
+        }
+
+        return ltrim(substr($result["query"], strlen($prefix)), "/");
     }
 
     /**
@@ -690,6 +841,30 @@ class Stylesheet
                         // https://www.w3.org/TR/selectors-4/#empty-pseudo
                         case "empty":
                             $query .= "[not(*) and not(normalize-space())]";
+                            break;
+
+                        // https://www.w3.org/TR/selectors-4/#relational
+                        case "has":
+                            $function = $this->functionalPseudoArgument($selector, $i);
+                            if ($function === null) {
+                                return null;
+                            }
+
+                            [$relativeSelectorList, $closeParen] = $function;
+                            $conditions = [];
+                            foreach ($this->splitSelectorList($relativeSelectorList) as $relativeSelector) {
+                                $relativeQuery = $this->relativeSelectorToXpath($relativeSelector);
+                                if ($relativeQuery !== null && $relativeQuery !== "") {
+                                    $conditions[] = $relativeQuery;
+                                }
+                            }
+
+                            if ($conditions === []) {
+                                return null;
+                            }
+
+                            $query .= "[" . implode(" or ", $conditions) . "]";
+                            $i = $closeParen + 1;
                             break;
 
                         // TODO: bit of a hack attempt at matches support, currently only matches against elements

--- a/tests/Css/HasSelectorTest.php
+++ b/tests/Css/HasSelectorTest.php
@@ -1,0 +1,147 @@
+<?php
+namespace Dompdf\Tests\Css;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Dompdf\Css\Stylesheet;
+use Dompdf\Dompdf;
+use Dompdf\Frame\FrameTree;
+use Dompdf\Tests\TestCase;
+
+final class HasSelectorTest extends TestCase
+{
+    private function stylesheet()
+    {
+        return new class(new Dompdf()) extends Stylesheet {
+            public function selectorToXpath(string $selector, bool $firstPass = false): ?array
+            {
+                return parent::selectorToXpath($selector, $firstPass);
+            }
+        };
+    }
+
+    private function preProcess(string $selector): string
+    {
+        $patterns = ["/\s+/", "/\s+([>.:+~#])\s+/"];
+        $replacements = [" ", "\\1"];
+
+        return preg_replace($patterns, $replacements, $selector);
+    }
+
+    public static function selectorMatchesProvider(): array
+    {
+        return [
+            "direct child first-child" => [
+                "li:has(> strong:first-child)",
+                '<body><ol>
+                    <li data-match><strong>Title</strong><span>Text</span></li>
+                    <li><span>Text</span><strong>Title</strong></li>
+                    <li><em>Text</em></li>
+                </ol></body>'
+            ],
+            "descendant" => [
+                "article:has(.target)",
+                '<body>
+                    <article data-match><div><span class="target"></span></div></article>
+                    <article><div><span></span></div></article>
+                </body>'
+            ],
+            "adjacent sibling" => [
+                "h2:has(+ p.note)",
+                '<body>
+                    <h2 data-match></h2><p class="note"></p>
+                    <h2></h2><div></div><p class="note"></p>
+                </body>'
+            ],
+            "subsequent sibling" => [
+                "h2:has(~ p.note)",
+                '<body>
+                    <section><h2 data-match></h2><div></div><p class="note"></p></section>
+                    <section><h2></h2><div></div></section>
+                </body>'
+            ],
+            "selector list" => [
+                "section:has(> img.hero, > table.featured)",
+                '<body>
+                    <section data-match><img class="hero"></section>
+                    <section data-match><table class="featured"></table></section>
+                    <section><img></section>
+                </body>'
+            ],
+            "nested functional pseudo-class" => [
+                "div:has(> span:nth-child(2))",
+                '<body>
+                    <div data-match><em></em><span></span></div>
+                    <div><span></span><em></em></div>
+                </body>'
+            ],
+            "compound relative selector" => [
+                "li:has(> strong em.highlight)",
+                '<body><ul>
+                    <li data-match><strong><span><em class="highlight"></em></span></strong></li>
+                    <li><strong><em></em></strong></li>
+                </ul></body>'
+            ],
+            "attribute selector" => [
+                "form:has(> input[checked])",
+                '<body>
+                    <form data-match><input checked></form>
+                    <form><input></form>
+                </body>'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider selectorMatchesProvider
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('selectorMatchesProvider')]
+    public function testSelectorMatches(string $selector, string $body): void
+    {
+        $sheet = $this->stylesheet();
+        $dom = new DOMDocument();
+        $dom->loadHTML("<html><head></head>$body</html>");
+        $tree = new FrameTree($dom);
+        $tree->build_tree();
+        $xpath = new DOMXPath($dom);
+
+        $query = $sheet->selectorToXpath($this->preProcess($selector));
+        $this->assertNotNull($query);
+        $nodeList = $xpath->query($query["query"]);
+        $this->assertNotFalse($nodeList);
+        $nodes = iterator_to_array($nodeList);
+
+        foreach ($tree as $frame) {
+            $node = $frame->get_node();
+            if (!($node instanceof DOMElement) || $node->nodeName === "head") {
+                continue;
+            }
+
+            $this->assertSame(
+                $node->hasAttribute("data-match"),
+                in_array($node, $nodes, true),
+                "Unexpected match state for {$node->nodeName}."
+            );
+        }
+    }
+
+    public static function invalidSelectorProvider(): array
+    {
+        return [
+            ["div:has()"],
+            ["div:has(:has(.target))"],
+            ["div:has(> p::before)"]
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSelectorProvider
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidSelectorProvider')]
+    public function testInvalidHasSelector(string $selector): void
+    {
+        $sheet = $this->stylesheet();
+        $this->assertNull($sheet->selectorToXpath($this->preProcess($selector)));
+    }
+}

--- a/tests/Css/HasSelectorTest.php
+++ b/tests/Css/HasSelectorTest.php
@@ -41,10 +41,10 @@ final class HasSelectorTest extends TestCase
                 </ol></body>'
             ],
             "descendant" => [
-                "article:has(.target)",
+                "div.wrapper:has(.target)",
                 '<body>
-                    <article data-match><div><span class="target"></span></div></article>
-                    <article><div><span></span></div></article>
+                    <div class="wrapper" data-match><div><span class="target"></span></div></div>
+                    <div class="wrapper"><div><span></span></div></div>
                 </body>'
             ],
             "adjacent sibling" => [
@@ -57,16 +57,16 @@ final class HasSelectorTest extends TestCase
             "subsequent sibling" => [
                 "h2:has(~ p.note)",
                 '<body>
-                    <section><h2 data-match></h2><div></div><p class="note"></p></section>
-                    <section><h2></h2><div></div></section>
+                    <div><h2 data-match></h2><div></div><p class="note"></p></div>
+                    <div><h2></h2><div></div></div>
                 </body>'
             ],
             "selector list" => [
-                "section:has(> img.hero, > table.featured)",
+                "div.wrapper:has(> img.hero, > table.featured)",
                 '<body>
-                    <section data-match><img class="hero"></section>
-                    <section data-match><table class="featured"></table></section>
-                    <section><img></section>
+                    <div class="wrapper" data-match><img class="hero"></div>
+                    <div class="wrapper" data-match><table class="featured"></table></div>
+                    <div class="wrapper"><img></div>
                 </body>'
             ],
             "nested functional pseudo-class" => [

--- a/tests/Css/HasSelectorTest.php
+++ b/tests/Css/HasSelectorTest.php
@@ -62,10 +62,10 @@ final class HasSelectorTest extends TestCase
                 </body>'
             ],
             "selector list" => [
-                "div.wrapper:has(> img.hero, > table.featured)",
+                "div.wrapper:has(> img.hero, > p.featured)",
                 '<body>
                     <div class="wrapper" data-match><img class="hero"></div>
-                    <div class="wrapper" data-match><table class="featured"></table></div>
+                    <div class="wrapper" data-match><p class="featured"></p></div>
                     <div class="wrapper"><img></div>
                 </body>'
             ],


### PR DESCRIPTION
## Summary

This PR adds support for the CSS Selectors Level 4 `:has()` relational pseudo-class.

It supports relative selector lists and reuses Dompdf's existing selector-to-XPath compiler for selectors inside `:has()`.

Examples:

```css
li:has(> strong:first-child)
article:has(.target)
h2:has(+ p.note)
h2:has(~ p.note)
section:has(> img.hero, > table.featured)
```

## Implementation

* Parses functional pseudo-class arguments, including nested parentheses and quoted content.
* Splits top-level selector lists inside `:has()`.
* Supports relative descendant, child (`>`), adjacent sibling (`+`), and subsequent sibling (`~`) selectors.
* Reuses the existing selector compiler for classes, IDs, attributes, and supported pseudo-classes such as `:first-child` and `:nth-child()`.
* Rejects nested `:has()` and pseudo-elements inside `:has()`.
* Converts the relative selectors to XPath predicates evaluated from the candidate element.

## Tests

Regression tests cover:

* direct child selectors combined with `:first-child`;
* descendant selectors;
* adjacent sibling selectors;
* subsequent sibling selectors;
* selector lists;
* nested functional pseudo-classes such as `:nth-child()`;
* compound selectors;
* attribute selectors;
* invalid or nested `:has()` expressions.
