### PR TITLE
Fix handling of DOM processing instructions

### DIFF
--- a/src/Frame/FrameTree.php
+++ b/src/Frame/FrameTree.php
@@ -259,6 +259,12 @@ class FrameTree implements IteratorAggregate
             $child = $children[$index];
             $nodeName = strtolower($child->nodeName);
 
+            // Skip processing instructions
+            if ($child->nodeType === XML_PI_NODE) {
+                $this->_remove_node($node, $children, $index);
+                continue;
+            }
+
             // Skip non-displaying nodes
             if (in_array($nodeName, self::$HIDDEN_TAGS)) {
                 if ($nodeName !== "head" && $nodeName !== "style") {

--- a/tests/DompdfTest.php
+++ b/tests/DompdfTest.php
@@ -181,6 +181,26 @@ class DompdfTest extends TestCase
         $this->assertEquals('', $dompdf->getDom()->textContent);
     }
 
+    public function testProcessingInstructionsAreNotRendered(): void
+    {
+        $nodeTypes = [];
+
+        $dompdf = new Dompdf();
+        $dompdf->setCallbacks([
+            [
+                "event" => "begin_frame",
+                "f" => function ($frame) use (&$nodeTypes) {
+                    $nodeTypes[] = $frame->get_node()->nodeType;
+                }
+            ]
+        ]);
+
+        $dompdf->loadHtml('<html><body><p>before</p><?php echo "x";?><p>after</p></body></html>');
+        $dompdf->render();
+
+        $this->assertNotContains(XML_PI_NODE, $nodeTypes);
+    }
+
     public static function callbacksProvider(): array
     {
         return [


### PR DESCRIPTION
Fixes the fatal error caused by calling `getAttribute()` on `DOMProcessingInstruction` nodes while building the frame tree.

Processing instructions are not HTML elements and therefore do not support attributes. Skip them during frame creation, while preserving the existing handling of text and comment nodes.

Adds a regression test covering a document containing a processing instruction.

Verification:

- regression test: 1 test — PASS
- full PHPUnit suite: 1,147 tests / 2,892 assertions — PASS
- PHP lint and PHPCS on changed files — PASS
- `git diff --check` — PASS

AI assistance was used to help prepare this contribution; the patch and test results were reviewed and validated.

Fixes #3689.